### PR TITLE
Updated patch to remove activesupport requirement for 1.9+

### DIFF
--- a/lib/mail.rb
+++ b/lib/mail.rb
@@ -3,11 +3,6 @@ module Mail # :doc:
 
   require 'date'
 
-  require 'active_support'
-  require 'active_support/core_ext/hash/indifferent_access'
-  require 'active_support/core_ext/object/blank'
-  require 'active_support/core_ext/string'
-
   require 'uri'
   require 'net/smtp'
   require 'mime/types'
@@ -20,7 +15,7 @@ module Mail # :doc:
     end
   end
 
-  if RUBY_VERSION >= "1.9.1"
+  if RUBY_VERSION >= "1.9.0"
     require 'mail/version_specific/ruby_1_9'
     RubyVer = Ruby19
   else
@@ -32,6 +27,9 @@ module Mail # :doc:
 
   require 'mail/core_extensions/nil'
   require 'mail/core_extensions/string'
+  require 'mail/core_extensions/object'
+
+  require 'mail/indifferent_hash'
 
   require 'mail/patterns'
   require 'mail/utilities'

--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -196,10 +196,11 @@ module Mail
     end
     
     def encoding=( val )
-      if val == "text" || val.blank? then
-        val = "8bit"
+      @encoding = if val == "text" || val.blank?
+          (only_us_ascii? ? '7bit' : '8bit')
+      else
+          val
       end
-      @encoding = (val == "text") ? "8bit" : val
     end
 
     # Returns the preamble (any text that is before the first MIME boundary)

--- a/lib/mail/core_extensions/object.rb
+++ b/lib/mail/core_extensions/object.rb
@@ -1,0 +1,9 @@
+class Object
+  def blank?
+    if respond_to?(:empty?)
+      empty?
+    else
+     !self
+    end
+  end
+end

--- a/lib/mail/core_extensions/string.rb
+++ b/lib/mail/core_extensions/string.rb
@@ -8,6 +8,10 @@ class String #:nodoc:
     gsub(/\n|\r\n|\r/) { "\n" }
   end
 
+  def blank?
+    self !~ /\S/
+  end
+
   unless method_defined?(:ascii_only?)
     # Provides all strings with the Ruby 1.9 method of .ascii_only? and
     # returns true or false

--- a/lib/mail/fields/common/parameter_hash.rb
+++ b/lib/mail/fields/common/parameter_hash.rb
@@ -8,7 +8,7 @@ module Mail
   # to make that happen
   # Parameters are defined in RFC2045, split keys are in RFC2231
 
-  class ParameterHash < HashWithIndifferentAccess
+  class ParameterHash < IndifferentHash
 
     include Mail::Utilities
 
@@ -28,7 +28,7 @@ module Mail
       if pairs.empty? # Just dealing with a single value pair
         super(exact || key_name)
       else # Dealing with a multiple value pair or a single encoded value pair
-        string = pairs.sort { |a,b| a.first <=> b.first }.map { |v| v.last }.join('')
+        string = pairs.sort { |a,b| a.first.to_s <=> b.first.to_s }.map { |v| v.last }.join('')
         if mt = string.match(/([\w\d\-]+)'(\w\w)'(.*)/)
           string = mt[3]
           encoding = mt[1]
@@ -40,7 +40,7 @@ module Mail
     end
 
     def encoded
-      map.sort { |a,b| a.first <=> b.first }.map do |key_name, value|
+      map.sort { |a,b| a.first.to_s <=> b.first.to_s }.map do |key_name, value|
         unless value.ascii_only?
           value = Mail::Encodings.param_encode(value)
           key_name = "#{key_name}*"
@@ -50,7 +50,7 @@ module Mail
     end
 
     def decoded
