### PR TITLE
Add authentication selection for imap retriever (issue no. 170)

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -139,7 +139,13 @@ module Mail
         raise ArgumentError.new("Mail::Retrievable#imap_start takes a block") unless block_given?
 
         imap = Net::IMAP.new(settings[:address], settings[:port], settings[:enable_ssl], nil, false)
-        imap.login(settings[:user_name], settings[:password])
+        if settings[:authentication].nil?
+          imap.login(settings[:user_name], settings[:password])
+        else
+          # Note that Net::IMAP#authenticate('LOGIN', ...) is not equal with Net::IMAP#login(...)!
+          # (see also http://www.ensta.fr/~diam/ruby/online/ruby-doc-stdlib/libdoc/net/imap/rdoc/classes/Net/IMAP.html#M000718)
+          imap.authenticate(settings[:authentication], settings[:user_name], settings[:password])
+        end
 
         yield imap
       ensure

--- a/spec/mail/network/retriever_methods/imap_spec.rb
+++ b/spec/mail/network/retriever_methods/imap_spec.rb
@@ -226,6 +226,29 @@ describe "IMAP Retriever" do
       MockIMAP.should be_disconnected
     end
   end
+  
+  describe "authentication mechanism" do
+    before(:each) do
+      @imap = MockIMAP.new
+      MockIMAP.stub!(:new).and_return(@imap)
+    end
+    it "should be login by default" do
+      @imap.should_not_receive(:authenticate)
+      @imap.should_receive(:login).with('foo', 'secret')
+      Mail.defaults do
+        retriever_method :imap, {:user_name => 'foo', :password => 'secret'}
+      end
+      messages = Mail.find
+    end
+    it "should be changeable" do
+      @imap.should_receive(:authenticate).with('CRAM-MD5', 'foo', 'secret')
+      @imap.should_not_receive(:login)
+      Mail.defaults do
+        retriever_method :imap, {:authentication => 'CRAM-MD5', :user_name => 'foo', :password => 'secret'}
+      end
+      messages = Mail.find
+    end
+  end
 
 end
 


### PR DESCRIPTION
Hi Mikel,

both spec and rcov are "green" (testet on Ruby 1.8.7.)
I also tested with my local imap-server (Dovecot on SL Server 10.6) and Gmail.

Cheers,
Björn

PS: Great gem, thanks!
