### PR TITLE
Use iana port on imap retriever

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -37,7 +37,7 @@ module Mail
     
     def initialize(values)
       self.settings = { :address              => "localhost",
-                        :port                 => 110,
+                        :port                 => 143,
                         :user_name            => nil,
                         :password             => nil,
                         :authentication       => nil,


### PR DESCRIPTION
Currently set to the pop3 port.

The imap retriever was dying until I realized the default port was wrong.
