### PR TITLE
Speed up reading of messages by about 12x

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -267,7 +267,7 @@ module Mail
     end
     
     def only_us_ascii?
-      ! raw_source =~ /[^\x01-\x7f]/
+      !(raw_source =~ /[^\x01-\x7f]/)
     end
     
     def empty?


### PR DESCRIPTION
I wrote a quickie to read an email and display its structure, and tested it on a 5MB email.  Unchanged, it took about 10s. This small change brought that down to <0.9s.

If some variation of this change has already been considered and turned down, please let me know why.

The program I used:

https://gist.github.com/1136344