-      map.sort { |a,b| a.first <=> b.first }.map do |key_name, value|
+      map.sort { |a,b| a.first.to_s <=> b.first.to_s }.map do |key_name, value|
         %Q{#{key_name}=#{quote_token(value)}}
       end.join("; ")
     end

--- a/lib/mail/indifferent_hash.rb
+++ b/lib/mail/indifferent_hash.rb
@@ -1,0 +1,26 @@
+module Mail
+  # Sort of like ActiveSupport HashWithIndifferentAccess, but lighter
+  class IndifferentHash < Hash
+    def initialize(other=nil)
+      if other.is_a?(Hash)
+        self.default = other.default
+        self.update(other)
+      else
+        super
+      end
+    end
+
+    def [](key_name)
+      super(key_name.to_sym)
+    end
+
+    def []=(k, v)
+      super(k.to_sym, v)
+    end
+
+    def update(other_hash)
+      super(other_hash.inject({}) {|c, (k, v)| c[k.to_sym] = v; c})
+    end
+    alias merge! update
+  end
+end

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1904,7 +1904,7 @@ module Mail
     end
 
     def init_with_hash(hash)
-      passed_in_options = hash.with_indifferent_access
+      passed_in_options = IndifferentHash.new(hash)
       self.raw_source = ''
 
       @header = Mail::Header.new

--- a/lib/mail/parts_list.rb
+++ b/lib/mail/parts_list.rb
@@ -31,8 +31,8 @@ module Mail
         # OK, 10000 is arbitrary... if anyone actually wants to explicitly sort 10000 parts of a
         # single email message... please show me a use case and I'll put more work into this method,
         # in the meantime, it works :)
-        a_order = order.index(a[:content_type].string.downcase) || 10000
-        b_order = order.index(b[:content_type].string.downcase) || 10000
+        a_order = order.index(a[:content_type].to_s.downcase) || 10000
+        b_order = order.index(b[:content_type].to_s.downcase) || 10000
         a_order <=> b_order
       end
       self.clear

--- a/lib/mail/version_specific/ruby_1_8.rb
+++ b/lib/mail/version_specific/ruby_1_8.rb
@@ -1,4 +1,9 @@
 # encoding: utf-8
+
+# For multibyte strings in Ruby 1.8
+require 'active_support'
+require 'active_support/core_ext/string'
+
 module Mail
   class Ruby18
     require 'base64'

--- a/spec/mail/fields/common/parameter_hash_spec.rb
+++ b/spec/mail/fields/common/parameter_hash_spec.rb
@@ -5,7 +5,7 @@ describe Mail::ParameterHash do
   it "should return the values in the hash" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'value2' => 'two'})
-    hash.keys.should == ['value1', 'value2']
+    hash.keys.should == [:value1, :value2]
     hash.values.should == ['one', 'two']
   end
 

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -58,7 +58,7 @@ describe Mail::ContentDispositionField do
     it "should give it's disposition type" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
       c.disposition_type.should == 'attachment'
-      c.parameters.should == {'filename' => 'File'}
+      c.parameters.should == {:filename => 'File'}
     end
 
     # see spec/fixtures/trec_2005_corpus/missing_content_disposition.eml

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -147,17 +147,17 @@ describe Mail::ContentTypeField do
 
     it "should return a parameter as a hash" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII')
-      c.parameters.should == {'charset' => 'US-ASCII'}
+      c.parameters.should == {:charset => 'US-ASCII'}
     end
 
     it "should return multiple parameters as a hash" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII; format=flowed')
-      c.parameters.should == {'charset' => 'US-ASCII', 'format' => 'flowed'}
+      c.parameters.should == {:charset => 'US-ASCII', :format => 'flowed'}
     end
 
     it "should return boundry parameters" do
       c = Mail::ContentTypeField.new('multipart/mixed; boundary=Apple-Mail-13-196941151')
-      c.parameters.should == {'boundary' => 'Apple-Mail-13-196941151'}
+      c.parameters.should == {:boundary => 'Apple-Mail-13-196941151'}
     end
 
     it "should be indifferent with the access" do
@@ -197,7 +197,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'application/octet-stream'
       c.main_type.should == 'application'
       c.sub_type.should == 'octet-stream'
-      c.parameters.should == {'name*' => "iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3"}
+      c.parameters.should == {:'name*' => "iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3"}
     end
 
     it "should handle 'application/pdf;'" do
@@ -215,7 +215,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'application/pdf'
       c.main_type.should == 'application'
       c.sub_type.should == 'pdf'
-      c.parameters.should == {"name" => "broken.pdf"}
+      c.parameters.should == {:name => "broken.pdf"}
     end
 
     it "should handle 'application/pkcs7-signature;'" do
@@ -233,7 +233,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'application/pkcs7-signature'
       c.main_type.should == 'application'
       c.sub_type.should == 'pkcs7-signature'
-      c.parameters.should == {"name" => "smime.p7s"}
+      c.parameters.should == {:name => "smime.p7s"}
     end
 
     it "should handle 'application/x-gzip; NAME=blah.gz'" do
@@ -242,7 +242,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'application/x-gzip'
       c.main_type.should == 'application'
       c.sub_type.should == 'x-gzip'
-      c.parameters.should == {"NAME" => "blah.gz"}
+      c.parameters.should == {:NAME => "blah.gz"}
     end
 
     it "should handle 'image/jpeg'" do
