### PR TITLE
Mail::Field.new("Subject: foobar", 'iso-2022-jp') is not set charset

### DIFF
--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -69,7 +69,8 @@ module Mail
     #  Field.new('content-type', ['text', 'plain', {:charset => 'UTF-8'}])
     def initialize(name, value = nil, charset = 'utf-8')
       case
-      when name =~ /:/ && value.blank?   # Field.new("field-name: field data")
+      when name =~ /:/                  # Field.new("field-name: field data")
+        charset = value unless value.blank?
         name, value = split(name)
         create_field(name, value, charset)
       when name !~ /:/ && value.blank?  # Field.new("field-name")

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -111,6 +111,11 @@ describe Mail::Field do
       field.field.class.should == Mail::MessageIdField
     end
 
+    it "should inherit charset" do
+      charset = 'iso-2022-jp'
+      field = Mail::Field.new('Subject: こんにちは', charset)
+      field.charset.should == charset
+    end
   end
 
   describe "error handling" do


### PR DESCRIPTION
Hi.

I found a bug that SubjectField is not set charset.
I don't know this is a bug or a spec, but all spec is pass when apply this patch.
Please consider this case.

Yalab
