### PR TITLE
Add another missing file reference to the Gemspec

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
-  s.extra_rdoc_files = ["README.rdoc", "CHANGELOG.rdoc", "TODO.rdoc"]
+  s.extra_rdoc_files = ["README.mkd", "CHANGELOG.rdoc", "TODO.rdoc"]
 
   s.add_dependency('mime-types', "~> 1.16")
   s.add_dependency('treetop', '~> 1.4.8')


### PR DESCRIPTION
There was another pull request but I forgot to update another one of the references in the Gemspec. This one should include both references to the new markdown README rather than the rdoc one.