@@ -314,7 +314,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/alternative'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"}
+      c.parameters.should == {:boundary =>"----=_NextPart_000_0093_01C81419.EB75E850"}
     end
 
     it "should handle 'multipart/alternative; boundary=----=_NextPart_000_0093_01C81419.EB75E850'" do
@@ -323,7 +323,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/alternative'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"}
+      c.parameters.should == {:boundary =>"----=_NextPart_000_0093_01C81419.EB75E850"}
     end
 
     it "should handle 'Multipart/Alternative;boundary=MuLtIpArT_BoUnDaRy'" do
@@ -332,7 +332,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/alternative'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" =>"MuLtIpArT_BoUnDaRy"}
+      c.parameters.should == {:boundary =>"MuLtIpArT_BoUnDaRy"}
     end
 
     it "should handle 'Multipart/Alternative;boundary=MuLtIpArT_BoUnDaRy'" do
@@ -341,7 +341,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/alternative'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" =>"MuLtIpArT_BoUnDaRy"}
+      c.parameters.should == {:boundary =>"MuLtIpArT_BoUnDaRy"}
     end
 
     it "should handle 'multipart/mixed'" do
@@ -368,7 +368,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/mixed'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'mixed'
-      c.parameters.should == {"boundary" => "Apple-Mail-13-196941151"}
+      c.parameters.should == {:boundary => "Apple-Mail-13-196941151"}
     end
 
     it "should handle 'multipart/mixed; boundary=mimepart_427e4cb4ca329_133ae40413c81ef'" do
@@ -377,7 +377,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/mixed'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'mixed'
-      c.parameters.should == {"boundary" => "mimepart_427e4cb4ca329_133ae40413c81ef"}
+      c.parameters.should == {:boundary => "mimepart_427e4cb4ca329_133ae40413c81ef"}
     end
 
     it "should handle 'multipart/report; report-type=delivery-status;'" do
@@ -386,7 +386,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/report'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'report'
-      c.parameters.should == {"report-type" => "delivery-status"}
+      c.parameters.should == {:"report-type" => "delivery-status"}
     end
 
     it "should handle 'multipart/signed;'" do
@@ -422,7 +422,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/html'
       c.main_type.should == 'text'
       c.sub_type.should == 'html'
-      c.parameters.should == {'charset' => 'iso-8859-1'}
+      c.parameters.should == {:charset => 'iso-8859-1'}
     end
 
     it "should handle 'TEXT/PLAIN; charset=ISO-8859-1;'" do
@@ -431,7 +431,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/plain'
       c.main_type.should == 'text'
       c.sub_type.should == 'plain'
-      c.parameters.should == {'charset' => 'ISO-8859-1'}
+      c.parameters.should == {:charset => 'ISO-8859-1'}
     end
 
     it "should handle 'text/plain'" do
@@ -458,7 +458,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/plain'
       c.main_type.should == 'text'
       c.sub_type.should == 'plain'
-      c.parameters.should == {'charset' => 'ISO-8859-1'}
+      c.parameters.should == {:charset => 'ISO-8859-1'}
     end
 
     it "should handle 'text/plain; charset=ISO-8859-1;'" do
@@ -467,7 +467,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/plain'
       c.main_type.should == 'text'
       c.sub_type.should == 'plain'
-      c.parameters.should == {'charset' => 'ISO-8859-1', 'format' => 'flowed'}
+      c.parameters.should == {:charset => 'ISO-8859-1', :format => 'flowed'}
     end
 
     it "should handle 'text/plain; charset=us-ascii;'" do
@@ -476,7 +476,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/plain'
       c.main_type.should == 'text'
       c.sub_type.should == 'plain'
-      c.parameters.should == {'charset' => 'us-ascii'}
+      c.parameters.should == {:charset => 'us-ascii'}
     end
 
     it "should handle 'text/plain; charset=US-ASCII; format=flowed'" do
@@ -485,7 +485,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/plain'
       c.main_type.should == 'text'
       c.sub_type.should == 'plain'
-      c.parameters.should == {'charset' => 'US-ASCII', 'format' => 'flowed'}
+      c.parameters.should == {:charset => 'US-ASCII', :format => 'flowed'}
     end
 
     it "should handle 'text/plain; charset=US-ASCII; format=flowed'" do
@@ -494,7 +494,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/plain'
       c.main_type.should == 'text'
       c.sub_type.should == 'plain'
-      c.parameters.should == {'charset' => 'US-ASCII', 'format' => 'flowed'}
+      c.parameters.should == {:charset => 'US-ASCII', :format => 'flowed'}
     end
 
     it "should handle 'text/plain; charset=utf-8'" do
