### PR TITLE
Datetime

### DIFF
--- a/lib/mail/fields/date_field.rb
+++ b/lib/mail/fields/date_field.rb
@@ -34,7 +34,7 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       if value.blank?
-        value = Time.now.strftime('%a, %d %b %Y %H:%M:%S %z')
+        value = ::DateTime.now.strftime('%a, %d %b %Y %H:%M:%S %z')
       else
         value = strip_field(FIELD_NAME, value)
         value.to_s.gsub!(/\(.*?\)/, '')

--- a/lib/mail/fields/resent_date_field.rb
+++ b/lib/mail/fields/resent_date_field.rb
@@ -14,7 +14,7 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       if value.blank?
-        value = Time.now.strftime('%a, %d %b %Y %H:%M:%S %z')
+        value = ::DateTime.now.strftime('%a, %d %b %Y %H:%M:%S %z')
       else
         value = strip_field(FIELD_NAME, value)
         value = ::DateTime.parse(value.to_s).strftime('%a, %d %b %Y %H:%M:%S %z')

--- a/spec/mail/fields/date_field_spec.rb
+++ b/spec/mail/fields/date_field_spec.rb
@@ -67,6 +67,12 @@ describe Mail::DateField do
       field = Mail::DateField.new("Fri, 21 Nov 1997 09(comment):   55  :  06 -0600")
       field.decoded.should == "Fri, 21 Nov 1997 09:55:06 -0600"
     end
+
+    it "should give today's date if no date is specified" do
+      now = Time.now
+      Time.stub!(:now).and_return(now)
+      Mail::DateField.new.date_time.should == ::DateTime.parse(now.to_s)
+    end
     
   end
 


### PR DESCRIPTION
I discovered that while at RubyConf, having switched my time zone to CST, the tests stopped passing. Curious, I poked around and discovered that the base Time class seems to have a bug in handling time zones. I didn't bother tracking down the exact bug since the behavior was fixed in the 1.9.x series, but since ActiveSupport's DateTime extension has the correct behavior, I switched the code over to use it instead consistently.
