### PR TITLE
Added to_yaml & from_yaml (as well as to_hash & from_hash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ spec/fixtures/emails/failed_emails/
 *.swp
 .idea
 tmp
+tags

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require "yaml"
+
 module Mail
   # The Message class provides a single point of access to all things to do with an
   # email message.
@@ -1706,6 +1708,25 @@ module Mail
       buffer << "\r\n"
       buffer << body.encoded(content_transfer_encoding)
       buffer
+    end
+
+    def to_yaml
+      ready_to_send!
+      hash = {}
+      header.fields.each do |field|
+        hash[field.name] = field.value
+      end
+      hash['subject'] = subject
+      hash['body'] = body.encoded(content_transfer_encoding)
+      hash.to_yaml
+    end
+
+    def self.from_yaml(str)
+      from_hash(YAML::load(str))
+    end
+
+    def self.from_hash(hash)
+      Mail::Message.new(hash)
     end
 
     def to_s

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -56,8 +56,6 @@ describe Mail::Message do
       doing { Mail::Message.new(File.read(fixture('emails', 'error_emails', 'missing_body.eml'))) }.should_not raise_error
     end
 
-
-
     it "should be able to parse an email with a funky date header" do
       doing { Mail::Message.new(File.read(fixture('emails', 'error_emails', 'bad_date_header2.eml'))) }
     end
@@ -118,6 +116,14 @@ describe Mail::Message do
       mail.in_reply_to.should be_blank
     end
 
+    it "should allow serializing to YAML" do
+      Mail::Message.new(:to => 'someone@somewhere.com', :cc => 'someoneelse@somewhere.com', :bcc => 'someonesecret@somewhere.com', :body => 'body', :subject => 'subject').to_yaml.should match /--- \nMime-Version: \"1.0\"\nCc: someoneelse@somewhere.com\nSubject: subject\nbody: body\nBcc: someonesecret@somewhere.com\nContent-Transfer-Encoding: 7bit\nMessage-ID: <.*>\nsubject: subject\nContent-Type: text\/plain\nTo: someone@somewhere.com\nDate: Mon, 07 Feb 2011 \d\d:\d\d:\d\d [+-]\d\d\d\d\n/
+    end
+
+    it "should deserialize after serializing" do
+      message = Mail::Message.new(:to => 'someone@somewhere.com', :cc => 'someoneelse@somewhere.com', :bcc => 'someonesecret@somewhere.com', :body => 'body', :subject => 'subject')
+      Mail::Message.from_yaml(message.to_yaml).should == message
+    end
   end
   
   describe "envelope line handling" do


### PR DESCRIPTION
Mail::Message#to_yaml used to give an error earlier.
TypeError: can't dump anonymous class Class
