### PR TITLE
Fixed more test suite warnings under 1.9.2:

### DIFF
--- a/lib/mail/fields/common/parameter_hash.rb
+++ b/lib/mail/fields/common/parameter_hash.rb
@@ -29,7 +29,7 @@ module Mail
         super(exact || key_name)
       else # Dealing with a multiple value pair or a single encoded value pair
         string = pairs.sort { |a,b| a.first.to_s <=> b.first.to_s }.map { |v| v.last }.join('')
-        if mt = string.match(/([\w\d\-]+)'(\w\w)'(.*)/)
+        if mt = string.match(/([\w\-]+)'(\w\w)'(.*)/)
           string = mt[3]
           encoding = mt[1]
         else

--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -125,8 +125,8 @@ module Mail
       end
       
       response = nil
-      smtp.start(settings[:domain], settings[:user_name], settings[:password], settings[:authentication]) do |smtp|
-        response = smtp.sendmail(message, envelope_from, destinations)
+      smtp.start(settings[:domain], settings[:user_name], settings[:password], settings[:authentication]) do |simple_mail|
+        response = simple_mail.sendmail(message, envelope_from, destinations)
       end
 
       return settings[:return_response] ? response : self

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -315,12 +315,13 @@ describe "Utilities Module" do
   end
 
   describe "url escaping" do
+    uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
+
     it "should have a wrapper on URI.escape" do
-      uri_escape("@?@!").should == URI.escape("@?@!")
+      uri_escape("@?@!").should == uri_parser.escape("@?@!")
     end
 
     it "should have a wrapper on URI.unescape" do
-      uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
       uri_unescape("@?@!").should == uri_parser.unescape("@?@!")
     end
   end


### PR DESCRIPTION
- 'warning: shadowing outer local variable - smtp' in 1.9.2
- 'warning: character class has duplicated range' under 1.9.2
- Fixed final occurrence of 'warning: URI.escape is obsolete' in specs under 1.9.2

All tests pass under 1.9.2. 1.8.7 has 4 _unrelated_ failures. I believe those failures are addressed by [247](https://github.com/mikel/mail/pull/247)
