### PR TITLE
Fixed charset warning issue with multipart messages

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1679,6 +1679,7 @@ module Mail
       self.body = ''
       text_part = Mail::Part.new({:content_type => 'text/plain;',
                                   :body => text})
+      text_part.charset = charset unless @defaulted_charset
       self.body << text_part
     end
 

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -471,6 +471,17 @@ describe "MIME Emails" do
         m.parts.last.to_s.should match /^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/
       end
 
+      it "should not raise a warning if there is a charset defined and there are non ascii chars in the body" do
+        body = "This is NOT plain text ASCII　− かきくけこ"
+        mail = Mail.new
+        mail.body = body
+        mail.charset = 'UTF-8'
+        mail.add_file fixture('attachments', 'test.png')
+        STDERR.should_not_receive(:puts)
+        mail.to_s
+      end
+
+
     end
 
 end


### PR DESCRIPTION
Hi,

I've added a test for this, got it failing and fixed it.

This issue was discussed by you here as well: http://groups.google.com/group/mail-ruby/browse_thread/thread/27c3bf043087dcda?pli=1

When an add_file was called to add an attachment on a plain (non-multipart) message _with UTF-8 characters_, the call which was made to create a new "Part" did not copy over the charset of the earlier plain-text message, but instead copied over only the body. Later, it would always show a warning message that the charset had to be detected, even if it was set before.

Caveat: You need to set charset before the first call to add_file.

Thanks,
Arvind
