### PR TITLE
relax i18n dependencies for rails 3.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "activesupport", ">= 2.3.6"
 gem "tlsmail" if RUBY_VERSION <= '1.8.6'
 gem "mime-types", "~> 1.16"
 gem "treetop", "~> 1.4.8"
-gem "i18n", "~> 0.4.1"
+gem "i18n", ">= 0.4.1"
 
 group :test do
   gem "ZenTest",    "~> 4.4.0"

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', ">= 2.3.6")
   s.add_dependency('mime-types', "~> 1.16")
   s.add_dependency('treetop', '~> 1.4.8')
-  s.add_dependency('i18n', '~> 0.4.1')
+  s.add_dependency('i18n', '>= 0.4.1')
   s.add_dependency('tlsmail', '~> 0.0.1') if RUBY_VERSION == '1.8.6'
 
   s.require_path = 'lib'


### PR DESCRIPTION
Hi Mikel,

could you please apply this commit and re-release Mail in order to relax the dependencies for I18n when used in Rails 3.0.3?

We've released I18n 0.5.0 and with the pretty tight dependencies defined by Mail one now gets a "can't activate i18n" error: https://gist.github.com/f0d2eb163c2ee4bcd944

I believe this commit relaxes the dependencies in the correct way, do you agree? I've also tested this by uninstalling my Mail gems, building the gem from my cloned repository and installing it locally. `rails new foo` afterwards worked fine, so I think this should work.

Thanks a lot!
