### PR TITLE
gemspec updated to reflect the fact there is now a README.mkd not README.rdoc

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency('tlsmail', '~> 0.0.1') if RUBY_VERSION == '1.8.6'
 
   s.require_path = 'lib'
-  s.files = %w(README.rdoc CHANGELOG.rdoc Dependencies.txt Gemfile Rakefile TODO.rdoc) + Dir.glob("lib/**/*")
+  s.files = %w(README.mkd CHANGELOG.rdoc Dependencies.txt Gemfile Rakefile TODO.rdoc) + Dir.glob("lib/**/*")
 end


### PR DESCRIPTION
The README seems to have been changed to markdown but the gemspec wasn't updated to the new extension causing a few errors.
