### PR TITLE
Parts list

### DIFF
--- a/lib/mail/parts_list.rb
+++ b/lib/mail/parts_list.rb
@@ -31,8 +31,8 @@ module Mail
         # OK, 10000 is arbitrary... if anyone actually wants to explicitly sort 10000 parts of a
         # single email message... please show me a use case and I'll put more work into this method,
         # in the meantime, it works :)
-        a_order = order.index(a[:content_type].string.downcase) || 10000
-        b_order = order.index(b[:content_type].string.downcase) || 10000
+        a_order = a[:content_type] ? order.index(a[:content_type].string.downcase) || 10000 : 10000
+        b_order = b[:content_type] ? order.index(b[:content_type].string.downcase) || 10000 : 10000
         a_order <=> b_order
       end
       self.clear

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -9,4 +9,12 @@ describe "PartsList" do
     p << 1
     p.sort.class.should == Mail::PartsList
   end
+  
+  it "should not fail if we do not have a content_type" do
+    p = Mail::PartsList.new
+    order = ['text/plain']
+    p << 'text/plain'
+    p << 'text/html'
+    p.sort!(order)
+  end
 end


### PR DESCRIPTION
When parsing incoming email, it is possible that a content-type for a part is missing.  If this is the case, then when we try to call .to_s on a mail, it will crash with an undefined method `string' for nil:NilClass.

Instead, the PartList class should handle this by checking for the existence of the content type for that part before calling .string