@@ -503,7 +503,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/plain'
       c.main_type.should == 'text'
       c.sub_type.should == 'plain'
-      c.parameters.should == {'charset' => 'utf-8'}
+      c.parameters.should == {:charset => 'utf-8'}
     end
 
     it "should handle 'text/plain; charset=utf-8'" do
@@ -512,7 +512,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/plain'
       c.main_type.should == 'text'
       c.sub_type.should == 'plain'
-      c.parameters.should == {'charset' => 'X-UNKNOWN'}
+      c.parameters.should == {:charset => 'X-UNKNOWN'}
     end
 
     it "should handle 'text/x-ruby-script;'" do
@@ -530,7 +530,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'text/x-ruby-script'
       c.main_type.should == 'text'
       c.sub_type.should == 'x-ruby-script'
-      c.parameters.should == {'name' => 'hello.rb'}
+      c.parameters.should == {:name => 'hello.rb'}
     end
 
     it "should handle 'multipart/mixed; boundary=\"=_NextPart_Lycos_15031600484464_ID\"" do
@@ -539,7 +539,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/mixed'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'mixed'
-      c.parameters.should == {'boundary' => '=_NextPart_Lycos_15031600484464_ID'}
+      c.parameters.should == {:boundary => '=_NextPart_Lycos_15031600484464_ID'}
     end
 
     it "should handle 'multipart/alternative; boundary=----=_=NextPart_000_0093_01C81419.EB75E850" do
@@ -548,7 +548,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/alternative'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'alternative'
-      c.parameters.should == {'boundary' => '----=_=NextPart_000_0093_01C81419.EB75E850'}
+      c.parameters.should == {:boundary => '----=_=NextPart_000_0093_01C81419.EB75E850'}
     end
 
     it "should handle 'multipart/alternative; boundary=\"----=_=NextPart_000_0093_01C81419.EB75E850\"" do
@@ -557,7 +557,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/alternative'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'alternative'
-      c.parameters.should == {'boundary' => '----=_=NextPart_000_0093_01C81419.EB75E850'}
+      c.parameters.should == {:boundary => '----=_=NextPart_000_0093_01C81419.EB75E850'}
     end
 
     it "should handle 'multipart/related;boundary=1_4626B816_9F1690;Type=\"application/smil\";Start=\"<mms.smil.txt>\"'" do
@@ -566,7 +566,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'multipart/related'
       c.main_type.should == 'multipart'
       c.sub_type.should == 'related'
-      c.parameters.should == {'boundary' => '1_4626B816_9F1690', 'Type' => 'application/smil', 'Start' => '<mms.smil.txt>'}
+      c.parameters.should == {:boundary => '1_4626B816_9F1690', :Type => 'application/smil', :Start => '<mms.smil.txt>'}
     end
 
     it "should handle 'IMAGE/JPEG; name=\"IM 006.jpg\"'" do
@@ -575,7 +575,7 @@ describe Mail::ContentTypeField do
       c.content_type.should == 'image/jpeg'
       c.main_type.should == 'image'
       c.sub_type.should == 'jpeg'
-      c.parameters.should == {'name' => "IM 006.jpg"}
+      c.parameters.should == {:name => "IM 006.jpg"}
     end
 
   end
@@ -623,7 +623,7 @@ describe Mail::ContentTypeField do
         result = %Q{Content-Type: application/octet-stream;\r\n\sfilename*=sjis'jp'01%20Quien%20Te%20Dij%91at.%20Pitbull.mp3\r\n}
       end
       c.filename = string
-      c.parameters.should == {'filename' => string}
+      c.parameters.should == {:filename => string}
       c.encoded.should == result
       $KCODE = @original if RUBY_VERSION < '1.9'
     end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -175,7 +175,8 @@ describe Mail::Message do
     end
   
     it "should still ask the body for a new instance even though these is nothing to parse, yet" do
-      Mail::Body.should_receive(:new)
+      body = Mail::Body.new('')
+      Mail::Body.should_receive(:new).and_return(body)
       mail = Mail::Message.new("To: mikel\r\nFrom: bob\r\nSubject: Hello!")
     end
 
@@ -1026,21 +1027,21 @@ describe Mail::Message do
         
         it "should be able to set a content type with an array and hash" do
           mail = Mail.new
-          mail.content_type = ["text", "plain", { "charset" => 'US-ASCII' }]
+          mail.content_type = ["text", "plain", { :charset => 'US-ASCII' }]
           mail[:content_type].encoded.should == %Q[Content-Type: text/plain;\r\n\scharset=US-ASCII\r\n]
