### PR TITLE
Mail::Message#to_yaml - fix specs in 1.8.7

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1720,7 +1720,7 @@ module Mail
       hash['delivery_handler'] = delivery_handler.to_s if delivery_handler
       hash['transport_encoding'] = transport_encoding.to_s
       special_variables = [:@header, :@delivery_handler, :@transport_encoding]
-      (instance_variables - special_variables).each do |var|
+      (instance_variables.map(&:to_sym) - special_variables).each do |var|
         hash[var.to_s] = instance_variable_get(var)
       end
       hash.to_yaml(opts)


### PR DESCRIPTION
Hi,

Apologies - I realised I only tested pull request #237 in ruby 1.9.2. This pull request fixes the specs in 1.8.7, which were failing due to Object#instance_variables outputting a list of strings rather than symbols.

Now tested and passing in 1.9.2, MRI 1.8.7 and REE 1.8.7.

Cheers,
Simon
