### PR TITLE
Adds Mail::Message#without_attachments! that removes all message's attachments (issue #33)

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1711,6 +1711,21 @@ module Mail
       buffer
     end
 
+    def without_attachments!
+      return self unless has_attachments?
+
+      parts.delete_if { |p| p.attachment? }
+      body_raw = if parts.empty?
+                   ''
+                 else
+                   body.encoded
+                 end
+
+      @body = Mail::Body.new(body_raw)
+
+      self
+    end
+
     def to_yaml(opts = {})
       hash = {}
       hash['headers'] = {}

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1533,6 +1533,24 @@ describe Mail::Message do
 
   end
 
+  describe "without_attachments!" do
+    it "should delete all attachments" do
+      emails_with_attachments = ['content_disposition', 'content_location',
+                                 'pdf', 'with_encoded_name', 'with_quoted_filename']
+
+      emails_with_attachments.each { |email|
+        mail = Mail.read(fixture(File.join('emails', 'attachment_emails', "attachment_#{email}.eml")))
+        mail_length_with_attachments = mail.to_s.length
+        mail.has_attachments?.should be_true
+        mail.without_attachments!
+
+        mail_length_without_attachments = mail.to_s.length
+        mail_length_without_attachments.should < mail_length_with_attachments
+        mail.has_attachments?.should be_false
+      }
+    end
+  end
+
   describe "replying" do
 
     describe "to a basic message" do


### PR DESCRIPTION
Hi,

I've implemented a method #without_attachments! that requires less memory than the solution proposed by ledermann in issue #33. I'm working on creating a #without_attachments that's not destructive, simply returning a new instance with the attachments removed, but haven't had success so far.

The only problem with this implementation, AFAIK, is that it doesn't works for RFC822 emails. I couldn't find out how to remove only te attachment from its body. Any ideas?

Thanks,
Vítor Baptista.
