### PR TITLE
Minor changes for fixing Issue 126

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -136,6 +136,7 @@ module Mail
     # Delete all emails from a IMAP mailbox
     def delete_all(mailbox='INBOX')
       mailbox ||= 'INBOX'
+      mailbox = Net::IMAP.encode_utf7(mailbox)
 
       start do |imap|
         imap.select(mailbox)
@@ -165,6 +166,9 @@ module Mail
         options[:order]   ||= :asc
         options[:what]    ||= :first
         options[:keys]    ||= 'ALL'
+
+        options[:mailbox] = Net::IMAP.encode_utf7(options[:mailbox])
+
         options
       end
 

--- a/spec/mail/network/retriever_methods/imap_spec.rb
+++ b/spec/mail/network/retriever_methods/imap_spec.rb
@@ -117,6 +117,8 @@ describe "IMAP Retriever" do
   describe "delete_all" do
     it "should delete all messages" do
       messages = Mail.all
+
+      Net::IMAP.should_receive(:encode_utf7).once
       Mail.delete_all
 
       MockIMAP.examples.size.should == 0
@@ -171,6 +173,15 @@ describe "IMAP Retriever" do
 
       options[:mailbox].should be_present
       options[:mailbox].should == 'some/mail/box'
+    end
+    it "should ensure utf7 conversion for mailbox names" do
+      retrievable = Mail::IMAP.new({})
+
+      Net::IMAP.stub!(:encode_utf7 => 'UTF7_STRING')
+      options = retrievable.send(:validate_options, {
+        :mailbox => 'UTF8_STRING'
+      })
+      options[:mailbox].should == 'UTF7_STRING'
     end
   end
 


### PR DESCRIPTION
Hi there

Adman65 found a minor error in the imap implementation (http://github.com/mikel/mail/issues/issue/126) concerning the encoding of mailbox names. The change has been tested with ruby 1.8.6, 1.9.1 and 1.9.2 and returned no errors when running specs. I hope you find it useful.

Fabian
