### PR TITLE
Per RFC 2822, emails should not contain consecutive dots. Resolves part of #279.

### DIFF
--- a/lib/mail/parsers/rfc2822.treetop
+++ b/lib/mail/parsers/rfc2822.treetop
@@ -110,7 +110,7 @@ module Mail
     end
     
     rule local_dot_atom_text
-      ("."* domain_text)+
+      ("."? domain_text)+
     end
     
     rule domain_text

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -246,18 +246,10 @@ describe Mail::Address do
                                          :raw          => 'Minero Aoki<aamine@0246.loveruby.net>'})
       end
 
-      it "should handle lots of dots" do
-        1.upto(10) do |times|
+      it "should reject multiple dots" do
+        2.upto(10) do |times|
           dots    = "." * times
-          address = Mail::Address.new("hoge#{dots}test@docomo.ne.jp")
-          address.should break_down_to({
-                                           :display_name => nil,
-                                           :address      => "hoge#{dots}test@docomo.ne.jp",
-                                           :local        => "hoge#{dots}test",
-                                           :domain       => 'docomo.ne.jp',
-                                           :format       => "hoge#{dots}test@docomo.ne.jp",
-                                           :comments     => nil,
-                                           :raw          => "hoge#{dots}test@docomo.ne.jp"})
+          doing { Mail::Address.new("hoge#{dots}test@docomo.ne.jp") }.should raise_error
         end
       end
 


### PR DESCRIPTION
Emails should not contain consecutive dots. I have updated the treetrop grammar and fixed the spec.

Cheers,

Poet
