### PR TITLE
Fixed URI.escape and URI.unescape warnings in 1.9.2

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -116,11 +116,15 @@ module Mail
     end
     
     def uri_escape( str )
-      URI.escape(str)
+      uri_parser.escape(str)
     end
     
     def uri_unescape( str )
-      URI.unescape(str)
+      uri_parser.unescape(str)
+    end
+    
+    def uri_parser
+      @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
     end
     
     # Matches two objects with their to_s values case insensitively

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -76,7 +76,7 @@ module Mail
     end
 
     def Ruby19.param_decode(str, encoding)
-      string = URI.unescape(str)
+      string = uri_parser.unescape(str)
       string.force_encoding(encoding) if encoding
       string
     end
@@ -84,7 +84,11 @@ module Mail
     def Ruby19.param_encode(str)
       encoding = str.encoding.to_s.downcase
       language = Configuration.instance.param_encode_language
-      "#{encoding}'#{language}'#{URI.escape(str)}"
+      "#{encoding}'#{language}'#{uri_parser.escape(str)}"
+    end
+
+    def Ruby19.uri_parser
+      @uri_parser ||= URI::Parser.new
     end
 
      # mails somtimes includes invalid encodings like iso885915 or utf8 so we transform them to iso885915 or utf8

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -180,7 +180,8 @@ describe "Attachments" do
 
     it "should provide a URL escaped content_id (without brackets) for use inside an email" do
       @inline = @mail.attachments['test.gif'].cid
-      @inline.should == URI.escape(@cid.gsub(/^</, '').gsub(/>$/, ''))
+      uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
+      @inline.should == uri_parser.escape(@cid.gsub(/^</, '').gsub(/>$/, ''))
     end
   end
 

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -320,7 +320,8 @@ describe "Utilities Module" do
     end
 
     it "should have a wrapper on URI.unescape" do
-      uri_unescape("@?@!").should == URI.unescape("@?@!")
+      uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
+      uri_unescape("@?@!").should == uri_parser.unescape("@?@!")
     end
   end
   


### PR DESCRIPTION
Fixed: "warning: URI.escape is obsolete" and "warning: URI.unescape is obsolete" when running under Ruby 1.9.2.  Tests all pass under 1.9.2 and 1.8.7.
