### PR TITLE
Fixed Regexp warning: character class has duplicated range

### DIFF
--- a/lib/mail/fields/common/parameter_hash.rb
+++ b/lib/mail/fields/common/parameter_hash.rb
@@ -29,7 +29,7 @@ module Mail
         super(exact || key_name)
       else # Dealing with a multiple value pair or a single encoded value pair
         string = pairs.sort { |a,b| a.first.to_s <=> b.first.to_s }.map { |v| v.last }.join('')
-        if mt = string.match(/([\w\d\-]+)'(\w\w)'(.*)/)
+        if mt = string.match(/([\w\-]+)'(\w\w)'(.*)/)
           string = mt[3]
           encoding = mt[1]
         else


### PR DESCRIPTION
Removed redundant `\d` from regex character class that already has `\w`, to prevent the following warning in ruby 1.9.2p180:

```
mail/lib/mail/fields/common/parameter_hash.rb:32:
  warning: character class has duplicated range: /([\w\d\-]+)'(\w\w)'(.*)/
```
