### PR TITLE
Use M as the pack string instead of *M

### DIFF
--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -565,14 +565,14 @@ describe Mail::Encodings do
   describe "quoted printable encoding and decoding" do
     it "should handle underscores in the text" do
       expected = 'something_with_underscores'
-      encoded = [expected].pack('*M')
-      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("*M").first.should == expected
+      encoded = [expected].pack('M')
+      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("M").first.should == expected
     end
 
     it "should handle underscores in the text" do
       expected = 'something with_underscores'
-      encoded = [expected].pack('*M')
-      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("*M").first.should == expected
+      encoded = [expected].pack('M')
+      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("M").first.should == expected
     end
 
     it "should keep the underscores in the text" do


### PR DESCRIPTION
The \* is ignored anyway and doesn't have any meaning. This also
fixes the build on Travis for Rubinius, since Rubinius raises on
this string.
