### PR TITLE
Handle multipart mail in Mail::Message#to_yaml / #from_yaml

### DIFF
--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -172,6 +172,14 @@ describe Mail::Message do
         deserialized = Mail::Message.from_yaml(yaml_hash.to_yaml)
         deserialized.delivery_handler.should be_nil
       end
+
+      it "should handle multipart mail" do
+        @yaml_mail.add_part Mail::Part.new(:content_type => 'text/html', :body => '<b>body</b>')
+        deserialized = Mail::Message.from_yaml(@yaml_mail.to_yaml)
+        deserialized.should be_multipart
+        deserialized.parts.each {|part| part.should be_a(Mail::Part)}
+        deserialized.parts.map(&:body).should == ['body', '<b>body</b>']
+      end
     end
   end
 


### PR DESCRIPTION
I've added code to recursively call to_yaml on mail.body.parts if the mail is multipart.

I've assumed mail.parts are all a kind of Mail::Part, is this correct?
