### PR TITLE
define String#blank? only if not defined yet

### DIFF
--- a/lib/mail/core_extensions/string.rb
+++ b/lib/mail/core_extensions/string.rb
@@ -8,8 +8,10 @@ class String #:nodoc:
     gsub(/\n|\r\n|\r/) { "\n" }
   end
 
-  def blank?
-    self !~ /\S/
+  unless String.instance_methods(false).map {|m| m.to_sym}.include?(:blank?)
+    def blank?
+      self !~ /\S/
+    end
   end
 
   unless method_defined?(:ascii_only?)


### PR DESCRIPTION
ActiveSupport's `String#blank?` has been a little bit extended in recent commits https://github.com/rails/rails/blob/64268c5dd1f908aceaecea1a5c61314dd2f2efc3/activesupport/lib/active_support/core_ext/object/blank.rb#L102-110

This commit adds a check whether `String#blank?` is already defined on not to prevent overwriting ActiveSupport's `String#blank?`
