### PR TITLE
Add blank? method for NilClass

### DIFF
--- a/lib/mail/core_extensions/nil.rb
+++ b/lib/mail/core_extensions/nil.rb
@@ -3,6 +3,10 @@
 # This is not loaded if ActiveSupport is already loaded
 
 class NilClass #:nodoc:
+  def blank?
+    true
+  end
+
   def to_crlf
     ''
   end


### PR DESCRIPTION
I'm using mail in a tiny gem which doesn't include ActiveSupport and runs in a pretty basic environment, when I try to deliver I get the following error:

NoMethodError:
      undefined method `each' for nil:NilClass
    # /Users/john/.rvm/gems/ruby-1.8.7-p334@release_party/gems/mail-2.3.0/lib/mail/elements/address.rb:200:in`strip_all_comments'
    # /Users/john/.rvm/gems/ruby-1.8.7-p334@release_party/gems/mail-2.3.0/lib/mail/elements/address.rb:117:in `domain'
    # /Users/john/.rvm/gems/ruby-1.8.7-p334@release_party/gems/mail-2.3.0/lib/mail/elements/address.rb:68:in`address'

This is because blank? returns false for comments, which has been assigned nil.
