### PR TITLE
Fixing problems with multibyte filenamed attachment

### DIFF
--- a/lib/mail/attachments_list.rb
+++ b/lib/mail/attachments_list.rb
@@ -37,9 +37,10 @@ module Mail
     end
 
     def []=(name, value)
-      default_values = { :content_type => "#{set_mime_type(name)}; filename=\"#{name}\"",
+      encoded_name = Mail::Encodings.decode_encode name, :encode
+      default_values = { :content_type => "#{set_mime_type(name)}; filename=\"#{encoded_name}\"",
                          :content_transfer_encoding => "#{guess_encoding}",
-                         :content_disposition => "#{@content_disposition_type}; filename=\"#{name}\"" }
+                         :content_disposition => "#{@content_disposition_type}; filename=\"#{encoded_name}\"" }
 
       if value.is_a?(Hash)
 
@@ -73,7 +74,7 @@ module Mail
           hash[:body].force_encoding("BINARY")
         end
       end
-      
+
       attachment = Part.new(hash)
       attachment.add_content_id(hash[:content_id])
 
@@ -102,4 +103,3 @@ module Mail
 
   end
 end
-


### PR DESCRIPTION
Current Mail fails to handle attachment with multibyte filename because it doesn't properly MIME-encode attachment filename.
This is the root cause of #78 and #83

The reason for using NKF library for this purpose is to make sure it works on both Ruby 1.8 and 1.9.
I actually consulted with several Ruby-core committers at Asakusa.rb, and they recommended to do so.
