### PR TITLE
Arguments need parentheses

### DIFF
--- a/lib/mail/multibyte/chars.rb
+++ b/lib/mail/multibyte/chars.rb
@@ -339,7 +339,7 @@ module Mail #:nodoc:
       # Example:
       #   'Laurent, où sont les tests ?'.mb_chars.upcase.to_s # => "LAURENT, OÙ SONT LES TESTS ?"
       def upcase
-        chars(Unicode.apply_mapping @wrapped_string, :uppercase_mapping)
+        chars(Unicode.apply_mapping(@wrapped_string), :uppercase_mapping)
       end
 
       # Convert characters in the string to lowercase.
@@ -347,7 +347,7 @@ module Mail #:nodoc:
       # Example:
       #   'VĚDA A VÝZKUM'.mb_chars.downcase.to_s # => "věda a výzkum"
       def downcase
-        chars(Unicode.apply_mapping @wrapped_string, :lowercase_mapping)
+        chars(Unicode.apply_mapping(@wrapped_string), :lowercase_mapping)
       end
 
       # Converts the first character to uppercase and the remainder to lowercase.


### PR DESCRIPTION
I've added parentheses to avoid these two warning messages:

/Users/doktahworm/.rvm/gems/ruby-1.8.7-p174/gems/mail-2.3.0/lib/mail/multibyte/chars.rb:342: warning: parenthesize argument(s) for future version
/Users/doktahworm/.rvm/gems/ruby-1.8.7-p174/gems/mail-2.3.0/lib/mail/multibyte/chars.rb:350: warning: parenthesize argument(s) for future version
