### PR TITLE
Encoding non-latin names in addresses fails when quoted name ends in non-latin character

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -181,7 +181,7 @@ module Mail
       return address if address.ascii_only? or charset.nil?
       us_ascii = %Q{\x00-\x7f}
       # Encode any non usascii strings embedded inside of quotes
-      address.gsub!(/(".*?[^#{us_ascii}].+?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
+      address.gsub!(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
       # Then loop through all remaining items and encode as needed
       tokens = address.split(/\s/)
       map_with_index(tokens) do |word, i|

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -640,7 +640,12 @@ describe Mail::Encodings do
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= test1@lindsaar.net, group: =?UTF-8?B?44GCZOOBgg==?= test2@lindsaar.net, me@lindsaar.net;'
       Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
     end
-    
+
+    it "should correctly match and encode non-usascii letters at the end of a quoted string" do
+      raw = '"Felix Baarß" <test@example.com>'
+      encoded = '=?UTF-8?B?RmVsaXggQmFhcsOf?= <test@example.com>'
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+    end
   end
 
   describe "address encoding" do


### PR DESCRIPTION
This patch fixes a problem where code like the following:

  mail.to = '"Johann Baarß" johann@example.com'

Would result in a syntactically incorrect "To" header. The problem is that the regex that matches the non-latin characters in Encodings.encode_non_usascii would not match non-latin characters immediately before the closing quote. This patch corrects the regex so that these characters are matched correctly.

There were two tests failing in master before I made this change. The same two tests are still failing after the patch; all others are green, including the test I added.
