### PR TITLE
Received field

### DIFF
--- a/lib/mail/fields/received_field.rb
+++ b/lib/mail/fields/received_field.rb
@@ -52,15 +52,23 @@ module Mail
     end
    
     def formatted_date
-        date_time.strftime("%a, %d %b %Y %H:%M:%S ") + date_time.zone.delete(':')
+      date_time.strftime("%a, %d %b %Y %H:%M:%S ") + date_time.zone.delete(':')
     end
  
     def encoded
-      "#{CAPITALIZED_FIELD}: #{info}; #{formatted_date}\r\n"
+      if value.blank?
+        "#{CAPITALIZED_FIELD}: \r\n"
+      else
+        "#{CAPITALIZED_FIELD}: #{info}; #{formatted_date}\r\n"
+      end
     end
     
     def decoded
-      "#{info}; #{formatted_date}" 
+      if value.blank?
+        ""
+      else
+        "#{info}; #{formatted_date}" 
+      end
     end
     
   end

--- a/spec/mail/fields/received_field_spec.rb
+++ b/spec/mail/fields/received_field_spec.rb
@@ -41,4 +41,11 @@ describe Mail::ReceivedField do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
     t.decoded.should == 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000'
   end
+  
+  it "should handle a blank value" do
+    t = Mail::ReceivedField.new('')
+    t.decoded.should == ''
+    t.encoded.should == "Received: \r\n"
+  end
+  
 end


### PR DESCRIPTION
The mail gem handles creating mail very well.  Other mail clients are not so good.   It is possible that when processing incoming email that a blank Received header may exists.  

If so, the mail gem should laugh at this mail and process it gracefully.

Ideally, the mail gem would autocreate a patch for the offending mail client, but with so many out there, the mail gem will have to wait for skynet to be created... or someone else to provide that patch.
