### PR TITLE
Updated ParameterHash so key comparisons are performed in a case-insensitive manner (fixes issue #104)

### DIFF
--- a/lib/mail/fields/common/parameter_hash.rb
+++ b/lib/mail/fields/common/parameter_hash.rb
@@ -13,10 +13,20 @@ module Mail
     include Mail::Utilities
 
     def [](key_name)
-      pairs = select { |k,v| k =~ /^#{key_name}\*/ }
-      pairs = pairs.to_a if RUBY_VERSION >= '1.9'
+      key_pattern = Regexp.escape(key_name.to_s)
+      pairs = []
+      exact = nil
+      each do |k,v|
+        if k =~ /^#{key_pattern}(\*|$)/i
+          if $1 == '*'
+            pairs << [k, v]
+          else
+            exact = k
+          end
+        end
+      end
       if pairs.empty? # Just dealing with a single value pair
-        super(key_name)
+        super(exact || key_name)
       else # Dealing with a multiple value pair or a single encoded value pair
         string = pairs.sort { |a,b| a.first <=> b.first }.map { |v| v.last }.join('')
         if mt = string.match(/([\w\d\-]+)'(\w\w)'(.*)/)

--- a/spec/mail/fields/common/parameter_hash_spec.rb
+++ b/spec/mail/fields/common/parameter_hash_spec.rb
@@ -18,6 +18,15 @@ describe Mail::ParameterHash do
     hash[:value2].should == 'two'
   end
 
+  it "should return the values in the hash using case-insensitive key matching" do
+    hash = Mail::ParameterHash.new
+    hash.merge!({'value1' => 'one', 'VALUE2' => 'two'})
+    hash['VALUE1'].should == 'one'
+    hash['vAlUe2'].should == 'two'
+    hash[:VaLuE1].should == 'one'
+    hash[:value2].should == 'two'
+  end
+
   it "should return the correct value if they are not encoded" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'value2' => 'two'})


### PR DESCRIPTION
I attempted to do my due diligence and I think this is a pretty good and simple solution to the issue underlying the issue #104 that I opened a few days ago. It includes spec tests of this functionality.

WARNING: I manually ran several spec tests, however I was unable to run (even prior to my making this change) the full "spec" rake task (I sent an email about this to the mailing list--it is still awaiting moderation I guess).

Anyhow, this is just my attempt to contribute and I welcome criticisms and suggestions and certainly won't be offended if this pull request is rejected.

NOTE: As my comments on issue #104 mention, it does appear that this improves the gem to more correctly follow the MIME RFCs (specifically 2045 and 2183) so that's a good thing, yes?
