### PR TITLE
Backport to fix a bug in net/smtp

### DIFF
--- a/lib/mail.rb
+++ b/lib/mail.rb
@@ -33,6 +33,7 @@ module Mail # :doc:
 
   require 'mail/core_extensions/nil'
   require 'mail/core_extensions/string'
+  require 'mail/core_extensions/smtp'
 
   require 'mail/patterns'
   require 'mail/utilities'

--- a/lib/mail/core_extensions/smtp.rb
+++ b/lib/mail/core_extensions/smtp.rb
@@ -1,0 +1,20 @@
+module Net
+  class SMTP
+    remove_method :tlsconnect
+
+    def tlsconnect(s)
+      verified = false
+      s = OpenSSL::SSL::SSLSocket.new s, @ssl_context
+      logging "TLS connection started"
+      s.sync_close = true
+      s.connect
+      if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
+        s.post_connection_check(@address)
+      end
+      verified = true
+      s
+    ensure
+      s.close unless verified
+    end
+  end
+end


### PR DESCRIPTION
There is a bug in net/smtp that is causing Sam Ruby's tests to fail.  I've fixed it in ruby-trunk, but we should backport the fix to the mail gem.

I've added the backport to my fork.

http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?view=rev&revision=30294
https://github.com/tenderlove/mail/commit/9e7e914c80dbe0741e765085840961975284b509
