### PR TITLE
Return field

### DIFF
--- a/lib/mail/fields/return_path_field.rb
+++ b/lib/mail/fields/return_path_field.rb
@@ -38,6 +38,7 @@ module Mail
     CAPITALIZED_FIELD = 'Return-Path'
     
     def initialize(value = nil, charset = 'utf-8')
+      value = nil if value == '<>'
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
       self.parse

--- a/spec/mail/fields/return_path_field_spec.rb
+++ b/spec/mail/fields/return_path_field_spec.rb
@@ -11,6 +11,11 @@ describe Mail::ReturnPathField do
     rp.encoded.should == "Return-Path: <mikel@test.lindsaar.net>\r\n"
   end
 
+  it "should accept <>" do
+    rp = Mail::ReturnPathField.new('<>')
+    rp.encoded.should == "Return-Path: <>\r\n"
+  end
+  
   it "should set the return path" do
     mail = Mail.new do
       to "to@someemail.com"


### PR DESCRIPTION
It is possible that someone sends and email with a Return-Path that is <>.

So, when this happens (value == '<>'), the value should be set to nil.
Added code in the ReturnPathField to check and change the value.
Added a spec to verify that code works.
All other tests pass.
