### PR TITLE
Suppress warnings

### DIFF
--- a/lib/mail/patterns.rb
+++ b/lib/mail/patterns.rb
@@ -9,6 +9,7 @@ module Mail
     aspecial     = %Q|()<>[]:;@\\,."| # RFC5322
     tspecial     = %Q|()<>@,;:\\"/[]?=| # RFC2045
     lwsp         = %Q| \t\r\n|
+    sp           = %Q| |
     control      = %Q|\x00-\x1f\x7f-\xff|
     
     if control.respond_to?(:force_encoding)
@@ -27,8 +28,8 @@ module Mail
     QP_UNSAFE     = /[^#{qp_safe}]/
     QP_SAFE       = /[#{qp_safe}]/
     CONTROL_CHAR  = /[#{control}]/n
-    ATOM_UNSAFE   = /[#{Regexp.quote aspecial}#{control}#{lwsp}]/n
+    ATOM_UNSAFE   = /[#{Regexp.quote aspecial}#{control}#{sp}]/n
     PHRASE_UNSAFE = /[#{Regexp.quote aspecial}#{control}]/n
-    TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{lwsp}]/n
+    TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{sp}]/n
   end
 end


### PR DESCRIPTION
I'm on Debian GNU/Linux sid. I got many warnings when I run rake on Ruby 1.9. This commit suppress a few warnings.

<pre>
% ruby1.9.1 -v
ruby 1.9.2p0 (2010-08-18 revision 29036) [x86_64-linux]
</pre>


<pre>
% ruby1.9.1 -S rake
...
.../mail/lib/mail/patterns.rb:30: warning: character class has duplicated range: /[\(\)<>\[\]:;@\\,\."\x00-\x1f\x7f-\xff    
]/
.../mail/lib/mail/patterns.rb:32: warning: character class has duplicated range: /[\(\)<>@,;:\\"\/\[\]\?=\x00-\x1f\x7f-\xff     
]/
...
</pre>


This commit fixes the above warnings.
