### PR TITLE
use to_str before gsubing on a string

### DIFF
--- a/lib/mail/core_extensions/string.rb
+++ b/lib/mail/core_extensions/string.rb
@@ -1,11 +1,11 @@
 # encoding: utf-8
 class String #:nodoc:
   def to_crlf
-    gsub(/\n|\r\n|\r/) { "\r\n" }
+    to_str.gsub(/\n|\r\n|\r/) { "\r\n" }
   end
 
   def to_lf
-    gsub(/\n|\r\n|\r/) { "\n" }
+    to_str.gsub(/\n|\r\n|\r/) { "\n" }
   end
 
   def blank?


### PR DESCRIPTION
gsub on safe strings poses problems because $x variables are local, therefore they're not available in the safe strings gsubs.
See https://github.com/rails/rails/issues/1555

Therefore, gsub on safe strings is going to be disable on rails.  
As mail uses it, it breaks tests on rails. This PR fixes the problem.
