### PR TITLE
removed 'destinations' from commandline sendmail call fixes #70

### DIFF
--- a/lib/mail/network/delivery_methods/sendmail.rb
+++ b/lib/mail/network/delivery_methods/sendmail.rb
@@ -49,11 +49,11 @@ module Mail
 
       arguments = [settings[:arguments], return_path].compact.join(" ")
 
-      Sendmail.call(settings[:location], arguments, mail.destinations.collect(&:shellescape).join(" "), mail)
+      Sendmail.call(settings[:location], arguments, mail)
     end
 
-    def Sendmail.call(path, arguments, destinations, mail)
-      IO.popen("#{path} #{arguments} #{destinations}", "w+") do |io|
+    def Sendmail.call(path, arguments, mail)
+      IO.popen("#{path} #{arguments}", "w+") do |io|
         io.puts mail.encoded.to_lf
         io.flush
       end


### PR DESCRIPTION
This pull request fixes issue 70 where the default sendmail settings do not work.

When adding the -t option exim removes addresses sent on the commandline from addresses it will send to. Some other forms of sendmail add them. Since mail produces all the required recipients in the mail blob, as long as -t is there, it should go to all recipients, and we want the addresses we're currently specifying on the commandline neither added nor removed, so I removed the recipients from the commandline call to the sendmail binary.
