### PR TITLE
Mail::Field#== comparison returns true for non-equal fields

### DIFF
--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -113,6 +113,8 @@ module Mail
       match_to_s(other.name, field.name)
     end
     
+    alias_method :==, :same
+    
     def <=>( other )
       self_order = FIELD_ORDER.rindex(self.name.to_s.downcase) || 100
       other_order = FIELD_ORDER.rindex(other.name.to_s.downcase) || 100

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -155,7 +155,16 @@ describe Mail::Field do
       list = [Mail::Field.new("To: mikel"), Mail::Field.new("Return-Path: bob")]
       list.sort[0].name.should == "Return-Path"
     end
+  end
 
+  describe 'user defined fields' do
+    it "should say it is == to another if their field names match" do
+      Mail::Field.new("X-Foo: mikel").same(Mail::Field.new("X-Foo: bob")).should be_true
+    end
+
+    it "should say it is not == to another if their field names do not match" do
+      Mail::Field.new("X-Foo: mikel").should_not == Mail::Field.new("X-Bar: bob")
+    end
   end
 
   describe "passing an encoding" do

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -342,6 +342,14 @@ describe Mail::Header do
       header.fields.length.should == 0
     end
     
+    it "should delete only matching fields found" do
+      header = Mail::Header.new
+      header.fields = ['X-SPAM: 1000', 'X-AUTHOR: Steve']
+      header['X-SPAM'] = nil
+      header['X-AUTHOR'].should_not be_nil
+      header.fields.length.should == 1
+    end
+    
     # Handle empty X-Optional header from Microsoft Exchange
     it "should handle an empty X-* header value" do
       header = Mail::Header.new("X-MS-TNEF-Correlator:\r\n")


### PR DESCRIPTION
Currently, the #== is included in Mail::Field via Comparable.  This means that the #== operator uses #<=> to check equality.  This doesn't work because equality in #<=> is based on the Field#name position in FIELD_ORDER, rather than actual equality of names.

This causes problems when any custom fields are used that are not in FIELD_ORDER.  This created problems when I tried deleting a field with 

```
header['X-Field'] = nil
```

Due to all custom fields coming back as equal, ALL custom fields are removed, not just _X-Field_.
