### PR TITLE
Allow quoted display name in address to end with a non-usascii part.

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -181,7 +181,7 @@ module Mail
       return address if address.ascii_only? or charset.nil?
       us_ascii = %Q{\x00-\x7f}
       # Encode any non usascii strings embedded inside of quotes
-      address.gsub!(/(".*?[^#{us_ascii}].+?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
+      address.gsub!(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
       # Then loop through all remaining items and encode as needed
       tokens = address.split(/\s/)
       map_with_index(tokens) do |word, i|

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -623,6 +623,12 @@ describe Mail::Encodings do
       Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
     end
 
+    it "should encode a quoted display name with us-ascii and non-usascii that ends with a non-usascii part" do
+      raw     = '"Marc André" <marc@test.lindsaar.net>'
+      encoded = '=?UTF-8?B?TWFyYyBBbmRyw6k=?= <marc@test.lindsaar.net>'
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+    end
+
     it "should encode multiple addresses correctly" do
       raw     = '"Mikel Lindsああr" <mikel@test.lindsaar.net>, "あdあ" <ada@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'


### PR DESCRIPTION
Right now the address:

`"Marc André" <marc@test.lindsaar.net>`

comes out in the header as:

`=?UTF8?Q?=22Marc_Andr=C3=A9=22_<marc@test.lindsaar.net>?=`

This fixes it so it comes out correctly as:

`=?UTF-8?B?TWFyYyBBbmRyw6k=?= <marc@test.lindsaar.net>`

I would have liked to write a spec expressing just this, but I could not find the right place for it.