-          mail.content_type_parameters.should == {"charset" => "US-ASCII"}
+          mail.content_type_parameters.should == {:charset => "US-ASCII"}
         end
         
         it "should be able to set a content type with an array and hash with a non-usascii field" do
           mail = Mail.new
-          mail.content_type = ["text", "plain", { "charset" => 'UTF-8' }]
+          mail.content_type = ["text", "plain", { :charset => 'UTF-8' }]
           mail[:content_type].encoded.should == %Q[Content-Type: text/plain;\r\n\scharset=UTF-8\r\n]
-          mail.content_type_parameters.should == {"charset" => "UTF-8"}
+          mail.content_type_parameters.should == {:charset => "UTF-8"}
         end
 
         it "should allow us to specify a content type in a block" do
           mail = Mail.new { content_type ["text", "plain", { "charset" => "UTF-8" }] }
-          mail.content_type_parameters.should == {"charset" => "UTF-8"}
+          mail.content_type_parameters.should == {:charset => "UTF-8"}
         end
         
       end
@@ -1434,6 +1435,7 @@ describe Mail::Message do
 
   describe "ordering messages" do
     it "should put all attachments as the last item" do
+      # XXX: AFAICT, this is not actually working. The code does not appear to implement this. -- singpolyma
       mail = Mail.new
       mail.attachments['image.png'] = "\302\302\302\302"
       p = Mail::Part.new(:content_type => 'multipart/alternative')

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -53,7 +53,7 @@ describe "MIME Emails" do
 
       it "should return the content-type parameters" do
         mail = Mail.new("Content-Type: text/plain; charset=US-ASCII; format=flowed")
-        mail.content_type_parameters.should == {'charset' => 'US-ASCII', 'format' => 'flowed'}
+        mail.content_type_parameters.should == {:charset => 'US-ASCII', :format => 'flowed'}
       end
 
       it "should recognize a multipart email" do

--- a/spec/mail/network/retriever_methods/imap_spec.rb
+++ b/spec/mail/network/retriever_methods/imap_spec.rb
@@ -158,16 +158,16 @@ describe "IMAP Retriever" do
       retrievable = Mail::IMAP.new({})
       options = retrievable.send(:validate_options, {})
 
-      options[:count].should be_present
+      options[:count].should_not be_blank
       options[:count].should == 10
 
-      options[:order].should be_present
+      options[:order].should_not be_blank
       options[:order].should == :asc
 
-      options[:what].should be_present
+      options[:what].should_not be_blank
       options[:what].should == :first
 
-      options[:mailbox].should be_present
+      options[:mailbox].should_not be_blank
       options[:mailbox].should == 'INBOX'
     end
     it "should not replace given configuration" do
@@ -179,16 +179,16 @@ describe "IMAP Retriever" do
         :what => :first
       })
 
-      options[:count].should be_present
+      options[:count].should_not be_blank
       options[:count].should == 2
 
-      options[:order].should be_present
+      options[:order].should_not be_blank
       options[:order].should == :asc
 
-      options[:what].should be_present
+      options[:what].should_not be_blank
       options[:what].should == :first
 
-      options[:mailbox].should be_present
+      options[:mailbox].should_not be_blank
       options[:mailbox].should == 'some/mail/box'
     end
     it "should ensure utf7 conversion for mailbox names" do

--- a/spec/mail/network/retriever_methods/pop3_spec.rb
+++ b/spec/mail/network/retriever_methods/pop3_spec.rb
@@ -172,13 +172,13 @@ describe "POP3 Retriever" do
       retrievable = Mail::POP3.new({})
       options = retrievable.send(:validate_options, {})
       
-      options[:count].should be_present
+      options[:count].should_not be_blank
       options[:count].should == 10
       
-      options[:order].should be_present
+      options[:order].should_not be_blank
       options[:order].should == :asc
       
-      options[:what].should be_present
+      options[:what].should_not be_blank
       options[:what].should == :first
     end
     
@@ -190,13 +190,13 @@ describe "POP3 Retriever" do
         :what => :first
       })
       
-      options[:count].should be_present
+      options[:count].should_not be_blank
       options[:count].should == 2
       
-      options[:order].should be_present
+      options[:order].should_not be_blank
       options[:order].should == :asc
       
-      options[:what].should be_present
+      options[:what].should_not be_blank
       options[:what].should == :first
     end
     


### PR DESCRIPTION
I've rebased my patch to remove the activesupport requirement on 1.9+  Would really like to see this mainlined
