### PR TITLE
Fix for issue 208 "mail.body after mail.add_file truncates message body"

### DIFF
--- a/lib/mail/part.rb
+++ b/lib/mail/part.rb
@@ -103,7 +103,7 @@ module Mail
         self.body   = body_part
       else
         self.header = "Content-Type: text/plain\r\n"
-        self.body   = header_part
+        self.body   = raw_source
       end
     end
     

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -455,6 +455,21 @@ describe "MIME Emails" do
         m.parts.first[:content_type].content_type.should == 'image/png'
         m.parts.last[:content_type].content_type.should == 'text/plain'
       end
+      
+      it "should allow you to add a body as text part if you have added a file and not truncate after newlines - issue 208" do
+        m = Mail.new do
+          from    'mikel@from.lindsaar.net'
+          subject 'Hello there Mikel'
+          to      'mikel@to.lindsaar.net'
+          add_file fixture('attachments', 'test.png')
+          body    "First Line\n\nSecond Line\n\nThird Line\n\n"
+          #Note: trailing \n\n is stripped off by Mail::Part initialization
+        end
+        m.parts.length.should == 2
+        m.parts.first[:content_type].content_type.should == 'image/png'
+        m.parts.last[:content_type].content_type.should == 'text/plain'
+        m.parts.last.to_s.should match /^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/
+      end
 
     end
 

--- a/spec/mail/part_spec.rb
+++ b/spec/mail/part_spec.rb
@@ -141,5 +141,13 @@ ENDPART
     end
 
   end
+  
+  it "should correctly parse plain text raw source and not truncate after newlines - issue 208" do
+    plain_text = "First Line\n\nSecond Line\n\nThird Line\n\n"
+    #Note: trailing \n\n is stripped off by Mail::Part initialization
+    part = Mail::Part.new(plain_text)
+    part[:content_type].content_type.should == 'text/plain'
+    part.to_s.should match /^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/
+  end
 
 end


### PR DESCRIPTION
specs pass in 1.8.6, 1.8.7 and 1.9.2

link to issue: https://github.com/mikel/mail/issues/208
