### PR TITLE
Fix references

### DIFF
--- a/lib/mail/fields/common/common_message_id.rb
+++ b/lib/mail/fields/common/common_message_id.rb
@@ -33,11 +33,11 @@ module Mail
     private
     
     def do_encode(field_name)
-      %Q{#{field_name}: #{message_ids.map { |m| "<#{m}>" }.join(', ')}\r\n}
+      %Q{#{field_name}: #{do_decode}\r\n}
     end
     
     def do_decode
-      "#{message_ids.map { |m| "<#{m}>" }.join(', ')}"
+      "#{message_ids.map { |m| "<#{m}>" }.join(' ')}"
     end
     
   end

--- a/spec/mail/fields/in_reply_to_field_spec.rb
+++ b/spec/mail/fields/in_reply_to_field_spec.rb
@@ -37,7 +37,7 @@ describe Mail::InReplyToField do
     
     it "should handle many encoded message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      t.encoded.should == "In-Reply-To: <1234@test.lindsaar.net>, <4567@test.lindsaar.net>\r\n"
+      t.encoded.should == "In-Reply-To: <1234@test.lindsaar.net> <4567@test.lindsaar.net>\r\n"
     end
 
     it "should provide decoded" do
@@ -47,7 +47,7 @@ describe Mail::InReplyToField do
     
     it "should handle many decoded message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      t.decoded.should == '<1234@test.lindsaar.net>, <4567@test.lindsaar.net>'
+      t.decoded.should == '<1234@test.lindsaar.net> <4567@test.lindsaar.net>'
     end
     
   end

--- a/spec/mail/fields/references_field_spec.rb
+++ b/spec/mail/fields/references_field_spec.rb
@@ -38,6 +38,7 @@ describe Mail::ReferencesField do
     t.value.should == '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
     t.message_id.should == '1234@test.lindsaar.net'
     t.message_ids.should == ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
+    t.to_s.should == '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
   end
 
 end


### PR DESCRIPTION
As I posted to the mailing list:

I think the References header is generating invalid output?

ruby-1.8.6-p399 > msg = Mail.new do
ruby-1.8.6-p399 >     references 'a@b.com x@y.com'
ruby-1.8.6-p399 ?>  end
 => #<Mail::Message:2164446680, Multipart: false, Headers:
<References: <a@b.com> x@y.com>>
ruby-1.8.6-p399 > msg.to_s
 => "Date: Fri, 05 Nov 2010 13:42:27 -0400\r\nMessage-ID:
4cd44203a4056_2253800daf04179a7@Donalds-Decisiv-MacBook-Pro.local.mail\r\nReferences:
a@b.com, x@y.com\r\nMime-Version: 1.0\r\nContent-Type:
text/plain\r\nContent-Transfer-Encoding: 7bit\r\n\r\n"

Note the References ids in this output are comma-separated. RFC2822
has the grammar as:

references      =       "References:" 1*msg-id CRLF
msg-id          =       [CFWS] "<" id-left "@" id-right ">" [CFWS]

A spot check of my email and the Enron database seems to concur that
whitespace separates messages ids, never commas.

Is this correct or am I misreading the spec?

Presuming that I'm correct, I went ahead and patched it and here's the pull request.
