### PR TITLE
Fix warning: useless use of == in void context

### DIFF
--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -8,9 +8,9 @@ end
 
 def check_decoded(actual, expected)
   if RUBY_VERSION >= '1.9'
-    actual.should == expected.force_encoding(Encoding::BINARY)
+    actual.should eql expected.force_encoding(Encoding::BINARY)
   else
-    actual.should == expected
+    actual.should eql expected
   end
 end
 
@@ -24,27 +24,27 @@ describe "Attachments" do
     it "should work" do
       file_data = File.read(filename = fixture('attachments', 'test.png'))
       @mail.attachments['test.png'] = File.read(fixture('attachments', 'test.png'))
-      @mail.attachments['test.png'].filename.should == 'test.png'
+      @mail.attachments['test.png'].filename.should eql 'test.png'
       check_decoded(@mail.attachments[0].decoded, file_data)
     end
 
     it "should work out magically the mime_type" do
       file_data = File.read(filename = fixture('attachments', 'test.png'))
       @mail.attachments['test.png'] = File.read(fixture('attachments', 'test.png'))
-      @mail.attachments[0].mime_type.should == 'image/png'
+      @mail.attachments[0].mime_type.should eql 'image/png'
     end
 
     it "should assign the filename" do
       file_data = File.read(filename = fixture('attachments', 'test.png'))
       @mail.attachments['test.png'] = file_data
-      @mail.attachments[0].filename.should == 'test.png'
+      @mail.attachments[0].filename.should eql 'test.png'
     end
 
     it "should assign mime-encoded multibyte filename" do
       file_data = File.read(filename = fixture('attachments', 'てすと.txt'))
       @mail.attachments['てすと.txt'] = file_data
       @mail.attachments.should_not be_blank
-      Mail::Encodings.decode_encode(@mail.attachments[0].filename, :decode).should == 'てすと.txt'
+      Mail::Encodings.decode_encode(@mail.attachments[0].filename, :decode).should eql 'てすと.txt'
     end
   end
 
@@ -52,7 +52,7 @@ describe "Attachments" do
     it "should work" do
       file_data = File.read(filename = fixture('attachments', 'test.png'))
       @mail.attachments['test.png'] = { :content => file_data }
-      @mail.attachments[0].filename.should == 'test.png'
+      @mail.attachments[0].filename.should eql 'test.png'
       check_decoded(@mail.attachments[0].decoded, file_data)
     end
 
@@ -60,14 +60,14 @@ describe "Attachments" do
       file_data = File.read(filename = fixture('attachments', 'test.png'))
       @mail.attachments['test.png'] = { :content => file_data,
                                         :content_type => "application/x-gzip" }
-      @mail.attachments[0].content_type.should == 'application/x-gzip'
+      @mail.attachments[0].content_type.should eql 'application/x-gzip'
     end
 
     it "should allow you to override the mime_type" do
       file_data = File.read(filename = fixture('attachments', 'test.png'))
       @mail.attachments['test.png'] = { :content => file_data,
                                         :mime_type => "application/x-gzip" }
-      @mail.attachments[0].mime_type.should == 'application/x-gzip'
+      @mail.attachments[0].mime_type.should eql 'application/x-gzip'
     end
 
     it "should allow you to override the mime_type" do
@@ -75,7 +75,7 @@ describe "Attachments" do
       @mail.attachments['invoice.jpg'] = { :data => "you smiling",
                                            :mime_type => "image/x-jpg",
                                            :transfer_encoding => "base64" }
-      @mail.attachments[0].mime_type.should == 'image/x-jpg'
+      @mail.attachments[0].mime_type.should eql 'image/x-jpg'
     end
 
   end
@@ -86,7 +86,7 @@ describe "Attachments" do
       file_data = File.read(filename = fixture('attachments', 'test.png'))
       @mail.attachments['test.png'] = { :content => file_data }
       @mail.ready_to_send!
-      @mail.attachments[0].content_transfer_encoding.should == 'base64'
+      @mail.attachments[0].content_transfer_encoding.should eql 'base64'
     end
 
     it "should encode it's body to base64" do
@@ -119,7 +119,7 @@ describe "Attachments" do
       else
         expected = @mail.attachments[0].read
       end
-      expected.should == file_data
+      expected.should eql file_data
     end
 
   end
@@ -132,10 +132,10 @@ describe "Attachments" do
       mail.attachments['test.gif'] = File.read(fixture('attachments', 'test.gif'))
       mail.attachments['test.jpg'] = File.read(fixture('attachments', 'test.jpg'))
       mail.attachments['test.zip'] = File.read(fixture('attachments', 'test.zip'))
-      mail.attachments[0].filename.should == 'test.pdf'
-      mail.attachments[1].filename.should == 'test.gif'
-      mail.attachments[2].filename.should == 'test.jpg'
-      mail.attachments[3].filename.should == 'test.zip'
+      mail.attachments[0].filename.should eql 'test.pdf'
+      mail.attachments[1].filename.should eql 'test.gif'
+      mail.attachments[2].filename.should eql 'test.jpg'
+      mail.attachments[3].filename.should eql 'test.zip'
     end
 
   end
@@ -145,15 +145,15 @@ describe "Attachments" do
     it "should set the content_disposition to inline or attachment as appropriate" do
       mail = Mail.new
       mail.attachments['test.pdf'] = File.read(fixture('attachments', 'test.pdf'))
-      mail.attachments['test.pdf'].content_disposition.should == 'attachment; filename=test.pdf'
+      mail.attachments['test.pdf'].content_disposition.should eql 'attachment; filename=test.pdf'
       mail.attachments.inline['test.png'] = File.read(fixture('attachments', 'test.png'))
-      mail.attachments.inline['test.png'].content_disposition.should == 'inline; filename=test.png'
+      mail.attachments.inline['test.png'].content_disposition.should eql 'inline; filename=test.png'
     end
 
     it "should return a cid" do
       mail = Mail.new
       mail.attachments.inline['test.png'] = File.read(fixture('attachments', 'test.png'))
-      mail.attachments['test.png'].url.should == "cid:#{mail.attachments['test.png'].cid}"
+      mail.attachments['test.png'].url.should eql "cid:#{mail.attachments['test.png'].cid}"
     end
 
     it "should respond true to inline?" do
@@ -181,7 +181,7 @@ describe "Attachments" do
     it "should provide a URL escaped content_id (without brackets) for use inside an email" do
       @inline = @mail.attachments['test.gif'].cid
       uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
-      @inline.should == uri_parser.escape(@cid.gsub(/^</, '').gsub(/>$/, ''))
+      @inline.should eql uri_parser.escape(@cid.gsub(/^</, '').gsub(/>$/, ''))
     end
   end
 
@@ -190,7 +190,7 @@ describe "Attachments" do
       mail = Mail.new
       mail.attachments['test.pdf'] = File.read(fixture('attachments', 'test.pdf'))
       mail.encoded
-      mail.mime_type.should == 'multipart/mixed'
+      mail.mime_type.should eql 'multipart/mixed'
     end
   end
 
@@ -201,42 +201,42 @@ describe "reading emails with attachments" do
 
     it "should find the attachment using content location" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_content_location.eml')))
-      mail.attachments.length.should == 1
+      mail.attachments.length.should eql 1
     end
 
     it "should find an attachment defined with 'name' and Content-Disposition: attachment" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_content_disposition.eml')))
-      mail.attachments.length.should == 1
+      mail.attachments.length.should eql 1
     end
 
     it "should use the content-type filename or name over the content-disposition filename" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_content_disposition.eml')))
-      mail.attachments[0].filename.should == 'hello.rb'
+      mail.attachments[0].filename.should eql 'hello.rb'
     end
 
     it "should decode an attachment" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_pdf.eml')))
-      mail.attachments[0].decoded.length.should == 1026
+      mail.attachments[0].decoded.length.should eql 1026
     end
 
     it "should find an attachment that has an encoded name value" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_with_encoded_name.eml')))
-      mail.attachments.length.should == 1
+      mail.attachments.length.should eql 1
       result = mail.attachments[0].filename
       if RUBY_VERSION >= '1.9'
         expected = "01 Quien Te Dij\212at. Pitbull.mp3".force_encoding(result.encoding)
       else
         expected = "01 Quien Te Dij\212at. Pitbull.mp3"
       end
-      result.should == expected
+      result.should eql expected
     end
 
     it "should find attachments inside parts with content-type message/rfc822" do
       mail = Mail.read(fixture(File.join("emails",
                                          "attachment_emails",
                                          "attachment_message_rfc822.eml")))
-      mail.attachments.length.should == 1
-      mail.attachments[0].decoded.length.should == 1026
+      mail.attachments.length.should eql 1
+      mail.attachments[0].decoded.length.should eql 1026
     end
 
     it "attach filename decoding (issue 83)" do
@@ -271,7 +271,7 @@ YWFhCg==
 limitMAIL
       mail = Mail.new(data)
       #~ puts Mail::Encodings.decode_encode(mail.attachments[0].filename, :decode)
-      mail.attachments[0].filename.should == "Foto0009.jpg"
+      mail.attachments[0].filename.should eql "Foto0009.jpg"
     end
 
   end
@@ -294,16 +294,16 @@ describe "attachment order" do
     mail.attachments['test.pdf'] = File.read(fixture('attachments', 'test.pdf'))
     mail.attachments['test.gif'] = File.read(fixture('attachments', 'test.gif'))
     mail.attachments['test.jpg'] = File.read(fixture('attachments', 'test.jpg'))
-    mail.attachments[0].filename.should == 'test.zip'
-    mail.attachments[1].filename.should == 'test.pdf'
-    mail.attachments[2].filename.should == 'test.gif'
-    mail.attachments[3].filename.should == 'test.jpg'
+    mail.attachments[0].filename.should eql 'test.zip'
+    mail.attachments[1].filename.should eql 'test.pdf'
+    mail.attachments[2].filename.should eql 'test.gif'
+    mail.attachments[3].filename.should eql 'test.jpg'
 
 
     mail2 = Mail.new(mail.encoded)
-    mail2.attachments[0].filename.should == 'test.zip'
-    mail2.attachments[1].filename.should == 'test.pdf'
-    mail2.attachments[2].filename.should == 'test.gif'
-    mail2.attachments[3].filename.should == 'test.jpg'
+    mail2.attachments[0].filename.should eql 'test.zip'
+    mail2.attachments[1].filename.should eql 'test.pdf'
+    mail2.attachments[2].filename.should eql 'test.gif'
+    mail2.attachments[3].filename.should eql 'test.jpg'
   end
 end

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -35,12 +35,12 @@ describe Mail::Body do
     
     it "should accept text as raw source data" do
       body = Mail::Body.new('this is some text')
-      body.to_s.should == 'this is some text'
+      body.to_s.should eql 'this is some text'
     end
     
     it "should accept nil as a value and return an empty body" do
       body = Mail::Body.new
-      body.to_s.should == ''
+      body.to_s.should eql ''
     end
 
     it "should accept an array as the body and join it" do
@@ -49,7 +49,7 @@ describe Mail::Body do
 
     it "should accept an array as the body and join it" do
       body = Mail::Body.new(["line one\n", "line two\n"])
-      body.encoded.should == "line one\r\nline two\r\n"
+      body.encoded.should eql "line one\r\nline two\r\n"
     end
 
   end
@@ -58,29 +58,29 @@ describe Mail::Body do
 
     it "should accept text as raw source data" do
       body = Mail::Body.new('this is some text')
-      body.encoded.should == 'this is some text'
+      body.encoded.should eql 'this is some text'
     end
     
     it "should set it's own encoding to us_ascii if it is ascii only body" do
       body = Mail::Body.new('This is some text')
-      body.charset.should == 'US-ASCII'
+      body.charset.should eql 'US-ASCII'
     end
     
     it "should allow you to set it's encoding" do
       body = Mail::Body.new('')
       body.charset = 'UTF-8'
-      body.charset.should == 'UTF-8'
+      body.charset.should eql 'UTF-8'
     end
 
     it "should allow you to specify an encoding" do
       body = Mail::Body.new('')
       body.encoding = 'base64'
-      body.encoding.should == 'base64'
+      body.encoding.should eql 'base64'
     end
     
     it "should convert all new lines to crlf" do
       body = Mail::Body.new("This has \n various \r new \r\n lines")
-      body.encoded.should == "This has \r\n various \r\n new \r\n lines"
+      body.encoded.should eql "This has \r\n various \r\n new \r\n lines"
     end
 
   end
@@ -89,30 +89,30 @@ describe Mail::Body do
     
     it "should convert all new lines to crlf" do
       body = Mail::Body.new("This has \n various \r new \r\n lines")
-      body.decoded.should == "This has \n various \n new \n lines"
+      body.decoded.should eql "This has \n various \n new \n lines"
     end
     
     it "should not change a body on decode if not given an encoding type to decode" do
       body = Mail::Body.new("The=3Dbody")
-      body.decoded.should == "The=3Dbody"
+      body.decoded.should eql "The=3Dbody"
     end
 
     it "should change return the raw text if it does not recognise the encoding" do
       body = Mail::Body.new("The=3Dbody")
       body.encoding = '7bit'
-      body.decoded.should == "The=3Dbody"
+      body.decoded.should eql "The=3Dbody"
     end
 
     it "should change a body on decode if given an encoding type to decode" do
       body = Mail::Body.new("The=3Dbody")
       body.encoding = 'quoted-printable'
-      body.decoded.should == "The=body"
+      body.decoded.should eql "The=body"
     end
 
     it "should change a body on decode if given an encoding type to decode" do
       body = Mail::Body.new("VGhlIGJvZHk=\n")
       body.encoding = 'base64'
-      body.decoded.should == "The body"
+      body.decoded.should eql "The body"
     end
 
   end
@@ -123,42 +123,42 @@ describe Mail::Body do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\nn------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.boundary.should == '----=_Part_2192_32400445'
+      body.boundary.should eql '----=_Part_2192_32400445'
     end
 
     it "should split at the boundry string given returning two message bodies" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\nn------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
-      body.split!('----=_Part_2192_32400445').parts.length.should == 2
+      body.split!('----=_Part_2192_32400445').parts.length.should eql 2
     end
 
     it "should keep the preamble text as it's own preamble" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\nn------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.preamble.should == "this is some text"
+      body.preamble.should eql "this is some text"
     end
     
     it "should return the parts as their own messages" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\nn------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.parts[0].class.should == Mail::Part
-      body.parts[1].class.should == Mail::Part
+      body.parts[0].class.should eql Mail::Part
+      body.parts[1].class.should eql Mail::Part
     end
     
     it "should return the first part as it's own message" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\nn------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.parts[0].content_type.should == "text/plain; charset=ISO-8859-1"
+      body.parts[0].content_type.should eql "text/plain; charset=ISO-8859-1"
     end
     
     it "should return the first part as it's own message" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\nn------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.parts[1].content_type.should == "text/html"
+      body.parts[1].content_type.should eql "text/html"
     end
 
     it "should separate out it's parts" do
@@ -172,7 +172,7 @@ describe Mail::Body do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\nn------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.parts.length.should == 2
+      body.parts.length.should eql 2
     end
 
     it "should round trip it's parts" do
@@ -183,9 +183,9 @@ describe Mail::Body do
       body.epilogue = "And this is the end"
       new_body = Mail::Body.new(body.encoded)
       new_body.split!('----=_Part_2192_32400445')
-      new_body.parts.length.should == 2
-      new_body.preamble.should == "Really! this is some text"
-      new_body.epilogue.should == "And this is the end"
+      new_body.parts.length.should eql 2
+      new_body.preamble.should eql "Really! this is some text"
+      new_body.epilogue.should eql "And this is the end"
     end
 
     it "should allow you to change the boundary" do
@@ -195,8 +195,8 @@ describe Mail::Body do
       body.boundary = '------=_MIMEPART'
       new_body = Mail::Body.new(body.encoded)
       new_body.split!('------=_MIMEPART')
-      new_body.parts.length.should == 2
-      new_body.preamble.should == "this is some text"
+      new_body.parts.length.should eql 2
+      new_body.preamble.should eql "this is some text"
     end
 
   end
@@ -222,7 +222,7 @@ describe Mail::Body do
     it "should allow you to add a part" do
       body = Mail::Body.new('')
       body << Mail::Part.new('')
-      body.parts.length.should == 1
+      body.parts.length.should eql 1
       body.should be_multipart
     end
 
@@ -231,12 +231,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/html\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched")
-      body.parts.length.should == 3
+      body.parts.length.should eql 3
       body.should be_multipart
       body.sort_parts!
-      body.parts[0].content_type.should == "text/plain"
-      body.parts[1].content_type.should == "text/enriched"
-      body.parts[2].content_type.should == "text/html"
+      body.parts[0].content_type.should eql "text/plain"
+      body.parts[1].content_type.should eql "text/enriched"
+      body.parts[2].content_type.should eql "text/html"
     end
     
     it "should allow you to sort the parts with an arbitrary sort order" do
@@ -245,12 +245,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/html\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched")
-      body.parts.length.should == 3
+      body.parts.length.should eql 3
       body.should be_multipart
       body.sort_parts!
-      body.parts[0].content_type.should == "text/plain"
-      body.parts[1].content_type.should == "text/html"
-      body.parts[2].content_type.should == "text/enriched"
+      body.parts[0].content_type.should eql "text/plain"
+      body.parts[1].content_type.should eql "text/html"
+      body.parts[2].content_type.should eql "text/enriched"
     end
     
     it "should allow you to sort the parts with an arbitrary sort order" do
@@ -259,12 +259,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/plain\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/html\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: application/x-yaml\r\nsubject: Enriched")
-      body.parts.length.should == 3
+      body.parts.length.should eql 3
       body.should be_multipart
       body.sort_parts!
-      body.parts[0].content_type.should == "application/x-yaml"
-      body.parts[1].content_type.should == "text/plain"
-      body.parts[2].content_type.should == "text/html"
+      body.parts[0].content_type.should eql "application/x-yaml"
+      body.parts[1].content_type.should eql "text/plain"
+      body.parts[2].content_type.should eql "text/html"
     end
     
     it "should sort the parts on encode" do
@@ -272,12 +272,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/html\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched")
-      body.parts.length.should == 3
+      body.parts.length.should eql 3
       body.should be_multipart
       body.encoded
-      body.parts[0].content_type.should == "text/plain"
-      body.parts[1].content_type.should == "text/enriched"
-      body.parts[2].content_type.should == "text/html"
+      body.parts[0].content_type.should eql "text/plain"
+      body.parts[1].content_type.should eql "text/enriched"
+      body.parts[2].content_type.should eql "text/html"
     end
     
     it "should put the part types it doesn't know about at the end" do
@@ -285,12 +285,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/html\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: image/jpeg\r\n")
-      body.parts.length.should == 3
+      body.parts.length.should eql 3
       body.should be_multipart
       body.encoded
-      body.parts[0].content_type.should == "text/plain"
-      body.parts[1].content_type.should == "text/html"
-      body.parts[2].content_type.should == "image/jpeg"
+      body.parts[0].content_type.should eql "text/plain"
+      body.parts[1].content_type.should eql "text/html"
+      body.parts[2].content_type.should eql "image/jpeg"
     end
     
     it "should allow you to sort the parts recursively" do
@@ -301,14 +301,14 @@ describe Mail::Body do
       body = Mail::Body.new('')
       body << part
       body << Mail::Part.new("content-type: image/jpeg\r\nsubject: JPGEG\r\n\r\nsdkjskjdksjdkjsd")
-      body.parts.length.should == 2
+      body.parts.length.should eql 2
       body.should be_multipart
       body.sort_parts!
       body.parts[0].content_type.should match %r{\Amultipart/alternate(;|\Z)} 
-      body.parts[1].content_type.should == "image/jpeg"
-      body.parts[0].parts[0].content_type.should == "text/plain"
-      body.parts[0].parts[1].content_type.should == "text/enriched"
-      body.parts[0].parts[2].content_type.should == "text/html"
+      body.parts[1].content_type.should eql "image/jpeg"
+      body.parts[0].parts[0].content_type.should eql "text/plain"
+      body.parts[0].parts[1].content_type.should eql "text/enriched"
+      body.parts[0].parts[2].content_type.should eql "text/html"
     end
     
     it "should allow you to sort the parts recursively" do
@@ -319,14 +319,14 @@ describe Mail::Body do
       body = Mail::Body.new('')
       body << part
       body << Mail::Part.new("content-type: image/jpeg\r\nsubject: JPGEG\r\n\r\nsdkjskjdksjdkjsd")
-      body.parts.length.should == 2
+      body.parts.length.should eql 2
       body.should be_multipart
       body.sort_parts!
       body.parts[0].content_type.should match %r{\Amultipart/alternate(;|\Z)} 
-      body.parts[1].content_type.should == "image/jpeg"
-      body.parts[0].parts[0].content_type.should == "text/plain"
-      body.parts[0].parts[1].content_type.should == "text/enriched"
-      body.parts[0].parts[2].content_type.should == "text/html"
+      body.parts[1].content_type.should eql "image/jpeg"
+      body.parts[0].parts[0].content_type.should eql "text/plain"
+      body.parts[0].parts[1].content_type.should eql "text/enriched"
+      body.parts[0].parts[2].content_type.should eql "text/html"
     end
     
   end
@@ -335,7 +335,7 @@ describe Mail::Body do
 
     it "should still equal itself" do
       body = Mail::Body.new('The body')
-      body.should == body
+      body.should eql body
     end
 
     it "should match on the body part decoded if given a string to ==" do
@@ -351,24 +351,24 @@ describe Mail::Body do
 
     it "should match on the body part decoded if given a string to =~" do
       body = Mail::Body.new('The body')
-      (body =~ /The/).should == 0
+      (body =~ /The/).should eql 0
     end
 
     it "should match on the body part decoded if given a string to ==" do
       body = Mail::Body.new("VGhlIGJvZHk=\n")
       body.encoding = 'base64'
-      (body =~ /The/).should == 0
+      (body =~ /The/).should eql 0
     end
 
     it "should match on the body part decoded if given a string to match" do
       body = Mail::Body.new('The body')
-      (body.match(/The/))[0].should == 'The'
+      (body.match(/The/))[0].should eql 'The'
     end
 
     it "should match on the body part decoded if given a string to match" do
       body = Mail::Body.new("VGhlIGJvZHk=\n")
       body.encoding = 'base64'
-      (body.match(/The/))[0].should == 'The'
+      (body.match(/The/))[0].should eql 'The'
     end
     
     it "should match on the body part decoded if given a string to include?" do
@@ -388,7 +388,7 @@ describe Mail::Body do
       body = Mail::Body.new("あいうえお\n")
       body.charset = 'iso-2022-jp'
       expect = (RUBY_VERSION < '1.9') ? "あいうえお\r\n" : "\e$B$\"$$$&$($*\e(B\r\n"
-      body.encoded.should == expect
+      body.encoded.should eql expect
     end
   end
 end

--- a/spec/mail/configuration_spec.rb
+++ b/spec/mail/configuration_spec.rb
@@ -6,20 +6,20 @@ describe Mail::Configuration do
     
     it "should be available from the Mail.defaults method" do
       Mail.defaults { delivery_method :smtp, { :address => 'some.host' } }
-      Mail.delivery_method.settings[:address].should == 'some.host'
+      Mail.delivery_method.settings[:address].should eql 'some.host'
     end
 
     it "should configure sendmail" do
       Mail.defaults { delivery_method :sendmail, :location => "/usr/bin/sendmail" }
-      Mail.delivery_method.class.should == Mail::Sendmail
-      Mail.delivery_method.settings[:location].should == "/usr/bin/sendmail"
+      Mail.delivery_method.class.should eql Mail::Sendmail
+      Mail.delivery_method.settings[:location].should eql "/usr/bin/sendmail"
     end
     
     it "should configure an open SMTP connection" do
       smtp = Net::SMTP.start('127.0.0.1', 25)
       Mail.defaults { delivery_method :smtp_connection, {:connection => smtp} }
-      Mail.delivery_method.class.should == Mail::SMTPConnection
-      Mail.delivery_method.smtp.should == smtp
+      Mail.delivery_method.class.should eql Mail::SMTPConnection
+      Mail.delivery_method.smtp.should eql smtp
     end
     
   end

--- a/spec/mail/elements/address_list_spec.rb
+++ b/spec/mail/elements/address_list_spec.rb
@@ -28,43 +28,43 @@ describe Mail::AddressList do
       parse_text  = 'test@lindsaar.net'
       result      = 'test@lindsaar.net'
       a = Mail::AddressList.new(parse_text)
-      a.addresses.first.to_s.should == result
+      a.addresses.first.to_s.should eql result
     end
 
     it "should give the addresses passed in" do
       parse_text  = 'test@lindsaar.net, test2@lindsaar.net'
       result      = ['test@lindsaar.net', 'test2@lindsaar.net']
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should == result
+      a.addresses.map {|addr| addr.to_s }.should eql result
     end
 
     it "should preserve the display name" do
       parse_text  = '"Mikel Lindsaar" <mikel@test.lindsaar.net>'
       result      = 'Mikel Lindsaar <mikel@test.lindsaar.net>'
       a = Mail::AddressList.new(parse_text)
-      a.addresses.first.format.should == result
-      a.addresses.first.display_name.should == 'Mikel Lindsaar'
+      a.addresses.first.format.should eql result
+      a.addresses.first.display_name.should eql 'Mikel Lindsaar'
     end
 
     it "should handle and ignore nil addresses" do
       parse_text  = ' , user-example@aol.com, e-s-a-s-2200@app.ar.com'
       result      = ['user-example@aol.com', 'e-s-a-s-2200@app.ar.com']
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should == result
+      a.addresses.map {|addr| addr.to_s }.should eql result
     end
 
     it "should handle truly horrific combinations of commas, spaces, and addresses" do
       parse_text = '  ,, foo@example.com,  ,    ,,, bar@example.com  ,,'
       result = ['foo@example.com', 'bar@example.com']
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should == result
+      a.addresses.map {|addr| addr.to_s }.should eql result
     end
 
     it "should handle folding whitespace" do
       parse_text = "foo@example.com,\r\n\tbar@example.com"
       result = ['foo@example.com', 'bar@example.com']
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should == result
+      a.addresses.map {|addr| addr.to_s }.should eql result
     end
 
     it "should handle malformed folding whitespace" do
@@ -72,7 +72,7 @@ describe Mail::AddressList do
       parse_text = "leads@sg.dc.com,\n\t sag@leads.gs.ry.com,\n\t sn@example-hotmail.com,\n\t e-s-a-g-8718@app.ar.com,\n\t jp@t-exmaple.com,\n\t\n\t cc@c-l-example.com"
       result = %w(leads@sg.dc.com sag@leads.gs.ry.com sn@example-hotmail.com e-s-a-g-8718@app.ar.com jp@t-exmaple.com cc@c-l-example.com)
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should == result
+      a.addresses.map {|addr| addr.to_s }.should eql result
     end
 
   end
@@ -80,57 +80,57 @@ describe Mail::AddressList do
   describe "functionality" do
     it "should give back a list of address nodes" do
       list = Mail::AddressList.new('mikel@me.com, bob@you.com')
-      list.address_nodes.length.should == 2
+      list.address_nodes.length.should eql 2
     end
 
     it "should have each nood a class of SyntaxNode" do
       list = Mail::AddressList.new('mikel@me.com, bob@you.com')
-      list.address_nodes.each { |n| n.class.should == Treetop::Runtime::SyntaxNode }
+      list.address_nodes.each { |n| n.class.should eql Treetop::Runtime::SyntaxNode }
     end
 
     it "should give a block of address nodes with groups" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.address_nodes.length.should == 2
+      list.address_nodes.length.should eql 2
     end
 
     it "should give all the recipients when asked" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.individual_recipients.length.should == 1
+      list.individual_recipients.length.should eql 1
     end
 
     it "should give all the groups when asked" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.group_recipients.length.should == 1
+      list.group_recipients.length.should eql 1
     end
 
     it "should ask the group for all it's addresses" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.group_recipients.first.group_list.addresses.length.should == 2
+      list.group_recipients.first.group_list.addresses.length.should eql 2
     end
 
     it "should give all the addresses when asked" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.addresses.length.should == 3
+      list.addresses.length.should eql 3
     end
     
     it "should handle a really nasty obsolete address list" do
       pending
       psycho_obsolete = "Mary Smith <@machine.tld:mary@example.net>, , jdoe@test   . example"
       list = Mail::AddressList.new(psycho_obsolete)
-      list.addresses.length.should == 2
+      list.addresses.length.should eql 2
     end
     
 
     it "should create an address instance for each address returned" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       list.addresses.each do |address|
-        address.class.should == Mail::Address
+        address.class.should eql Mail::Address
       end
     end
 
     it "should provide a list of group names" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.group_names.should == ["my_group"]
+      list.group_names.should eql ["my_group"]
     end
     
   end

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -12,34 +12,34 @@ describe Mail::Address do
     end
 
     it "should allow us to instantiate an empty address object and call to_s" do
-      Mail::Address.new.to_s.should == ''
+      Mail::Address.new.to_s.should eql ''
     end
 
     it "should allow us to instantiate an empty address object and call format" do
-      Mail::Address.new.format.should == ''
+      Mail::Address.new.format.should eql ''
     end
 
     it "should allow us to instantiate an empty address object and call address" do
       [nil, '', ' '].each do |input|
-        Mail::Address.new(input).address.should == nil
+        Mail::Address.new(input).address.should eql nil
       end
     end
 
     it "should allow us to instantiate an empty address object and call local" do
       [nil, '', ' '].each do |input|
-        Mail::Address.new(input).local.should == nil
+        Mail::Address.new(input).local.should eql nil
       end
     end
 
     it "should allow us to instantiate an empty address object and call domain" do
       [nil, '', ' '].each do |input|
-        Mail::Address.new(input).domain.should == nil
+        Mail::Address.new(input).domain.should eql nil
       end
     end
 
     ['"-Earnings...Notification-" <vodacom.co.rs>', '<56253817>'].each do |spammy_address|
       it "should allow for funky spammy address #{spammy_address}" do
-        Mail::Address.new(spammy_address).address.should == nil
+        Mail::Address.new(spammy_address).address.should eql nil
       end
     end
 
@@ -47,83 +47,83 @@ describe Mail::Address do
     it "should give it's address back on :to_s if there is no display name" do
       parse_text = 'test@lindsaar.net'
       result     = 'test@lindsaar.net'
-      Mail::Address.new(parse_text).to_s.should == 'test@lindsaar.net'
+      Mail::Address.new(parse_text).to_s.should eql 'test@lindsaar.net'
     end
 
     it "should give it's format back on :to_s if there is a display name" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'Mikel Lindsaar <test@lindsaar.net>'
-      Mail::Address.new(parse_text).to_s.should == 'Mikel Lindsaar <test@lindsaar.net>'
+      Mail::Address.new(parse_text).to_s.should eql 'Mikel Lindsaar <test@lindsaar.net>'
     end
 
     it "should give back the display name" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'Mikel Lindsaar'
       a          = Mail::Address.new(parse_text)
-      a.display_name.should == result
+      a.display_name.should eql result
     end
 
     it "should preserve the display name passed in" do
       parse_text = '"Mikel Lindsaar" <mikel@test.lindsaar.net>'
       result     = 'Mikel Lindsaar'
       a          = Mail::Address.new(parse_text)
-      a.display_name.should == result
+      a.display_name.should eql result
     end
 
     it "should preserve the display name passed in with token unsafe chars" do
       parse_text = '"Mikel@@@Lindsaar" <mikel@test.lindsaar.net>'
       result     = 'Mikel@@@Lindsaar'
       a          = Mail::Address.new(parse_text)
-      a.display_name.should == result
+      a.display_name.should eql result
     end
 
     it "should give back the local part" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'test'
       a          = Mail::Address.new(parse_text)
-      a.local.should == result
+      a.local.should eql result
     end
 
     it "should give back the domain" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'lindsaar.net'
       a          = Mail::Address.new(parse_text)
-      a.domain.should == result
+      a.domain.should eql result
     end
 
     it "should give back the formated address" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'Mikel Lindsaar <test@lindsaar.net>'
       a          = Mail::Address.new(parse_text)
-      a.format.should == result
+      a.format.should eql result
     end
 
     it "should handle an address without a domain" do
       parse_text = 'test'
       result     = 'test'
       a          = Mail::Address.new(parse_text)
-      a.address.should == result
+      a.address.should eql result
     end
 
     it "should handle comments" do
       parse_text = "Mikel Lindsaar (author) <test@lindsaar.net>"
       result     = ['author']
       a          = Mail::Address.new(parse_text)
-      a.comments.should == result
+      a.comments.should eql result
     end
 
     it "should handle multiple comments" do
       parse_text = "Mikel (first name) Lindsaar (author) <test@lindsaar.net>"
       result     = ['first name', 'author']
       a          = Mail::Address.new(parse_text)
-      a.comments.should == result
+      a.comments.should eql result
     end
 
     it "should give back the raw value" do
       parse_text = "Mikel (first name) Lindsaar (author) <test@lindsaar.net>"
       result     = "Mikel (first name) Lindsaar (author) <test@lindsaar.net>"
       a          = Mail::Address.new(parse_text)
-      a.raw.should == result
+      a.raw.should eql result
     end
 
   end
@@ -132,27 +132,27 @@ describe Mail::Address do
     it "should allow you to assign an address" do
       a         = Mail::Address.new
       a.address = 'mikel@test.lindsaar.net'
-      a.address.should == 'mikel@test.lindsaar.net'
-      a.format.should == 'mikel@test.lindsaar.net'
+      a.address.should eql 'mikel@test.lindsaar.net'
+      a.format.should eql 'mikel@test.lindsaar.net'
     end
 
     it "should allow you to assign a display name" do
       a              = Mail::Address.new
       a.display_name = 'Mikel Lindsaar'
-      a.display_name.should == 'Mikel Lindsaar'
+      a.display_name.should eql 'Mikel Lindsaar'
     end
 
     it "should return an empty format a display name and no address defined" do
       a              = Mail::Address.new
       a.display_name = 'Mikel Lindsaar'
-      a.format.should == ''
+      a.format.should eql ''
     end
 
     it "should allow you to assign an address and a display name" do
       a              = Mail::Address.new
       a.address      = 'mikel@test.lindsaar.net'
       a.display_name = 'Mikel Lindsaar'
-      a.format.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      a.format.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
   end
 
@@ -167,7 +167,7 @@ describe Mail::Address do
 
         ].each do |(words, ok)|
           a = Mail::Address.new(words)
-          a.local.should == ok
+          a.local.should eql ok
         end
       end
 
@@ -180,7 +180,7 @@ describe Mail::Address do
 
         ].each do |(words, ok)|
           a = Mail::Address.new(%Q|me@#{words}|)
-          a.domain.should == ok
+          a.domain.should eql ok
         end
       end
     end
@@ -577,7 +577,7 @@ describe Mail::Address do
       it "should add a display name" do
         address              = Mail::Address.new
         address.display_name = "Mikel Lindsaar"
-        address.display_name.should == 'Mikel Lindsaar'
+        address.display_name.should eql 'Mikel Lindsaar'
       end
     end
 
@@ -593,21 +593,21 @@ describe Mail::Address do
     it "should add a display name" do
       address              = Mail::Address.new
       address.display_name = "Mikel Lindsaar"
-      address.display_name.should == 'Mikel Lindsaar'
+      address.display_name.should eql 'Mikel Lindsaar'
     end
 
     it "should take an address and a display name and join them" do
       address              = Mail::Address.new
       address.address      = "mikel@test.lindsaar.net"
       address.display_name = "Mikel Lindsaar"
-      address.format.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      address.format.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
     it "should take a display name and an address and join them" do
       address              = Mail::Address.new
       address.display_name = "Mikel Lindsaar"
       address.address      = "mikel@test.lindsaar.net"
-      address.format.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      address.format.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
   end
@@ -617,7 +617,7 @@ describe Mail::Address do
       address              = Mail::Address.new
       address.display_name = "Mikel Lindsaar"
       address.address      = "mikel@test.lindsaar.net"
-      address.encoded.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      address.encoded.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
     it "should provide an encoded output for non us-ascii" do
@@ -625,9 +625,9 @@ describe Mail::Address do
       address.display_name = "まける"
       address.address      = "mikel@test.lindsaar.net"
       if RUBY_VERSION >= '1.9'
-        address.encoded.should == '=?UTF-8?B?44G+44GR44KL?= <mikel@test.lindsaar.net>'
+        address.encoded.should eql '=?UTF-8?B?44G+44GR44KL?= <mikel@test.lindsaar.net>'
       else
-        address.encoded.should == '=?UTF8?B?44G+44GR44KL?= <mikel@test.lindsaar.net>'
+        address.encoded.should eql '=?UTF8?B?44G+44GR44KL?= <mikel@test.lindsaar.net>'
       end
     end
 
@@ -635,7 +635,7 @@ describe Mail::Address do
       address              = Mail::Address.new
       address.display_name = "まける"
       address.address      = "mikel@test.lindsaar.net"
-      address.decoded.should == '"まける" <mikel@test.lindsaar.net>'
+      address.decoded.should eql '"まける" <mikel@test.lindsaar.net>'
     end
 
   end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -18,15 +18,15 @@ describe Mail::Encodings do
     end
   
     it "should return the Base64 Encoding class" do
-      Mail::Encodings.get_encoding('Base64').should == Mail::Encodings::Base64
+      Mail::Encodings.get_encoding('Base64').should eql Mail::Encodings::Base64
     end
   
     it "should return the base64 Encoding class" do
-      Mail::Encodings.get_encoding('base64').should == Mail::Encodings::Base64
+      Mail::Encodings.get_encoding('base64').should eql Mail::Encodings::Base64
     end
   
     it "should return the base64 Encoding class" do
-      Mail::Encodings.get_encoding(:base64).should == Mail::Encodings::Base64
+      Mail::Encodings.get_encoding(:base64).should eql Mail::Encodings::Base64
     end
 
   end
@@ -46,15 +46,15 @@ describe Mail::Encodings do
     end
   
     it "should return the QuotedPrintable Encoding class" do
-      Mail::Encodings.get_encoding('quoted-printable').should == Mail::Encodings::QuotedPrintable
+      Mail::Encodings.get_encoding('quoted-printable').should eql Mail::Encodings::QuotedPrintable
     end
   
     it "should return the QuotedPrintable Encoding class" do
-      Mail::Encodings.get_encoding('Quoted-Printable').should == Mail::Encodings::QuotedPrintable
+      Mail::Encodings.get_encoding('Quoted-Printable').should eql Mail::Encodings::QuotedPrintable
     end
   
     it "should return the QuotedPrintable Encoding class" do
-      Mail::Encodings.get_encoding(:quoted_printable).should == Mail::Encodings::QuotedPrintable
+      Mail::Encodings.get_encoding(:quoted_printable).should eql Mail::Encodings::QuotedPrintable
     end
 
   end
@@ -80,11 +80,11 @@ describe Mail::Encodings do
       if RUBY_VERSION >= "1.9.1"
         string = "This is a string"
         string = string.force_encoding('US-ASCII')
-        Mail::Encodings.b_value_encode(string).should == "This is a string"
+        Mail::Encodings.b_value_encode(string).should eql "This is a string"
       else
         string = "This is a string"
         encoding = 'US-ASCII'
-        Mail::Encodings.b_value_encode(string, encoding).should == "This is a string"
+        Mail::Encodings.b_value_encode(string, encoding).should eql "This is a string"
       end
     end
     
@@ -92,11 +92,11 @@ describe Mail::Encodings do
       if RUBY_VERSION >= "1.9.1"
         string = "This is あ string"
         string = string.force_encoding('UTF-8')
-        Mail::Encodings.b_value_encode(string).should == '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
+        Mail::Encodings.b_value_encode(string).should eql '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       else
         string = "This is あ string"
         encoding = 'UTF-8'
-        Mail::Encodings.b_value_encode(string, encoding).should == '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
+        Mail::Encodings.b_value_encode(string, encoding).should eql '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       end
     end
 
@@ -116,11 +116,11 @@ describe Mail::Encodings do
       if RUBY_VERSION >= "1.9.1"
         string = "This is あ really long string This is あ really long string This is あ really long string This is あ really long string This is あ really long string"
         string = string.force_encoding('UTF-8')
-        Mail::Encodings.b_value_encode(string).should == '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
+        Mail::Encodings.b_value_encode(string).should eql '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
       else
         string = "This is あ really long string This is あ really long string This is あ really long string This is あ really long string This is あ really long string"
         encoding = 'UTF-8'
-        Mail::Encodings.b_value_encode(string, encoding).should == '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
+        Mail::Encodings.b_value_encode(string, encoding).should eql '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
       end
     end
 
@@ -128,14 +128,14 @@ describe Mail::Encodings do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should decode a long encoded string" do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
       result = "This is あ really long string This is あ really long string This is あ really long string This is あ really long string This is あ really long string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
   end
@@ -161,11 +161,11 @@ describe Mail::Encodings do
       if RUBY_VERSION >= "1.9.1"
         string = "This is a string"
         string = string.force_encoding('US-ASCII')
-        Mail::Encodings.q_value_encode(string).should == "This is a string"
+        Mail::Encodings.q_value_encode(string).should eql "This is a string"
       else
         string = "This is a string"
         encoding = 'US-ASCII'
-        Mail::Encodings.q_value_encode(string, encoding).should == "This is a string"
+        Mail::Encodings.q_value_encode(string, encoding).should eql "This is a string"
       end
     end
     
@@ -185,11 +185,11 @@ describe Mail::Encodings do
       if RUBY_VERSION >= "1.9.1"
         string = "This is あ string"
         string = string.force_encoding('UTF-8')
-        Mail::Encodings.q_value_encode(string).should == '=?UTF-8?Q?This_is_=E3=81=82_string?='
+        Mail::Encodings.q_value_encode(string).should eql '=?UTF-8?Q?This_is_=E3=81=82_string?='
       else
         string = "This is あ string"
         encoding = 'UTF-8'
-        Mail::Encodings.q_value_encode(string, encoding).should == '=?UTF-8?Q?This_is_=E3=81=82_string?='
+        Mail::Encodings.q_value_encode(string, encoding).should eql '=?UTF-8?Q?This_is_=E3=81=82_string?='
       end
     end
 
@@ -197,14 +197,14 @@ describe Mail::Encodings do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
     
     it "should detect a q encoded string and decode it" do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should not fold a long string that has no spaces" do
@@ -217,8 +217,8 @@ describe Mail::Encodings do
       end
       mail = Mail.new
       mail.subject = original
-      mail[:subject].decoded.should == original
-      mail[:subject].encoded.gsub("UTF-8", "UTF8").should == result
+      mail[:subject].decoded.should eql original
+      mail[:subject].encoded.gsub("UTF-8", "UTF8").should eql result
     end
 
     it "should round trip a complex string properly" do
@@ -229,14 +229,14 @@ describe Mail::Encodings do
       result = "Subject: =?UTF8?Q?=D0=92=D0=BE=D1=81=D1=81=D1=82=D0=B0=D0=BD=D0=BE=D0=B2=D0=BB=D0=B5=D0=BD=D0=B8=D0=B5=D0=92=D0=BE=D1=81=D1=81=D1=82=D0=B0=D0=BD=D0=BE=D0=B2=D0=BB=D0=B5=D0=BD=D0=B8=D0=B5=D0=92=D0=B0=D1=88=D0=B5=D0=B3=D0=BE=D0=BF=D0=B0=D1=80=D0=BE=D0=BB=D1=8F?=\r\n =?UTF8?Q?_This_is_a_NUT=3F=3F=3F=3F=3FZ=5F=5Fstring_that=3D=3D_could?=\r\n =?UTF8?Q?_=28break=29_anything?=\r\n"
       mail = Mail.new
       mail.subject = original
-      mail[:subject].decoded.should == original
-      mail[:subject].encoded.gsub("UTF-8", "UTF8").should == result
+      mail[:subject].decoded.should eql original
+      mail[:subject].encoded.gsub("UTF-8", "UTF8").should eql result
       mail = Mail.new(mail.encoded)
-      mail[:subject].decoded.should == original
-      mail[:subject].encoded.gsub("UTF-8", "UTF8").should == result
+      mail[:subject].decoded.should eql original
+      mail[:subject].encoded.gsub("UTF-8", "UTF8").should eql result
       mail = Mail.new(mail.encoded)
-      mail[:subject].decoded.should == original
-      mail[:subject].encoded.gsub("UTF-8", "UTF8").should == result
+      mail[:subject].decoded.should eql original
+      mail[:subject].encoded.gsub("UTF-8", "UTF8").should eql result
     end
     
     it "should round trip another complex string (koi-8)" do
@@ -247,7 +247,7 @@ describe Mail::Encodings do
       mail[:subject].charset = 'koi8-r'
       wrapped = mail[:subject].wrapped_value
       unwrapped = Mail::Encodings.value_decode(wrapped)
-      unwrapped.gsub("Subject: ", "").should == original
+      unwrapped.gsub("Subject: ", "").should eql original
     end
   end
   
@@ -289,54 +289,54 @@ describe Mail::Encodings do
     it "should leave an unencoded string alone" do
       string = "this isn't encoded"
       result = "this isn't encoded"
-      Mail::Encodings.param_decode(string, 'us-ascii').should == result
+      Mail::Encodings.param_decode(string, 'us-ascii').should eql result
     end
     
     it "should unencode an encoded string" do
       string = "This%20is%20even%20more%20"
       result = "This is even more "
       result.force_encoding('us-ascii') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.param_decode(string, 'us-ascii').should == result
+      Mail::Encodings.param_decode(string, 'us-ascii').should eql result
     end
     
     it "should unencoded an encoded string and return the right charset on 1.9" do
       string = "This%20is%20even%20more%20"
       result = "This is even more "
       result.force_encoding('us-ascii') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.param_decode(string, 'us-ascii').should == result
+      Mail::Encodings.param_decode(string, 'us-ascii').should eql result
     end
     
     it "should unencode a complete string that included unencoded parts" do
       string = "This%20is%20even%20more%20%2A%2A%2Afun%2A%2A%2A%20isn't it"
       result = "This is even more ***fun*** isn't it"
       result.force_encoding('iso-8859-1') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.param_decode(string, 'iso-8859-1').should == result
+      Mail::Encodings.param_decode(string, 'iso-8859-1').should eql result
     end
     
     it "should encode a string" do
       string = "This is  あ string"
       if RUBY_VERSION >= '1.9'
-        Mail::Encodings.param_encode(string).should == "utf-8'en'This%20is%20%20%E3%81%82%20string"
+        Mail::Encodings.param_encode(string).should eql "utf-8'en'This%20is%20%20%E3%81%82%20string"
       else
-        Mail::Encodings.param_encode(string).should == "utf8'en'This%20is%20%20%E3%81%82%20string"
+        Mail::Encodings.param_encode(string).should eql "utf8'en'This%20is%20%20%E3%81%82%20string"
       end
     end
 
     it "should just quote US-ASCII with spaces" do
       string = "This is even more"
       if RUBY_VERSION >= '1.9'
-        Mail::Encodings.param_encode(string).should == '"This is even more"'
+        Mail::Encodings.param_encode(string).should eql '"This is even more"'
       else
-        Mail::Encodings.param_encode(string).should == '"This is even more"'
+        Mail::Encodings.param_encode(string).should eql '"This is even more"'
       end
     end
 
     it "should leave US-ASCII without spaces alone" do
       string = "fun"
       if RUBY_VERSION >= '1.9'
-        Mail::Encodings.param_encode(string).should == 'fun'
+        Mail::Encodings.param_encode(string).should eql 'fun'
       else
-        Mail::Encodings.param_encode(string).should == 'fun'
+        Mail::Encodings.param_encode(string).should eql 'fun'
       end
     end
     
@@ -348,96 +348,96 @@ describe Mail::Encodings do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect a multiple encoded Base64 string to the decoded string" do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?==?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect a multiple encoded Base64 string with a space to the decoded string" do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= =?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect a multiple encoded Base64 string with a whitespace to the decoded string" do
       string = "=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= \r\n\s=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?="
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should decode B and Q encodings together if needed" do
       string = "=?UTF-8?Q?This_is_=E3=81=82_string?==?UTF-8?Q?This_is_=E3=81=82_string?= Some non encoded stuff =?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= \r\n\sMore non encoded stuff"
       result = "This is あ stringThis is あ string Some non encoded stuff This is あ string \r\n\sMore non encoded stuff"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect a encoded and unencoded Base64 string to the decoded string" do
       string = "Some non encoded stuff =?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= \r\n\sMore non encoded stuff"
       result = "Some non encoded stuff This is あ string \r\n\sMore non encoded stuff"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect an encoded QP string to the decoded string" do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect multiple encoded QP string to the decoded string" do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?==?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect multiple encoded QP string with a space to the decoded string" do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?= =?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect multiple encoded QP string with a space to the decoded string" do
       string = "=?UTF-8?Q?This_is_=E3=81=82_string?= \r\n\s=?UTF-8?Q?This_is_=E3=81=82_string?="
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect a encoded and unencoded QP string to the decoded string" do
       string = "Some non encoded stuff =?UTF-8?Q?This_is_=E3=81=82_string?= \r\n\sMore non encoded stuff"
       result = "Some non encoded stuff This is あ string \r\n\sMore non encoded stuff"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should detect a plain string and return it" do
       string = 'This is あ string'
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
 
     it "should handle a very long string efficiently" do
       string = "This is a string " * 10000
-      Mail::Encodings.value_decode(string).should == string
+      Mail::Encodings.value_decode(string).should eql string
     end
 
     it "should handle Base64 encoded ISO-2022-JP string" do
       pending
       string = "ISO-2022-JP =?iso-2022-jp?B?GyRCJCQkPSRLITwkXiRrJEskSyE8JDgkJyQkJFQhPBsoQg==?="
       result = "ISO-2022-JP いそにーまるににーじぇいぴー"
-      Mail::Encodings.value_decode(string).should == result
+      Mail::Encodings.value_decode(string).should eql result
     end
   end
   
@@ -461,7 +461,7 @@ describe Mail::Encodings do
         else
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :decode).should == result
+        Mail::Encodings.decode_encode(string, :decode).should eql result
       end
 
       it "should detect an encoded QP string and return the decoded string" do
@@ -472,7 +472,7 @@ describe Mail::Encodings do
         else
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :decode).should == result
+        Mail::Encodings.decode_encode(string, :decode).should eql result
       end
 
       it "should detect an a string is already decoded and leave it alone" do
@@ -483,7 +483,7 @@ describe Mail::Encodings do
         else
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :decode).should == result
+        Mail::Encodings.decode_encode(string, :decode).should eql result
       end
 
     end
@@ -499,7 +499,7 @@ describe Mail::Encodings do
           result = '=?UTF8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :encode).should == result
+        Mail::Encodings.decode_encode(string, :encode).should eql result
       end
 
       it "should leave a string that doesn't need encoding alone" do
@@ -510,7 +510,7 @@ describe Mail::Encodings do
         else
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :encode).should == result
+        Mail::Encodings.decode_encode(string, :encode).should eql result
       end
 
     end
@@ -519,31 +519,31 @@ describe Mail::Encodings do
       it "should unquote quoted printable and convert to utf-8" do
         a ="=?ISO-8859-1?Q?[166417]_Bekr=E6ftelse_fra_Rejsefeber?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should == "[166417] Bekr\303\246ftelse fra Rejsefeber"
+        b.should eql "[166417] Bekr\303\246ftelse fra Rejsefeber"
       end
 
       it "should unquote base64 and convert to utf-8" do
         a ="=?ISO-8859-1?B?WzE2NjQxN10gQmVrcuZmdGVsc2UgZnJhIFJlanNlZmViZXI=?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should == "[166417] Bekr\303\246ftelse fra Rejsefeber"
+        b.should eql "[166417] Bekr\303\246ftelse fra Rejsefeber"
       end
 
       it "should handle no charset" do
         a ="[166417]_Bekr=E6ftelse_fra_Rejsefeber"
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should == "[166417]_Bekr=E6ftelse_fra_Rejsefeber"
+        b.should eql "[166417]_Bekr=E6ftelse_fra_Rejsefeber"
       end
 
       it "should unquote multiple lines" do
         a ="=?utf-8?q?Re=3A_=5B12=5D_=23137=3A_Inkonsistente_verwendung_von_=22Hin?==?utf-8?b?enVmw7xnZW4i?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should == "Re: [12] #137: Inkonsistente verwendung von \"Hinzuf\303\274gen\""
+        b.should eql "Re: [12] #137: Inkonsistente verwendung von \"Hinzuf\303\274gen\""
       end
 
       it "should unquote a string in the middle of the text" do
         a ="Re: Photos =?ISO-8859-1?Q?Brosch=FCre_Rand?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should == "Re: Photos Brosch\303\274re Rand"
+        b.should eql "Re: Photos Brosch\303\274re Rand"
       end
 
       it "should unquote and change to an ISO encoding if we really want" do
@@ -551,13 +551,13 @@ describe Mail::Encodings do
         b = Mail::Encodings.unquote_and_convert_to(a, 'iso-8859-1')
         expected = "Brosch\374re Rand"
         expected.force_encoding('iso-8859-1').encode!('utf-8') if expected.respond_to?(:force_encoding)
-        b.should == expected
+        b.should eql expected
       end
 
       it "should unquote multiple strings in the middle of the text" do
         a = "=?Shift_JIS?Q?=93=FA=96{=8C=EA=?= <a@example.com>, =?Shift_JIS?Q?=93=FA=96{=8C=EA=?= <b@example.com>"
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should == "日本語 <a@example.com>, 日本語 <b@example.com>"
+        b.should eql "日本語 <a@example.com>, 日本語 <b@example.com>"
       end      
     end
   end
@@ -566,19 +566,19 @@ describe Mail::Encodings do
     it "should handle underscores in the text" do
       expected = 'something_with_underscores'
       encoded = [expected].pack('*M')
-      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("*M").first.should == expected
+      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("*M").first.should eql expected
     end
 
     it "should handle underscores in the text" do
       expected = 'something with_underscores'
       encoded = [expected].pack('*M')
-      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("*M").first.should == expected
+      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("*M").first.should eql expected
     end
 
     it "should keep the underscores in the text" do
       expected = 'something_with_underscores'
       encoded = Mail::Encodings.get_encoding(:quoted_printable).encode(expected)
-      Mail::Encodings.get_encoding(:quoted_printable).decode(encoded).should == expected
+      Mail::Encodings.get_encoding(:quoted_printable).decode(encoded).should eql expected
     end
 
     it "should handle a new line in the text" do
@@ -588,7 +588,7 @@ describe Mail::Encodings do
         expected = "\nRe: ol\341"
       end
       encoded = "=?ISO-8859-1?Q?\nRe=3A_ol=E1?="
-      Mail::Encodings.value_decode(encoded).should == expected
+      Mail::Encodings.value_decode(encoded).should eql expected
     end
 
   end
@@ -596,49 +596,49 @@ describe Mail::Encodings do
   describe "pre encoding non usascii text" do
     it "should not change an ascii string" do
       raw     = 'mikel@test.lindsaar.net'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == raw
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eql raw
     end
 
     it "should encode a display that contains non usascii" do
       raw     = 'Lindsああr <mikel@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eql encoded
     end
 
     it "should encode a display that contains non usascii with quotes as no quotes" do
       raw     = '"Lindsああr" <mikel@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eql encoded
     end
 
     it "should encode a display name with us-ascii and non-usascii parts" do
       raw     = 'Mikel Lindsああr <mikel@test.lindsaar.net>'
       encoded = 'Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eql encoded
     end
 
     it "should encode a display name with us-ascii and non-usascii parts ignoring quotes" do
       raw     = '"Mikel Lindsああr" <mikel@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eql encoded
     end
 
     it "should encode multiple addresses correctly" do
       raw     = '"Mikel Lindsああr" <mikel@test.lindsaar.net>, "あdあ" <ada@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eql encoded
     end
 
     it "should encode multiple unquoted addresses correctly" do
       raw     = 'Mikel Lindsああr <mikel@test.lindsaar.net>, あdあ <ada@test.lindsaar.net>'
       encoded = 'Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eql encoded
     end
 
     it "should encode multiple un bracketed addresses and groups correctly" do
       raw     = '"Mikel Lindsああr" test1@lindsaar.net, group: "あdあ" test2@lindsaar.net, me@lindsaar.net;'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= test1@lindsaar.net, group: =?UTF-8?B?44GCZOOBgg==?= test2@lindsaar.net, me@lindsaar.net;'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should == encoded
+      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eql encoded
     end
     
   end
@@ -647,37 +647,37 @@ describe Mail::Encodings do
     it "should not do anything to a plain address" do
       raw     = 'mikel@test.lindsaar.net'
       encoded = 'mikel@test.lindsaar.net'
-      Mail::Encodings.address_encode(raw, 'utf-8').should == encoded
+      Mail::Encodings.address_encode(raw, 'utf-8').should eql encoded
     end
 
     it "should encode an address correctly" do
       raw     = '"Mikel Lindsああr" <mikel@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should == encoded
+      Mail::Encodings.address_encode(raw, 'utf-8').should eql encoded
     end
 
     it "should encode multiple addresses correctly" do
       raw     = ['"Mikel Lindsああr" <mikel@test.lindsaar.net>', '"あdあ" <ada@test.lindsaar.net>']
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should == encoded
+      Mail::Encodings.address_encode(raw, 'utf-8').should eql encoded
     end
 
     it "should handle a single ascii address correctly from a string" do
       raw     = ['"Mikel Lindsaar" <mikel@test.lindsaar.net>']
       encoded = '"Mikel Lindsaar" <mikel@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should == encoded
+      Mail::Encodings.address_encode(raw, 'utf-8').should eql encoded
     end
 
     it "should handle multiple ascii addresses correctly from a string" do
       raw     = 'Mikel Lindsaar <mikel@test.lindsaar.net>, Ada <ada@test.lindsaar.net>'
       encoded = 'Mikel Lindsaar <mikel@test.lindsaar.net>, Ada <ada@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should == encoded
+      Mail::Encodings.address_encode(raw, 'utf-8').should eql encoded
     end
 
     it "should handle ascii addresses correctly as an array" do
       raw     = ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'Ada <ada@test.lindsaar.net>']
       encoded = 'Mikel Lindsaar <mikel@test.lindsaar.net>, Ada <ada@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should == encoded
+      Mail::Encodings.address_encode(raw, 'utf-8').should eql encoded
     end
 
   end

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -11,11 +11,11 @@ describe "Test emails" do
     # message identifier, and a textual message in the body.
     it "should handle the basic test email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example01.eml'))
-      mail.from.should == ["jdoe@machine.example"]
-      mail.to.should == ['mary@example.net']
-      mail.message_id.should == '1234@local.machine.example'
-      mail.date.should == ::DateTime.parse('21 Nov 1997 09:55:06 -0600')
-      mail.subject.should == 'Saying Hello'
+      mail.from.should eql ["jdoe@machine.example"]
+      mail.to.should eql ['mary@example.net']
+      mail.message_id.should eql '1234@local.machine.example'
+      mail.date.should eql ::DateTime.parse('21 Nov 1997 09:55:06 -0600')
+      mail.subject.should eql 'Saying Hello'
     end
 
     # From RFC 2822:
@@ -24,12 +24,12 @@ describe "Test emails" do
     # sender field would be used:
     it "should handle the sender test email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example02.eml'))
-      mail.from.should == ['jdoe@machine.example']
-      mail.sender.should == 'mjones@machine.example'
-      mail.to.should == ['mary@example.net']
-      mail.message_id.should == '1234@local.machine.example'
-      mail.date.should == ::DateTime.parse('21 Nov 1997 09:55:06 -0600')
-      mail.subject.should == 'Saying Hello'
+      mail.from.should eql ['jdoe@machine.example']
+      mail.sender.should eql 'mjones@machine.example'
+      mail.to.should eql ['mary@example.net']
+      mail.message_id.should eql '1234@local.machine.example'
+      mail.date.should eql ::DateTime.parse('21 Nov 1997 09:55:06 -0600')
+      mail.subject.should eql 'Saying Hello'
     end
 
     # From RFC 2822:
@@ -49,11 +49,11 @@ describe "Test emails" do
     # "Giant; \"Big\" Box" <sysservices@example.net>
     it "should handle multiple recipients test email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example03.eml'))
-      mail.from.should == ['john.q.public@example.com']
-      mail.to.should == ['mary@x.test', 'jdoe@example.org', 'one@y.test']
-      mail.cc.should == ['boss@nil.test', "sysservices@example.net"]
-      mail.message_id.should == '5678.21-Nov-1997@example.com'
-      mail.date.should == ::DateTime.parse('1 Jul 2003 10:52:37 +0200')
+      mail.from.should eql ['john.q.public@example.com']
+      mail.to.should eql ['mary@x.test', 'jdoe@example.org', 'one@y.test']
+      mail.cc.should eql ['boss@nil.test', "sysservices@example.net"]
+      mail.message_id.should eql '5678.21-Nov-1997@example.com'
+      mail.date.should eql ::DateTime.parse('1 Jul 2003 10:52:37 +0200')
     end
 
     # From RFC 2822:
@@ -63,11 +63,11 @@ describe "Test emails" do
     # group recipient named Undisclosed recipients.
     it "should handle group address email test" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example04.eml'))
-      mail.from.should == ['pete@silly.example']
-      mail.to.should == ['c@a.test', 'joe@where.test', 'jdoe@one.test']
-      mail[:cc].group_names.should == ['Undisclosed recipients']
-      mail.message_id.should == 'testabcd.1234@silly.example'
-      mail.date.should == ::DateTime.parse('Thu, 13 Feb 1969 23:32:54 -0330')
+      mail.from.should eql ['pete@silly.example']
+      mail.to.should eql ['c@a.test', 'joe@where.test', 'jdoe@one.test']
+      mail[:cc].group_names.should eql ['Undisclosed recipients']
+      mail.message_id.should eql 'testabcd.1234@silly.example'
+      mail.date.should eql ::DateTime.parse('Thu, 13 Feb 1969 23:32:54 -0330')
     end
 
 
@@ -82,11 +82,11 @@ describe "Test emails" do
     # fields in each message.
     it "should handle reply messages" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example05.eml'))
-      mail.from.should == ["jdoe@machine.example"]
-      mail.to.should == ['mary@example.net']
-      mail.subject.should == 'Saying Hello'
-      mail.message_id.should == '1234@local.machine.example'
-      mail.date.should == ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
+      mail.from.should eql ["jdoe@machine.example"]
+      mail.to.should eql ['mary@example.net']
+      mail.subject.should eql 'Saying Hello'
+      mail.message_id.should eql '1234@local.machine.example'
+      mail.date.should eql ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
     end
 
     # From RFC 2822:
@@ -97,27 +97,27 @@ describe "Test emails" do
     # "Reply-To:" field instead of the address in the "From:" field.
     it "should handle reply message 2" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example06.eml'))
-      mail.from.should == ['mary@example.net']
-      mail.to.should == ['jdoe@machine.example']
-      mail.reply_to.should == ['smith@home.example']
-      mail.subject.should == 'Re: Saying Hello'
-      mail.message_id.should == '3456@example.net'
-      mail[:in_reply_to].message_ids.should == ['1234@local.machine.example']
-      mail[:references].message_ids.should == ['1234@local.machine.example']
-      mail.date.should == ::DateTime.parse('Fri, 21 Nov 1997 10:01:10 -0600')
+      mail.from.should eql ['mary@example.net']
+      mail.to.should eql ['jdoe@machine.example']
+      mail.reply_to.should eql ['smith@home.example']
+      mail.subject.should eql 'Re: Saying Hello'
+      mail.message_id.should eql '3456@example.net'
+      mail[:in_reply_to].message_ids.should eql ['1234@local.machine.example']
+      mail[:references].message_ids.should eql ['1234@local.machine.example']
+      mail.date.should eql ::DateTime.parse('Fri, 21 Nov 1997 10:01:10 -0600')
     end
 
     # From RFC 2822:
     # Final reply message
     it "should handle the final reply message" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example07.eml'))
-      mail.to.should == ['smith@home.example']
-      mail.from.should == ['jdoe@machine.example']
-      mail.subject.should == 'Re: Saying Hello'
-      mail.date.should == ::DateTime.parse('Fri, 21 Nov 1997 11:00:00 -0600')
-      mail.message_id.should == 'abcd.1234@local.machine.tld'
-      mail.in_reply_to.should == '3456@example.net'
-      mail[:references].message_ids.should == ['1234@local.machine.example', '3456@example.net']
+      mail.to.should eql ['smith@home.example']
+      mail.from.should eql ['jdoe@machine.example']
+      mail.subject.should eql 'Re: Saying Hello'
+      mail.date.should eql ::DateTime.parse('Fri, 21 Nov 1997 11:00:00 -0600')
+      mail.message_id.should eql 'abcd.1234@local.machine.tld'
+      mail.in_reply_to.should eql '3456@example.net'
+      mail[:references].message_ids.should eql ['1234@local.machine.example', '3456@example.net']
     end
 
     # From RFC2822
@@ -135,15 +135,15 @@ describe "Test emails" do
     # and send that.
     it "should handle the rfc resent example email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example08.eml'))
-      mail.resent_from.should == ['mary@example.net']
-      mail.resent_to.should == ['j-brown@other.example']
-      mail.resent_date.should == ::DateTime.parse('Mon, 24 Nov 1997 14:22:01 -0800')
-      mail.resent_message_id.should == '78910@example.net'
-      mail.from.should == ['jdoe@machine.example']
-      mail.to.should == ['mary@example.net']
-      mail.subject.should == 'Saying Hello'
-      mail.date.should == ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
-      mail.message_id.should == '1234@local.machine.example'
+      mail.resent_from.should eql ['mary@example.net']
+      mail.resent_to.should eql ['j-brown@other.example']
+      mail.resent_date.should eql ::DateTime.parse('Mon, 24 Nov 1997 14:22:01 -0800')
+      mail.resent_message_id.should eql '78910@example.net'
+      mail.from.should eql ['jdoe@machine.example']
+      mail.to.should eql ['mary@example.net']
+      mail.subject.should eql 'Saying Hello'
+      mail.date.should eql ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
+      mail.message_id.should eql '1234@local.machine.example'
     end
 
     # A.4. Messages with trace fields
@@ -154,15 +154,15 @@ describe "Test emails" do
     # can be long.
     it "should handle the RFC trace example email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example09.eml'))
-      mail.received[0].info.should == 'from x.y.test by example.net via TCP with ESMTP id ABC12345 for <mary@example.net>'
-      mail.received[0].date_time.should == ::DateTime.parse('21 Nov 1997 10:05:43 -0600')
-      mail.received[1].info.should == 'from machine.example by x.y.test'
-      mail.received[1].date_time.should == ::DateTime.parse('21 Nov 1997 10:01:22 -0600')
-      mail.from.should == ['jdoe@machine.example']
-      mail.to.should == ['mary@example.net']
-      mail.subject.should == 'Saying Hello'
-      mail.date.should == ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
-      mail.message_id.should == '1234@local.machine.example'
+      mail.received[0].info.should eql 'from x.y.test by example.net via TCP with ESMTP id ABC12345 for <mary@example.net>'
+      mail.received[0].date_time.should eql ::DateTime.parse('21 Nov 1997 10:05:43 -0600')
+      mail.received[1].info.should eql 'from machine.example by x.y.test'
+      mail.received[1].date_time.should eql ::DateTime.parse('21 Nov 1997 10:01:22 -0600')
+      mail.from.should eql ['jdoe@machine.example']
+      mail.to.should eql ['mary@example.net']
+      mail.subject.should eql 'Saying Hello'
+      mail.date.should eql ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
+      mail.message_id.should eql '1234@local.machine.example'
     end
 
     # A.5. White space, comments, and other oddities
@@ -186,11 +186,11 @@ describe "Test emails" do
 
     it "should handle the rfc whitespace test email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example10.eml'))
-      mail.from.should == ["pete(his account)@silly.test"]
-      mail.to.should ==  ["c@(Chris's host.)public.example", "joe@example.org", "jdoe@one.test"]
-      mail[:cc].group_names.should == ['(Empty list)(start)Undisclosed recipients ']
-      mail.date.should == ::DateTime.parse('Thu, 13 Feb 1969 23:32 -0330')
-      mail.message_id.should == 'testabcd.1234@silly.test'
+      mail.from.should eql ["pete(his account)@silly.test"]
+      mail.to.should eql  ["c@(Chris's host.)public.example", "joe@example.org", "jdoe@one.test"]
+      mail[:cc].group_names.should eql ['(Empty list)(start)Undisclosed recipients ']
+      mail.date.should eql ::DateTime.parse('Thu, 13 Feb 1969 23:32 -0330')
+      mail.message_id.should eql 'testabcd.1234@silly.test'
     end
 
     # A.6. Obsoleted forms
@@ -205,11 +205,11 @@ describe "Test emails" do
     it "should handle the rfc obsolete addressing" do
       pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example11.eml'))
-      mail[:from].addresses.should == ['john.q.public@example.com']
-      mail.from.should == '"Joe Q. Public" <john.q.public@example.com>'
-      mail.to.should == ["@machine.tld:mary@example.net", 'jdoe@test.example']
-      mail.date.should == ::DateTime.parse('Tue, 1 Jul 2003 10:52:37 +0200')
-      mail.message_id.should == '5678.21-Nov-1997@example.com'
+      mail[:from].addresses.should eql ['john.q.public@example.com']
+      mail.from.should eql '"Joe Q. Public" <john.q.public@example.com>'
+      mail.to.should eql ["@machine.tld:mary@example.net", 'jdoe@test.example']
+      mail.date.should eql ::DateTime.parse('Tue, 1 Jul 2003 10:52:37 +0200')
+      mail.message_id.should eql '5678.21-Nov-1997@example.com'
     end
 
     # A.6.2. Obsolete dates
@@ -221,10 +221,10 @@ describe "Test emails" do
     it "should handle the rfc obsolete dates" do
       pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example12.eml'))
-      mail.from.should == 'jdoe@machine.example'
-      mail.to.should == 'mary@example.net'
-      mail.date.should == ::DateTime.parse('21 Nov 97 09:55:06 GMT')
-      mail.message_id.should == '1234@local.machine.example'
+      mail.from.should eql 'jdoe@machine.example'
+      mail.to.should eql 'mary@example.net'
+      mail.date.should eql ::DateTime.parse('21 Nov 97 09:55:06 GMT')
+      mail.message_id.should eql '1234@local.machine.example'
     end
 
     # A.6.3. Obsolete white space and comments
@@ -242,10 +242,10 @@ describe "Test emails" do
     it "should handle the rfc obsolete whitespace email" do
       pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example13.eml'))
-      mail.from.should == 'John Doe <jdoe@machine(comment).example>'
-      mail.to.should == 'Mary Smith <mary@example.net>'
-      mail.date.should == ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
-      mail.message_id.should == '1234@local(blah).machine.example'
+      mail.from.should eql 'John Doe <jdoe@machine(comment).example>'
+      mail.to.should eql 'Mary Smith <mary@example.net>'
+      mail.date.should eql ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
+      mail.message_id.should eql '1234@local(blah).machine.example'
       doing { Mail::Message.new(email) }.should_not raise_error
     end
 
@@ -263,7 +263,7 @@ describe "Test emails" do
       end
 
       it "should have two parts" do
-        @message.parts.length.should == 2
+        @message.parts.length.should eql 2
       end
 
     end
@@ -278,8 +278,8 @@ describe "Test emails" do
       end
       
       it "should have one attachment called signature.asc" do
-        @message.attachments.length.should == 1
-        @message.attachments.first.filename.should == 'signature.asc'
+        @message.attachments.length.should eql 1
+        @message.attachments.first.filename.should eql 'signature.asc'
       end
       
     end
@@ -294,7 +294,7 @@ describe "Test emails" do
       end
 
       it "should return an empty groups list" do
-        @message[:to].group_addresses.should == []
+        @message[:to].group_addresses.should eql []
       end
     end
 
@@ -311,7 +311,7 @@ describe "Test emails" do
     end
 
     it "should return an empty groups list" do
-      @message.to.should == ['user-example@aol.com', 'e-s-a-s-2200@app.ar.com']
+      @message.to.should eql ['user-example@aol.com', 'e-s-a-s-2200@app.ar.com']
     end
     
   end

--- a/spec/mail/field_list_spec.rb
+++ b/spec/mail/field_list_spec.rb
@@ -14,10 +14,10 @@ describe Mail::FieldList do
     fl << Mail::Field.new("From: mikel@me.com")
     fl << Mail::Field.new("Received: from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
     fl << Mail::Field.new("Return-Path: mikel@me.com")
-    fl[0].field.class.should == Mail::ReturnPathField
-    fl[1].field.class.should == Mail::ReceivedField
-    fl[2].field.class.should == Mail::FromField
-    fl[3].field.class.should == Mail::ToField
+    fl[0].field.class.should eql Mail::ReturnPathField
+    fl[1].field.class.should eql Mail::ReceivedField
+    fl[2].field.class.should eql Mail::FromField
+    fl[3].field.class.should eql Mail::ToField
   end
   
   it "should add new Received items after the existing ones" do

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -7,22 +7,22 @@ describe Mail::Field do
 
     it "should be instantiated" do
       doing {Mail::Field.new('To: Mikel')}.should_not raise_error
-      Mail::Field.new('To: Mikel').field.class.should == Mail::ToField
+      Mail::Field.new('To: Mikel').field.class.should eql Mail::ToField
     end
 
     it "should allow you to init on an array" do
       field = Mail::Field.new("To", ['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>'])
-      field.addresses.should == ["test1@lindsaar.net", "test2@lindsaar.net"]
+      field.addresses.should eql ["test1@lindsaar.net", "test2@lindsaar.net"]
     end
 
     it "should allow us to pass an empty value" do
       doing {Mail::Field.new('To')}.should_not raise_error
-      Mail::Field.new('To').field.class.should == Mail::ToField
+      Mail::Field.new('To').field.class.should eql Mail::ToField
     end
 
     it "should allow us to pass a value" do
       doing {Mail::Field.new('To', 'Mikel')}.should_not raise_error
-      Mail::Field.new('To', 'Mikel').field.class.should == Mail::ToField
+      Mail::Field.new('To', 'Mikel').field.class.should eql Mail::ToField
     end
 
     it "should match up fields to class names" do
@@ -35,7 +35,7 @@ describe Mail::Field do
       structured_fields.each do |sf|
         words = sf.split("-").map { |a| a.capitalize }
         klass = "#{words.join}Field"
-        Mail::Field.new("#{sf}: ").field.class.should == Mail.const_get(klass)
+        Mail::Field.new("#{sf}: ").field.class.should eql Mail.const_get(klass)
       end
     end
 
@@ -49,41 +49,41 @@ describe Mail::Field do
       structured_fields.each do |sf|
         words = sf.split("-").map { |a| a.capitalize }
         klass = "#{words.join}Field"
-        Mail::Field.new("#{sf}: ").field.class.should == Mail.const_get(klass)
+        Mail::Field.new("#{sf}: ").field.class.should eql Mail.const_get(klass)
       end
     end
 
     it "should say anything that is not a known field is an optional field" do
       unstructured_fields = %w[ Too Becc bccc Random X-Mail MySpecialField ]
       unstructured_fields.each do |sf|
-        Mail::Field.new("#{sf}: Value").field.class.should == Mail::OptionalField
+        Mail::Field.new("#{sf}: Value").field.class.should eql Mail::OptionalField
       end
     end
 
     it "should split the name and values out of the raw field passed in" do
       field = Mail::Field.new('To: Bob')
-      field.name.should == 'To'
-      field.value.should == 'Bob'
+      field.name.should eql 'To'
+      field.value.should eql 'Bob'
     end
 
     it "should split the name and values out of the raw field passed in if missing whitespace" do
       field = Mail::Field.new('To:Bob')
-      field.name.should == 'To'
-      field.value.should == 'Bob'
+      field.name.should eql 'To'
+      field.value.should eql 'Bob'
     end
 
     it "should split the name and values out of the raw field passed in if having added inapplicable whitespace" do
       field = Mail::Field.new('To                  :                   Bob                      ')
-      field.name.should == 'To'
-      field.value.should == 'Bob'
+      field.name.should eql 'To'
+      field.value.should eql 'Bob'
     end
 
     it "should return an unstuctured field if the structured field parsing raises an error" do
       Mail::ToField.should_receive(:new).and_raise(Mail::Field::ParseError)
       field = Mail::Field.new('To: Bob, ,,, Frank, Smith')
-      field.field.class.should == Mail::UnstructuredField
-      field.name.should == 'To'
-      field.value.should == 'Bob, ,,, Frank, Smith'
+      field.field.class.should eql Mail::UnstructuredField
+      field.name.to_s.should eql 'To'
+      field.value.to_s.should eql 'Bob, ,,, Frank, Smith'
     end
 
     it "should call to_s on it's field when sent to_s" do
@@ -101,28 +101,28 @@ describe Mail::Field do
 
     it "should change it's type if you change the name" do
       field = Mail::Field.new("To: mikel@me.com")
-      field.field.class.should == Mail::ToField
+      field.field.class.should eql Mail::ToField
       field.value = "bob@me.com"
-      field.field.class.should == Mail::ToField
+      field.field.class.should eql Mail::ToField
     end
 
     it "should create a field without trying to parse if given a symbol" do
       field = Mail::Field.new('Message-ID')
-      field.field.class.should == Mail::MessageIdField
+      field.field.class.should eql Mail::MessageIdField
     end
 
     it "should inherit charset" do
       charset = 'iso-2022-jp'
       field = Mail::Field.new('Subject: こんにちは', charset)
-      field.charset.should == charset
+      field.charset.should eql charset
     end
   end
 
   describe "error handling" do
     it "should populate the errors array if it finds a field it can't deal with" do
       field = Mail::Field.new('Content-Transfer-Encoding: bit')
-      field.field.errors[0][0].should == 'Content-Transfer-Encoding'
-      field.field.errors[0][1].should == 'bit'
+      field.field.errors[0][0].to_s.should eql 'Content-Transfer-Encoding'
+      field.field.errors[0][1].to_s.should eql 'bit'
       field.field.errors[0][2].to_s.should =~ /ContentTransferEncodingElement can not parse |17-bit|/
     end
   end
@@ -148,12 +148,12 @@ describe Mail::Field do
     end
 
     it "should say it is not == to another if their field names do not match" do
-      Mail::Field.new("From: mikel").should_not == Mail::Field.new("To: bob")
+      Mail::Field.new("From: mikel").should_not eql Mail::Field.new("To: bob")
     end
 
     it "should sort according to the field order" do
       list = [Mail::Field.new("To: mikel"), Mail::Field.new("Return-Path: bob")]
-      list.sort[0].name.should == "Return-Path"
+      list.sort[0].name.should eql "Return-Path"
     end
 
   end
@@ -161,28 +161,28 @@ describe Mail::Field do
   describe "passing an encoding" do
     it "should allow you to send in unencoded strings to fields and encode them" do
       subject = Mail::SubjectField.new("This is あ string", 'utf-8')
-      subject.encoded.should == "Subject: =?UTF-8?Q?This_is_=E3=81=82_string?=\r\n"
-      subject.decoded.should == "This is あ string"
+      subject.encoded.should eql "Subject: =?UTF-8?Q?This_is_=E3=81=82_string?=\r\n"
+      subject.decoded.should eql "This is あ string"
     end
 
     it "should allow you to send in unencoded strings to address fields and encode them" do
       to = Mail::ToField.new('"Mikel Lindsああr" <mikel@test.lindsaar.net>', 'utf-8')
-      to.encoded.should == "To: =?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
+      to.encoded.should eql "To: =?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
     end
 
     it "should allow you to send in unencoded strings without quotes to address fields and encode them" do
       to = Mail::ToField.new('Mikel Lindsああr <mikel@test.lindsaar.net>', 'utf-8')
-      to.encoded.should == "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
+      to.encoded.should eql "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
     end
 
     it "should allow you to send in unencoded strings to address fields and encode them" do
       to = Mail::ToField.new("あdあ <ada@test.lindsaar.net>", 'utf-8')
-      to.encoded.should == "To: =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      to.encoded.should eql "To: =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
     end
 
     it "should allow you to send in multiple unencoded strings to address fields and encode them" do
       to = Mail::ToField.new(["Mikel Lindsああr <mikel@test.lindsaar.net>", "あdあ <ada@test.lindsaar.net>"], 'utf-8')
-      to.encoded.should == "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      to.encoded.should eql "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
     end
 
     it "should allow you to send in multiple unencoded strings to any address field" do
@@ -190,55 +190,55 @@ describe Mail::Field do
       mail.charset = 'utf-8'
       array = ["Mikel Lindsああr <mikel@test.lindsaar.net>", "あdあ <ada@test.lindsaar.net>"]
       field = Mail::ToField.new(array, 'utf-8')
-      field.encoded.should == "#{Mail::ToField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      field.encoded.should eql "#{Mail::ToField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
       field = Mail::FromField.new(array, 'utf-8')
-      field.encoded.should == "#{Mail::FromField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      field.encoded.should eql "#{Mail::FromField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
       field = Mail::CcField.new(array, 'utf-8')
-      field.encoded.should == "#{Mail::CcField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      field.encoded.should eql "#{Mail::CcField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
       field = Mail::ReplyToField.new(array, 'utf-8')
-      field.encoded.should == "#{Mail::ReplyToField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      field.encoded.should eql "#{Mail::ReplyToField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
     end
 
     it "should allow an encoded value in the Subject field and decode it automatically (issue 44)" do
       pending if RUBY_VERSION < '1.9'
       subject = Mail::SubjectField.new("=?ISO-8859-1?Q?2_=FAlt?=", 'utf-8')
-      subject.decoded.should == "2 últ"
+      subject.decoded.should eql "2 últ"
     end
 
     it "should allow you to encoded text in the middle (issue 44)" do
       pending if RUBY_VERSION < '1.9'
       subject = Mail::SubjectField.new("ma=?ISO-8859-1?Q?=F1ana?=", 'utf-8')
-      subject.decoded.should == "mañana"
+      subject.decoded.should eql "mañana"
     end
 
     it "more tolerable to encoding definitions, ISO (issue 120)" do
       pending if RUBY_VERSION < '1.9'
       subject = Mail::SubjectField.new("ma=?ISO88591?Q?=F1ana?=", 'utf-8')
-      subject.decoded.should == "mañana"
+      subject.decoded.should eql "mañana"
     end
 
     it "more tolerable to encoding definitions, ISO-long (issue 120)" do
       pending if RUBY_VERSION < '1.9'
       subject = Mail::SubjectField.new("=?iso2022jp?B?SEVBUlQbJEIkSiQ0TyJNbRsoQg?=", 'utf-8')
-      subject.decoded.should ==  "HEARTなご連絡"
+      subject.decoded.should eql  "HEARTなご連絡"
     end
 
     it "more tolerable to encoding definitions, UTF (issue 120)" do
       to = Mail::ToField.new("=?utf8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>", 'utf-8')
-      to.encoded.should == "To: =?utf8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
-      to.decoded.should == "\"あdあ\" <ada@test.lindsaar.net>"
+      to.encoded.should eql "To: =?utf8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      to.decoded.should eql "\"あdあ\" <ada@test.lindsaar.net>"
     end
 
     it "more tolerable to encoding definitions, ISO (issue 120)" do
       subject = Mail::SubjectField.new("=?UTF8?B?UmU6IHRlc3QgZW52w61vIG1lbnNhamUgY29u?=", 'utf-8')
-      subject.decoded.should == "Re: test envío mensaje con"
+      subject.decoded.should eql "Re: test envío mensaje con"
     end
 
 
     it "more tolerable to encoding definitions, Windows (issue 120)" do
       pending if RUBY_VERSION < '1.9'
       subject = Mail::SubjectField.new("=?Windows1252?Q?It=92s_a_test=3F?=", 'utf-8')
-      subject.decoded.should == "It’s a test?"
+      subject.decoded.should eql "It’s a test?"
     end
   end
 

--- a/spec/mail/fields/bcc_field_spec.rb
+++ b/spec/mail/fields/bcc_field_spec.rb
@@ -35,14 +35,14 @@ describe Mail::BccField do
 
     it "should accept a string with the field name" do
       t = Mail::BccField.new('Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Bcc'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Bcc'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::BccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Bcc'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Bcc'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -52,35 +52,35 @@ describe Mail::BccField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::BccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::BccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return nothing on encoded as Bcc should not be in the mail" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == ""
+      t.encoded.should eql ""
     end
     
     it "should return the decoded line" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.decoded.should == "sam@me.com, my_group: mikel@me.com, bob@you.com;"
+      t.decoded.should eql "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
     
   end

--- a/spec/mail/fields/cc_field_spec.rb
+++ b/spec/mail/fields/cc_field_spec.rb
@@ -20,14 +20,14 @@ describe Mail::CcField do
 
     it "should accept a string with the field name" do
       t = Mail::CcField.new('Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Cc'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Cc'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::CcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Cc'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Cc'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -37,40 +37,40 @@ describe Mail::CcField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::CcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::CcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line for one address" do
       t = Mail::CcField.new('sam@me.com')
-      t.encoded.should == "Cc: sam@me.com\r\n"
+      t.encoded.should eql "Cc: sam@me.com\r\n"
     end
     
     it "should return the encoded line" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == "Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      t.encoded.should eql "Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
     it "should return the decoded line" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.decoded.should == "sam@me.com, my_group: mikel@me.com, bob@you.com;"
+      t.decoded.should eql "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
     
   end

--- a/spec/mail/fields/comments_field_spec.rb
+++ b/spec/mail/fields/comments_field_spec.rb
@@ -11,14 +11,14 @@ describe Mail::CommentsField do
 
   it "should accept a string with the field name" do
     t = Mail::CommentsField.new('Comments: this is a comment')
-    t.name.should == 'Comments'
-    t.value.should == 'this is a comment'
+    t.name.should eql 'Comments'
+    t.value.should eql 'this is a comment'
   end
 
   it "should accept a string with the field name" do
     t = Mail::CommentsField.new('this is a comment')
-    t.name.should == 'Comments'
-    t.value.should == 'this is a comment'
+    t.name.should eql 'Comments'
+    t.value.should eql 'this is a comment'
   end
   
   

--- a/spec/mail/fields/common/address_container_spec.rb
+++ b/spec/mail/fields/common/address_container_spec.rb
@@ -4,15 +4,15 @@ require 'spec_helper'
 describe 'AddressContainer' do
   it "should allow you to append an address to an address field result" do
     m = Mail.new("To: mikel@test.lindsaar.net")
-    m.to.should == ['mikel@test.lindsaar.net']
+    m.to.should eql(['mikel@test.lindsaar.net'])
     m.to << 'bob@test.lindsaar.net'
-    m.to.should == ['mikel@test.lindsaar.net', 'bob@test.lindsaar.net']
+    m.to.should eql(['mikel@test.lindsaar.net', 'bob@test.lindsaar.net'])
   end
   
   it "should handle complex addresses correctly" do
     m = Mail.new("From: mikel@test.lindsaar.net")
-    m.from.should == ['mikel@test.lindsaar.net']
+    m.from.should eql(['mikel@test.lindsaar.net'])
     m.from << '"Ada Lindsaar" <ada@test.lindsaar.net>, bob@test.lindsaar.net'
-    m.from.should == ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net', 'bob@test.lindsaar.net']
+    m.from.should eql(['mikel@test.lindsaar.net', 'ada@test.lindsaar.net', 'bob@test.lindsaar.net'])
   end
 end

--- a/spec/mail/fields/common/common_address_spec.rb
+++ b/spec/mail/fields/common/common_address_spec.rb
@@ -7,81 +7,81 @@ describe "Mail::CommonAddress" do
   
     it "should give the addresses it is going to" do
       field = Mail::ToField.new("To: test1@lindsaar.net")
-      field.addresses.first.should == "test1@lindsaar.net"
+      field.addresses.first.should eql "test1@lindsaar.net"
     end
   
     it "should split up the address list into individual addresses" do
       field = Mail::ToField.new("To: test1@lindsaar.net, test2@lindsaar.net")
-      field.addresses.should == ["test1@lindsaar.net", "test2@lindsaar.net"]
+      field.addresses.should eql ["test1@lindsaar.net", "test2@lindsaar.net"]
     end
 
     it "should give the formatted addresses" do
       field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
-      field.formatted.should == ["Mikel <test1@lindsaar.net>", "Bob <test2@lindsaar.net>"]
+      field.formatted.should eql ["Mikel <test1@lindsaar.net>", "Bob <test2@lindsaar.net>"]
     end
 
     it "should give the display names" do
       field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
-      field.display_names.should == ["Mikel", "Bob"]
+      field.display_names.should eql ["Mikel", "Bob"]
     end
 
     it "should give the actual address objects" do
       field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
       field.addrs.each do |addr|
-        addr.class.should == Mail::Address
+        addr.class.should eql Mail::Address
       end
     end
 
     it "should handle groups as well" do
       field = Mail::ToField.new("To: test1@lindsaar.net, group: test2@lindsaar.net, me@lindsaar.net;")
-      field.addresses.should == ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
+      field.addresses.should eql ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
     end
 
     it "should provide a list of groups" do
       field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.group_names.should == ["My Group"]
+      field.group_names.should eql ["My Group"]
     end
 
     it "should provide a list of addresses per group" do
       field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.groups["My Group"].length.should == 2
-      field.groups["My Group"].first.to_s.should == 'test2@lindsaar.net'
-      field.groups["My Group"].last.to_s.should == 'me@lindsaar.net'
+      field.groups["My Group"].length.should eql 2
+      field.groups["My Group"].first.to_s.should eql 'test2@lindsaar.net'
+      field.groups["My Group"].last.to_s.should eql 'me@lindsaar.net'
     end
 
     it "should provide a list of addresses that are just in the groups" do
       field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.group_addresses.should == ['test2@lindsaar.net', 'me@lindsaar.net']
+      field.group_addresses.should eql ['test2@lindsaar.net', 'me@lindsaar.net']
     end
 
     it "should handle initializing as an empty string" do
       field = Mail::ToField.new("")
-      field.addresses.should == []
+      field.addresses.should eql []
       field.value = 'mikel@test.lindsaar.net'
-      field.addresses.should == ['mikel@test.lindsaar.net']
+      field.addresses.should eql ['mikel@test.lindsaar.net']
     end
 
     it "should encode to an empty string if it has no addresses or groups" do
       field = Mail::ToField.new("")
-      field.encoded.should == ''
+      field.encoded.should eql ''
       field.value = 'mikel@test.lindsaar.net'
-      field.encoded.should == "To: mikel@test.lindsaar.net\r\n"
+      field.encoded.should eql "To: mikel@test.lindsaar.net\r\n"
     end
 
     it "should allow you to append an address" do
       field = Mail::ToField.new("")
       field << 'mikel@test.lindsaar.net'
-      field.addresses.should == ["mikel@test.lindsaar.net"]
+      field.addresses.should eql ["mikel@test.lindsaar.net"]
     end
 
     it "should preserve the display name" do
       field = Mail::ToField.new('"Mikel Lindsaar" <mikel@test.lindsaar.net>')
-      field.display_names.should == ["Mikel Lindsaar"]
+      field.display_names.should eql ["Mikel Lindsaar"]
     end
 
     it "should handle multiple addresses" do
       field = Mail::ToField.new(['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>'])
-      field.addresses.should == ['test1@lindsaar.net', 'test2@lindsaar.net']
+      field.addresses.should eql ['test1@lindsaar.net', 'test2@lindsaar.net']
     end
 
   end
@@ -90,32 +90,32 @@ describe "Mail::CommonAddress" do
     
     it "should allow us to encode an address field" do
       field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.encoded.should == "To: test1@lindsaar.net, \r\n\sMy Group: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
+      field.encoded.should eql "To: test1@lindsaar.net, \r\n\sMy Group: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
     end
     
     it "should allow us to encode a simple address field" do
       field = Mail::ToField.new("test1@lindsaar.net")
-      field.encoded.should == "To: test1@lindsaar.net\r\n"
+      field.encoded.should eql "To: test1@lindsaar.net\r\n"
     end
     
     it "should allow us to encode an address field" do
       field = Mail::CcField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.encoded.should == "Cc: test1@lindsaar.net, \r\n\sMy Group: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
+      field.encoded.should eql "Cc: test1@lindsaar.net, \r\n\sMy Group: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
     end
 
     it "should allow us to decode an address field" do
       field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.decoded.should == "test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;"
+      field.decoded.should eql "test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;"
     end
     
     it "should allow us to decode a non ascii address field" do
       field = Mail::ToField.new("=?UTF-8?B?44G/44GR44KL?= <raasdnil@text.lindsaar.net>")
-      field.decoded.should == '"みける" <raasdnil@text.lindsaar.net>'
+      field.decoded.should eql '"みける" <raasdnil@text.lindsaar.net>'
     end
     
     it "should allow us to decode a non ascii address field" do
       field = Mail::ToField.new("=?UTF-8?B?44G/44GR44KL?= <raasdnil@text.lindsaar.net>, =?UTF-8?B?44G/44GR44KL?= <mikel@text.lindsaar.net>")
-      field.decoded.should == '"みける" <raasdnil@text.lindsaar.net>, "みける" <mikel@text.lindsaar.net>'
+      field.decoded.should eql '"みける" <raasdnil@text.lindsaar.net>, "みける" <mikel@text.lindsaar.net>'
     end
 
   end
@@ -126,7 +126,7 @@ describe "Mail::CommonAddress" do
     field.each do |address|
       addresses << address.address
     end
-    addresses.should == ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
+    addresses.should eql ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
   end
 
 end

--- a/spec/mail/fields/common/common_field_spec.rb
+++ b/spec/mail/fields/common/common_field_spec.rb
@@ -15,8 +15,8 @@ describe Mail::CommonField do
     
     it "should leave ascii alone" do
       field = Mail::SubjectField.new("This is a test")
-      field.encoded.should == "Subject: This is a test\r\n"
-      field.decoded.should == "This is a test"
+      field.encoded.should eql "Subject: This is a test\r\n"
+      field.decoded.should eql "This is a test"
     end
     
     it "should encode a utf-8 string as utf-8 quoted printable" do
@@ -29,9 +29,9 @@ describe Mail::CommonField do
         result = "Subject: =?UTF-8?Q?=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n"
       end
       field = Mail::SubjectField.new(value)
-      field.encoded.should == result
-      field.decoded.should == value
-      field.value.should == value
+      field.encoded.should eql result
+      field.decoded.should eql value
+      field.value.should eql value
     end
 
     it "should wrap an encoded at 60 characters" do
@@ -44,9 +44,9 @@ describe Mail::CommonField do
         result = "Subject: =?UTF-8?Q?=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n"
       end
       field = Mail::SubjectField.new(value)
-      field.encoded.should == result
-      field.decoded.should == value
-      field.value.should == value
+      field.encoded.should eql result
+      field.decoded.should eql value
+      field.value.should eql value
     end
   
     it "should handle charsets in assigned addresses" do
@@ -59,9 +59,9 @@ describe Mail::CommonField do
         result = "From: =?UTF-8?B?44GL44GN44GP44GR44GT?= <mikel@test.lindsaar.net>\r\n"
       end
       field = Mail::FromField.new(value)
-      field.encoded.should == result
-      field.decoded.should == value
-      field.value.should == "=?UTF-8?B?44GL44GN44GP44GR44GT?= <mikel@test.lindsaar.net>"
+      field.encoded.should eql result
+      field.decoded.should eql value
+      field.value.should eql "=?UTF-8?B?44GL44GN44GP44GR44GT?= <mikel@test.lindsaar.net>"
     end
     
   end

--- a/spec/mail/fields/common/parameter_hash_spec.rb
+++ b/spec/mail/fields/common/parameter_hash_spec.rb
@@ -14,32 +14,32 @@ describe Mail::ParameterHash do
   it "should return the values in the hash regardless of symbol or string" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'value2' => 'two'})
-    hash['value1'].should == 'one'
-    hash['value2'].should == 'two'
-    hash[:value1].should == 'one'
-    hash[:value2].should == 'two'
+    hash['value1'].should eql 'one'
+    hash['value2'].should eql 'two'
+    hash[:value1].should eql 'one'
+    hash[:value2].should eql 'two'
   end
 
   it "should return the values in the hash using case-insensitive key matching" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'VALUE2' => 'two'})
-    hash['VALUE1'].should == 'one'
-    hash['vAlUe2'].should == 'two'
-    hash[:VaLuE1].should == 'one'
-    hash[:value2].should == 'two'
+    hash['VALUE1'].should eql 'one'
+    hash['vAlUe2'].should eql 'two'
+    hash[:VaLuE1].should eql 'one'
+    hash[:value2].should eql 'two'
   end
 
   it "should return the correct value if they are not encoded" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'value2' => 'two'})
-    hash['value1'].should == 'one'
-    hash['value2'].should == 'two'
+    hash['value1'].should eql 'one'
+    hash['value2'].should eql 'two'
   end
 
   it "should return a name list concatenated" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value*1' => 'one', 'value*2' => 'two'})
-    hash['value'].should == 'onetwo'
+    hash['value'].should eql 'onetwo'
   end
 
   it "should return a name list concatenated and unencoded" do
@@ -47,13 +47,13 @@ describe Mail::ParameterHash do
     hash.merge!({'value*0*' => "us-ascii'en'This%20is%20even%20more%20",
                  'value*1*' => "%2A%2A%2Afun%2A%2A%2A%20",
                  'value*2'  => "isn't it"})
-    hash['value'].should == "This is even more ***fun*** isn't it"
+    hash['value'].should eql "This is even more ***fun*** isn't it"
   end
 
   it "should allow us to add a value" do
     hash = Mail::ParameterHash.new
     hash['value'] = 'bob'
-    hash['value'].should == 'bob'
+    hash['value'].should eql 'bob'
   end
 
   it "should return an encoded value" do
@@ -61,7 +61,7 @@ describe Mail::ParameterHash do
     hash.merge!({'value*0*' => "us-ascii'en'This%20is%20even%20more%20",
                  'value*1*' => "%2A%2A%2Afun%2A%2A%2A%20",
                  'value*2'  => "isn't it"})
-    hash.encoded.should == %Q{value*0*=us-ascii'en'This%20is%20even%20more%20;\r\n\svalue*1*=%2A%2A%2Afun%2A%2A%2A%20;\r\n\svalue*2="isn't it"}
+    hash.encoded.should eql %Q{value*0*=us-ascii'en'This%20is%20even%20more%20;\r\n\svalue*1*=%2A%2A%2Afun%2A%2A%2A%20;\r\n\svalue*2="isn't it"}
   end
 
 end

--- a/spec/mail/fields/content_description_field_spec.rb
+++ b/spec/mail/fields/content_description_field_spec.rb
@@ -24,14 +24,14 @@ describe Mail::ContentDescriptionField do
 
     it "should accept a string with the field name" do
       t = Mail::ContentDescriptionField.new('Content-Description: This is a description')
-      t.name.should == 'Content-Description'
-      t.value.should == 'This is a description'
+      t.name.should eql 'Content-Description'
+      t.value.should eql 'This is a description'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ContentDescriptionField.new('This is a description')
-      t.name.should == 'Content-Description'
-      t.value.should == 'This is a description'
+      t.name.should eql 'Content-Description'
+      t.value.should eql 'This is a description'
     end
 
   end

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -10,55 +10,55 @@ describe Mail::ContentDispositionField do
 
     it "should accept a string with the field name" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      c.name.should == 'Content-Disposition'
-      c.value.should == 'attachment; filename=File'
+      c.name.should eql 'Content-Disposition'
+      c.value.should eql 'attachment; filename=File'
     end
 
     it "should accept a string without the field name" do
       c = Mail::ContentDispositionField.new('attachment; filename=File')
-      c.name.should == 'Content-Disposition'
-      c.value.should == 'attachment; filename=File'
+      c.name.should eql 'Content-Disposition'
+      c.value.should eql 'attachment; filename=File'
     end
 
     it "should accept a nil value and generate a disposition type" do
       c = Mail::ContentDispositionField.new(nil)
-      c.name.should == 'Content-Disposition'
+      c.name.should eql 'Content-Disposition'
       c.value.should_not be_nil
     end
 
     it "should render encoded" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      c.encoded.should == "Content-Disposition: attachment;\r\n\sfilename=File\r\n"
+      c.encoded.should eql "Content-Disposition: attachment;\r\n\sfilename=File\r\n"
     end
 
     it "should render encoded for inline" do
       c = Mail::ContentDispositionField.new('Content-Disposition: inline')
-      c.encoded.should == "Content-Disposition: inline\r\n"
+      c.encoded.should eql "Content-Disposition: inline\r\n"
     end
 
     it "should render decoded" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      c.decoded.should == 'attachment; filename=File'
+      c.decoded.should eql 'attachment; filename=File'
     end
 
     it "should render decoded inline" do
       c = Mail::ContentDispositionField.new('Content-Disposition: inline')
-      c.decoded.should == 'inline'
+      c.decoded.should eql 'inline'
     end
 
     it "should handle upper and mixed case INLINE and AttachMent" do
       c = Mail::ContentDispositionField.new('Content-Disposition: INLINE')
-      c.decoded.should == 'inline'
+      c.decoded.should eql 'inline'
       c = Mail::ContentDispositionField.new('Content-Disposition: AttachMent')
-      c.decoded.should == 'attachment'
+      c.decoded.should eql 'attachment'
     end
   end
 
   describe "instance methods" do
     it "should give it's disposition type" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      c.disposition_type.should == 'attachment'
-      c.parameters.should == {"filename" => 'File'}
+      c.disposition_type.should eql 'attachment'
+      c.parameters.should eql({"filename" => 'File'})
     end
 
     # see spec/fixtures/trec_2005_corpus/missing_content_disposition.eml

--- a/spec/mail/fields/content_id_field_spec.rb
+++ b/spec/mail/fields/content_id_field_spec.rb
@@ -35,32 +35,32 @@ describe Mail::ContentIdField do
 
     it "should accept a string with the field name" do
       c = Mail::ContentIdField.new('Content-ID: <1234@test.lindsaar.net>')
-      c.name.should == 'Content-ID'
-      c.value.should == '<1234@test.lindsaar.net>'
-      c.content_id.should == '1234@test.lindsaar.net'
+      c.name.should eql 'Content-ID'
+      c.value.should eql '<1234@test.lindsaar.net>'
+      c.content_id.should eql '1234@test.lindsaar.net'
     end
 
     it "should accept a string without the field name" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.name.should == 'Content-ID'
-      m.value.should == '<1234@test.lindsaar.net>'
-      m.content_id.should == '1234@test.lindsaar.net'
+      m.name.should eql 'Content-ID'
+      m.value.should eql '<1234@test.lindsaar.net>'
+      m.content_id.should eql '1234@test.lindsaar.net'
     end
 
     it "should accept a nil value and generate a content_id" do
       m = Mail::ContentIdField.new(nil)
-      m.name.should == 'Content-ID'
+      m.name.should eql 'Content-ID'
       m.value.should_not be_nil
     end
 
     it "should allow it to be encoded" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.encoded.should == "Content-ID: <1234@test.lindsaar.net>\r\n"
+      m.encoded.should eql "Content-ID: <1234@test.lindsaar.net>\r\n"
     end
 
     it "should allow it to be decoded" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.decoded.should == "<1234@test.lindsaar.net>"
+      m.decoded.should eql "<1234@test.lindsaar.net>"
     end
 
   end
@@ -69,16 +69,16 @@ describe Mail::ContentIdField do
 
     it "should not accept a string with multiple message IDs but only return the first" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      m.name.should == 'Content-ID'
-      m.to_s.should == '<1234@test.lindsaar.net>'
-      m.content_id.should == '1234@test.lindsaar.net'
+      m.name.should eql 'Content-ID'
+      m.to_s.should eql '<1234@test.lindsaar.net>'
+      m.content_id.should eql '1234@test.lindsaar.net'
     end
 
     it "should change the message id if given a new message id" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.to_s.should == '<1234@test.lindsaar.net>'
+      m.to_s.should eql '<1234@test.lindsaar.net>'
       m.value = '<4567@test.lindsaar.net>'
-      m.to_s.should == '<4567@test.lindsaar.net>'
+      m.to_s.should eql '<4567@test.lindsaar.net>'
     end
 
   end
@@ -86,13 +86,13 @@ describe Mail::ContentIdField do
   describe "instance methods" do
     it "should provide to_s" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.to_s.should == '<1234@test.lindsaar.net>'
-      m.content_id.to_s.should == '1234@test.lindsaar.net'
+      m.to_s.should eql '<1234@test.lindsaar.net>'
+      m.content_id.to_s.should eql '1234@test.lindsaar.net'
     end
 
     it "should provide encoded" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.encoded.should == "Content-ID: <1234@test.lindsaar.net>\r\n"
+      m.encoded.should eql "Content-ID: <1234@test.lindsaar.net>\r\n"
     end
     
     it "should respond to :responsible_for?" do

--- a/spec/mail/fields/content_location_field_spec.rb
+++ b/spec/mail/fields/content_location_field_spec.rb
@@ -12,24 +12,24 @@ describe Mail::ContentLocationField do
 
     it "should accept a string with the field name" do
       t = Mail::ContentLocationField.new('Content-Location: photo.jpg')
-      t.name.should == 'Content-Location'
-      t.value.should == 'photo.jpg'
+      t.name.should eql 'Content-Location'
+      t.value.should eql 'photo.jpg'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ContentLocationField.new('photo.jpg')
-      t.name.should == 'Content-Location'
-      t.value.should == 'photo.jpg'
+      t.name.should eql 'Content-Location'
+      t.value.should eql 'photo.jpg'
     end
 
     it "should render an encoded field" do
       t = Mail::ContentLocationField.new('photo.jpg')
-      t.encoded.should == "Content-Location: photo.jpg\r\n"
+      t.encoded.should eql "Content-Location: photo.jpg\r\n"
     end
 
     it "should render a decoded field" do
       t = Mail::ContentLocationField.new('photo.jpg')
-      t.decoded.should == 'photo.jpg'
+      t.decoded.should eql 'photo.jpg'
     end
 
   end
@@ -38,7 +38,7 @@ describe Mail::ContentLocationField do
     
     it "should return an encoding string unquoted" do
       t = Mail::ContentLocationField.new('"A quoted filename.jpg"')
-      t.location.should == 'A quoted filename.jpg'
+      t.location.should eql 'A quoted filename.jpg'
     end
     
   end

--- a/spec/mail/fields/content_transfer_encoding_field_spec.rb
+++ b/spec/mail/fields/content_transfer_encoding_field_spec.rb
@@ -45,24 +45,24 @@ describe Mail::ContentTransferEncodingField do
 
     it "should accept a string with the field name" do
       t = Mail::ContentTransferEncodingField.new('Content-Transfer-Encoding: 7bit')
-      t.name.should == 'Content-Transfer-Encoding'
-      t.value.should == '7bit'
+      t.name.should eql 'Content-Transfer-Encoding'
+      t.value.should eql '7bit'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ContentTransferEncodingField.new('7bit')
-      t.name.should == 'Content-Transfer-Encoding'
-      t.value.should == '7bit'
+      t.name.should eql 'Content-Transfer-Encoding'
+      t.value.should eql '7bit'
     end
 
     it "should render an encoded field" do
       t = Mail::ContentTransferEncodingField.new('7bit')
-      t.encoded.should == "Content-Transfer-Encoding: 7bit\r\n"
+      t.encoded.should eql "Content-Transfer-Encoding: 7bit\r\n"
     end
 
     it "should render a decoded field" do
       t = Mail::ContentTransferEncodingField.new('7bit')
-      t.decoded.should == '7bit'
+      t.decoded.should eql '7bit'
     end
 
   end
@@ -72,24 +72,24 @@ describe Mail::ContentTransferEncodingField do
     it "should return an encoding string" do
       ["7bit", "8bit", "binary", 'quoted-printable', "base64"].each do |encoding|
         t = Mail::ContentTransferEncodingField.new(encoding)
-        t.encoding.should == encoding
+        t.encoding.should eql encoding
       end
     end
     
     it "should handle any valid 'x-token' value" do
       t = Mail::ContentTransferEncodingField.new('X-This-is_MY-encoding')
-      t.encoding.should == 'x-this-is_my-encoding'
+      t.encoding.should eql 'x-this-is_my-encoding'
     end
     
     it "should handle an x-encoding" do
       t = Mail::ContentTransferEncodingField.new("x-uuencode")
-      t.encoding.should == "x-uuencode"
+      t.encoding.should eql "x-uuencode"
     end
 
     it "should replace the existing value" do
       t = Mail::ContentTransferEncodingField.new("7bit")
       t.parse("quoted-printable")
-      t.encoding.should == 'quoted-printable'
+      t.encoding.should eql 'quoted-printable'
     end
 
     it "should raise an error on bogus values" do
@@ -98,14 +98,14 @@ describe Mail::ContentTransferEncodingField do
     
     it "should handle an empty content transfer encoding" do
       t = Mail::ContentTransferEncodingField.new("")
-      t.encoding.should == ""
+      t.encoding.should eql ""
     end
 
     it "should handle a hyphen" do
       t = Mail::ContentTransferEncodingField.new('7-bit')
-      t.decoded.should == '7bit'
+      t.decoded.should eql '7bit'
       t = Mail::ContentTransferEncodingField.new('8-bit')
-      t.decoded.should == '8bit'
+      t.decoded.should eql '8bit'
     end
 
   end

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -76,94 +76,94 @@ describe Mail::ContentTypeField do
 
     it "should accept a string with the field name" do
       c = Mail::ContentTypeField.new('Content-Type: text/plain')
-      c.name.should == 'Content-Type'
-      c.value.should == 'text/plain'
+      c.name.should eql 'Content-Type'
+      c.value.should eql 'text/plain'
     end
 
     it "should accept a string without the field name" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.name.should == 'Content-Type'
-      c.value.should == 'text/plain'
+      c.name.should eql 'Content-Type'
+      c.value.should eql 'text/plain'
     end
 
     it "should accept a nil value and generate a content_type" do
       c = Mail::ContentTypeField.new('Content-Type', nil)
-      c.name.should == 'Content-Type'
+      c.name.should eql 'Content-Type'
       c.value.should_not be_nil
     end
 
     it "should render encoded" do
       c = Mail::ContentTypeField.new('Content-Type: text/plain')
-      c.encoded.should == "Content-Type: text/plain\r\n"
+      c.encoded.should eql "Content-Type: text/plain\r\n"
     end
 
     it "should render encoded with parameters" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII; format=flowed')
-      c.encoded.should == %Q{Content-Type: text/plain;\r\n\scharset=US-ASCII;\r\n\sformat=flowed\r\n}
+      c.encoded.should eql %Q{Content-Type: text/plain;\r\n\scharset=US-ASCII;\r\n\sformat=flowed\r\n}
     end
 
     it "should render quoted values encoded" do
       c = Mail::ContentTypeField.new('text/plain; example="foo bar"')
-      c.encoded.should == %Q{Content-Type: text/plain;\r\n\sexample="foo bar"\r\n}
+      c.encoded.should eql %Q{Content-Type: text/plain;\r\n\sexample="foo bar"\r\n}
     end
 
     it "should render decoded" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII; format=flowed')
-      c.decoded.should == 'text/plain; charset=US-ASCII; format=flowed'
+      c.decoded.should eql 'text/plain; charset=US-ASCII; format=flowed'
     end
 
     it "should render quoted values decoded" do
       c = Mail::ContentTypeField.new('text/plain; example="foo bar"')
-      c.decoded.should == 'text/plain; example="foo bar"'
+      c.decoded.should eql 'text/plain; example="foo bar"'
     end
 
     it "should render " do
       c = Mail::ContentTypeField.new('message/delivery-status')
-      c.main_type.should == 'message'
-      c.sub_type.should == 'delivery-status'
+      c.main_type.should eql 'message'
+      c.sub_type.should eql 'delivery-status'
     end
   end
 
   describe "instance methods" do
     it "should return a content_type" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.content_type.should == 'text/plain'
+      c.content_type.should eql 'text/plain'
     end
 
     it "should return a content_type for the :string method" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.string.should == 'text/plain'
+      c.string.should eql 'text/plain'
     end
 
     it "should return a main_type" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.main_type.should == 'text'
+      c.main_type.should eql 'text'
     end
 
     it "should return a sub_type" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.main_type.should == 'text'
+      c.main_type.should eql 'text'
     end
 
     it "should return a parameter as a hash" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII')
-      c.parameters.should == {"charset" => 'US-ASCII'}
+      c.parameters.should eql({"charset" => 'US-ASCII'})
     end
 
     it "should return multiple parameters as a hash" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII; format=flowed')
-      c.parameters.should == {"charset" => 'US-ASCII', "format" => 'flowed'}
+      c.parameters.should eql({"charset" => 'US-ASCII', "format" => 'flowed'})
     end
 
     it "should return boundry parameters" do
       c = Mail::ContentTypeField.new('multipart/mixed; boundary=Apple-Mail-13-196941151')
-      c.parameters.should == {"boundary" => 'Apple-Mail-13-196941151'}
+      c.parameters.should eql({"boundary" => 'Apple-Mail-13-196941151'})
     end
 
     it "should be indifferent with the access" do
       c = Mail::ContentTypeField.new('multipart/mixed; boundary=Apple')
-      c.parameters[:boundary].should == "Apple"
-      c.parameters['boundary'].should == "Apple"
+      c.parameters[:boundary].should eql "Apple"
+      c.parameters['boundary'].should eql "Apple"
     end
 
   end
@@ -194,388 +194,388 @@ describe Mail::ContentTypeField do
     it "should handle 'application/octet-stream; name*=iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3'" do
       string = %q{application/octet-stream; name*=iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'application/octet-stream'
-      c.main_type.should == 'application'
-      c.sub_type.should == 'octet-stream'
-      c.parameters.should == {'name*' => "iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3"}
+      c.content_type.should eql 'application/octet-stream'
+      c.main_type.should eql 'application'
+      c.sub_type.should eql 'octet-stream'
+      c.parameters.should eql({'name*' => "iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3"})
     end
 
     it "should handle 'application/pdf;'" do
       string = %q{application/pdf;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'application/pdf'
-      c.main_type.should == 'application'
-      c.sub_type.should == 'pdf'
-      c.parameters.should == {}
+      c.content_type.should eql 'application/pdf'
+      c.main_type.should eql 'application'
+      c.sub_type.should eql 'pdf'
+      c.parameters.should eql({})
     end
 
     it "should handle 'application/pdf; name=\"broken.pdf\"'" do
       string = %q{application/pdf; name="broken.pdf"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'application/pdf'
-      c.main_type.should == 'application'
-      c.sub_type.should == 'pdf'
-      c.parameters.should == {"name" => "broken.pdf"}
+      c.content_type.should eql 'application/pdf'
+      c.main_type.should eql 'application'
+      c.sub_type.should eql 'pdf'
+      c.parameters.should eql({"name" => "broken.pdf"})
     end
 
     it "should handle 'application/pkcs7-signature;'" do
       string = %q{application/pkcs7-signature;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'application/pkcs7-signature'
-      c.main_type.should == 'application'
-      c.sub_type.should == 'pkcs7-signature'
-      c.parameters.should == {}
+      c.content_type.should eql 'application/pkcs7-signature'
+      c.main_type.should eql 'application'
+      c.sub_type.should eql 'pkcs7-signature'
+      c.parameters.should eql({})
     end
 
     it "should handle 'application/pkcs7-signature; name=smime.p7s'" do
       string = %q{application/pkcs7-signature; name=smime.p7s}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'application/pkcs7-signature'
-      c.main_type.should == 'application'
-      c.sub_type.should == 'pkcs7-signature'
-      c.parameters.should == {"name" => "smime.p7s"}
+      c.content_type.should eql 'application/pkcs7-signature'
+      c.main_type.should eql 'application'
+      c.sub_type.should eql 'pkcs7-signature'
+      c.parameters.should eql({"name" => "smime.p7s"})
     end
 
     it "should handle 'application/x-gzip; NAME=blah.gz'" do
       string = %q{application/x-gzip; NAME=blah.gz}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'application/x-gzip'
-      c.main_type.should == 'application'
-      c.sub_type.should == 'x-gzip'
-      c.parameters.should == {"NAME" => "blah.gz"}
+      c.content_type.should eql 'application/x-gzip'
+      c.main_type.should eql 'application'
+      c.sub_type.should eql 'x-gzip'
+      c.parameters.should eql({"NAME" => "blah.gz"})
     end
 
     it "should handle 'image/jpeg'" do
       string = %q{image/jpeg}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'image/jpeg'
-      c.main_type.should == 'image'
-      c.sub_type.should == 'jpeg'
-      c.parameters.should == {}
+      c.content_type.should eql 'image/jpeg'
+      c.main_type.should eql 'image'
+      c.sub_type.should eql 'jpeg'
+      c.parameters.should eql({})
     end
 
     it "should handle 'image/jpeg'" do
       string = %q{image/jpeg}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'image/jpeg'
-      c.main_type.should == 'image'
-      c.sub_type.should == 'jpeg'
-      c.parameters.should == {}
+      c.content_type.should eql 'image/jpeg'
+      c.main_type.should eql 'image'
+      c.sub_type.should eql 'jpeg'
+      c.parameters.should eql({})
     end
 
     it "should handle 'image/jpeg;'" do
       string = %q{image/jpeg}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'image/jpeg'
-      c.main_type.should == 'image'
-      c.sub_type.should == 'jpeg'
-      c.parameters.should == {}
+      c.content_type.should eql 'image/jpeg'
+      c.main_type.should eql 'image'
+      c.sub_type.should eql 'jpeg'
+      c.parameters.should eql({})
     end
 
     it "should handle 'image/png;'" do
       string = %q{image/png}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'image/png'
-      c.main_type.should == 'image'
-      c.sub_type.should == 'png'
-      c.parameters.should == {}
+      c.content_type.should eql 'image/png'
+      c.main_type.should eql 'image'
+      c.sub_type.should eql 'png'
+      c.parameters.should eql({})
     end
 
     it "should handle 'message/delivery-status'" do
       string = %q{message/delivery-status}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'message/delivery-status'
-      c.main_type.should == 'message'
-      c.sub_type.should == 'delivery-status'
-      c.parameters.should == {}
+      c.content_type.should eql 'message/delivery-status'
+      c.main_type.should eql 'message'
+      c.sub_type.should eql 'delivery-status'
+      c.parameters.should eql({})
     end
 
     it "should handle 'message/rfc822'" do
       string = %q{message/rfc822}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'message/rfc822'
-      c.main_type.should == 'message'
-      c.sub_type.should == 'rfc822'
-      c.parameters.should == {}
+      c.content_type.should eql 'message/rfc822'
+      c.main_type.should eql 'message'
+      c.sub_type.should eql 'rfc822'
+      c.parameters.should eql({})
     end
 
     it "should handle 'multipart/alternative;'" do
       string = %q{multipart/alternative;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/alternative'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'alternative'
-      c.parameters.should == {}
+      c.content_type.should eql 'multipart/alternative'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'alternative'
+      c.parameters.should eql({})
     end
 
     it "should handle 'multipart/alternative; boundary=\"----=_NextPart_000_0093_01C81419.EB75E850\"'" do
       string = %q{multipart/alternative; boundary="----=_NextPart_000_0093_01C81419.EB75E850"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/alternative'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"}
+      c.content_type.should eql 'multipart/alternative'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'alternative'
+      c.parameters.should eql({"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"})
     end
 
     it "should handle 'multipart/alternative; boundary=----=_NextPart_000_0093_01C81419.EB75E850'" do
       string = %q{multipart/alternative; boundary="----=_NextPart_000_0093_01C81419.EB75E850"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/alternative'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"}
+      c.content_type.should eql 'multipart/alternative'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'alternative'
+      c.parameters.should eql({"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"})
     end
 
     it "should handle 'Multipart/Alternative;boundary=MuLtIpArT_BoUnDaRy'" do
       string = %q{Multipart/Alternative; boundary=MuLtIpArT_BoUnDaRy}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/alternative'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" =>"MuLtIpArT_BoUnDaRy"}
+      c.content_type.should eql 'multipart/alternative'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'alternative'
+      c.parameters.should eql({"boundary" =>"MuLtIpArT_BoUnDaRy"})
     end
 
     it "should handle 'Multipart/Alternative;boundary=MuLtIpArT_BoUnDaRy'" do
       string = %q{Multipart/Alternative;boundary=MuLtIpArT_BoUnDaRy}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/alternative'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" =>"MuLtIpArT_BoUnDaRy"}
+      c.content_type.should eql 'multipart/alternative'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'alternative'
+      c.parameters.should eql({"boundary" =>"MuLtIpArT_BoUnDaRy"})
     end
 
     it "should handle 'multipart/mixed'" do
       string = %q{multipart/mixed}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/mixed'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'mixed'
-      c.parameters.should == {}
+      c.content_type.should eql 'multipart/mixed'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'mixed'
+      c.parameters.should eql({})
     end
 
     it "should handle 'multipart/mixed;'" do
       string = %q{multipart/mixed;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/mixed'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'mixed'
-      c.parameters.should == {}
+      c.content_type.should eql 'multipart/mixed'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'mixed'
+      c.parameters.should eql({})
     end
 
     it "should handle 'multipart/mixed; boundary=Apple-Mail-13-196941151'" do
       string = %q{multipart/mixed; boundary=Apple-Mail-13-196941151}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/mixed'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'mixed'
-      c.parameters.should == {"boundary" => "Apple-Mail-13-196941151"}
+      c.content_type.should eql 'multipart/mixed'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'mixed'
+      c.parameters.should eql({"boundary" => "Apple-Mail-13-196941151"})
     end
 
     it "should handle 'multipart/mixed; boundary=mimepart_427e4cb4ca329_133ae40413c81ef'" do
       string = %q{multipart/mixed; boundary=mimepart_427e4cb4ca329_133ae40413c81ef}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/mixed'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'mixed'
-      c.parameters.should == {"boundary" => "mimepart_427e4cb4ca329_133ae40413c81ef"}
+      c.content_type.should eql 'multipart/mixed'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'mixed'
+      c.parameters.should eql({"boundary" => "mimepart_427e4cb4ca329_133ae40413c81ef"})
     end
 
     it "should handle 'multipart/report; report-type=delivery-status;'" do
       string = %q{multipart/report; report-type=delivery-status;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/report'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'report'
-      c.parameters.should == {"report-type" => "delivery-status"}
+      c.content_type.should eql 'multipart/report'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'report'
+      c.parameters.should eql({"report-type" => "delivery-status"})
     end
 
     it "should handle 'multipart/signed;'" do
       string = %q{multipart/signed;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/signed'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'signed'
-      c.parameters.should == {}
+      c.content_type.should eql 'multipart/signed'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'signed'
+      c.parameters.should eql({})
     end
 
     it "should handle 'text/enriched;'" do
       string = %q{text/enriched;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/enriched'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'enriched'
-      c.parameters.should == {}
+      c.content_type.should eql 'text/enriched'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'enriched'
+      c.parameters.should eql({})
     end
 
     it "should handle 'text/html;'" do
       string = %q{text/html;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/html'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'html'
-      c.parameters.should == {}
+      c.content_type.should eql 'text/html'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'html'
+      c.parameters.should eql({})
     end
 
     it "should handle 'text/html; charset=iso-8859-1;'" do
       string = %q{text/html; charset=iso-8859-1;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/html'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'html'
-      c.parameters.should == {"charset" => 'iso-8859-1'}
+      c.content_type.should eql 'text/html'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'html'
+      c.parameters.should eql({"charset" => 'iso-8859-1'})
     end
 
     it "should handle 'TEXT/PLAIN; charset=ISO-8859-1;'" do
       string = %q{TEXT/PLAIN; charset=ISO-8859-1;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {"charset" => 'ISO-8859-1'}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({"charset" => 'ISO-8859-1'})
     end
 
     it "should handle 'text/plain'" do
       string = %q{text/plain}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({})
     end
 
     it "should handle 'text/plain;'" do
       string = %q{text/plain;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({})
     end
 
     it "should handle 'text/plain; charset=ISO-8859-1'" do
       string = %q{text/plain; charset=ISO-8859-1}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {"charset" => 'ISO-8859-1'}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({"charset" => 'ISO-8859-1'})
     end
 
     it "should handle 'text/plain; charset=ISO-8859-1;'" do
       string = %q{text/plain; charset=ISO-8859-1; format=flowed}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {"charset" => 'ISO-8859-1', "format" => 'flowed'}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({"charset" => 'ISO-8859-1', "format" => 'flowed'})
     end
 
     it "should handle 'text/plain; charset=us-ascii;'" do
       string = %q{text/plain; charset=us-ascii}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {"charset" => 'us-ascii'}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({"charset" => 'us-ascii'})
     end
 
     it "should handle 'text/plain; charset=US-ASCII; format=flowed'" do
       string = %q{text/plain; charset=US-ASCII; format=flowed}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {"charset" => 'US-ASCII', "format" => 'flowed'}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({"charset" => 'US-ASCII', "format" => 'flowed'})
     end
 
     it "should handle 'text/plain; charset=US-ASCII; format=flowed'" do
       string = %q{text/plain; charset=US-ASCII; format=flowed}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {"charset" => 'US-ASCII', "format" => 'flowed'}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({"charset" => 'US-ASCII', "format" => 'flowed'})
     end
 
     it "should handle 'text/plain; charset=utf-8'" do
       string = %q{text/plain; charset=utf-8}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {"charset" => 'utf-8'}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({"charset" => 'utf-8'})
     end
 
     it "should handle 'text/plain; charset=utf-8'" do
       string = %q{text/plain; charset=X-UNKNOWN}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/plain'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'plain'
-      c.parameters.should == {"charset" => 'X-UNKNOWN'}
+      c.content_type.should eql 'text/plain'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'plain'
+      c.parameters.should eql({"charset" => 'X-UNKNOWN'})
     end
 
     it "should handle 'text/x-ruby-script;'" do
       string = %q{text/x-ruby-script;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/x-ruby-script'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'x-ruby-script'
-      c.parameters.should == {}
+      c.content_type.should eql 'text/x-ruby-script'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'x-ruby-script'
+      c.parameters.should eql({})
     end
 
     it "should handle 'text/x-ruby-script; name=\"hello.rb\"'" do
       string = %q{text/x-ruby-script; name="hello.rb"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'text/x-ruby-script'
-      c.main_type.should == 'text'
-      c.sub_type.should == 'x-ruby-script'
-      c.parameters.should == {"name" => 'hello.rb'}
+      c.content_type.should eql 'text/x-ruby-script'
+      c.main_type.should eql 'text'
+      c.sub_type.should eql 'x-ruby-script'
+      c.parameters.should eql({"name" => 'hello.rb'})
     end
 
     it "should handle 'multipart/mixed; boundary=\"=_NextPart_Lycos_15031600484464_ID\"" do
       string = %q{multipart/mixed; boundary="=_NextPart_Lycos_15031600484464_ID"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/mixed'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'mixed'
-      c.parameters.should == {"boundary" => '=_NextPart_Lycos_15031600484464_ID'}
+      c.content_type.should eql 'multipart/mixed'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'mixed'
+      c.parameters.should eql({"boundary" => '=_NextPart_Lycos_15031600484464_ID'})
     end
 
     it "should handle 'multipart/alternative; boundary=----=_=NextPart_000_0093_01C81419.EB75E850" do
       string = %q{multipart/alternative; boundary=----=_=NextPart_000_0093_01C81419.EB75E850}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/alternative'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" => '----=_=NextPart_000_0093_01C81419.EB75E850'}
+      c.content_type.should eql 'multipart/alternative'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'alternative'
+      c.parameters.should eql({"boundary" => '----=_=NextPart_000_0093_01C81419.EB75E850'})
     end
 
     it "should handle 'multipart/alternative; boundary=\"----=_=NextPart_000_0093_01C81419.EB75E850\"" do
       string = %q{multipart/alternative; boundary="----=_=NextPart_000_0093_01C81419.EB75E850"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/alternative'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'alternative'
-      c.parameters.should == {"boundary" => '----=_=NextPart_000_0093_01C81419.EB75E850'}
+      c.content_type.should eql 'multipart/alternative'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'alternative'
+      c.parameters.should eql({"boundary" => '----=_=NextPart_000_0093_01C81419.EB75E850'})
     end
 
     it "should handle 'multipart/related;boundary=1_4626B816_9F1690;Type=\"application/smil\";Start=\"<mms.smil.txt>\"'" do
       string = %q{multipart/related;boundary=1_4626B816_9F1690;Type="application/smil";Start="<mms.smil.txt>"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'multipart/related'
-      c.main_type.should == 'multipart'
-      c.sub_type.should == 'related'
-      c.parameters.should == {"boundary" => '1_4626B816_9F1690', "Type" => 'application/smil', "Start" => '<mms.smil.txt>'}
+      c.content_type.should eql 'multipart/related'
+      c.main_type.should eql 'multipart'
+      c.sub_type.should eql 'related'
+      c.parameters.should eql({"boundary" => '1_4626B816_9F1690', "Type" => 'application/smil', "Start" => '<mms.smil.txt>'})
     end
 
     it "should handle 'IMAGE/JPEG; name=\"IM 006.jpg\"'" do
       string = %q{IMAGE/JPEG; name="IM 006.jpg"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should == 'image/jpeg'
-      c.main_type.should == 'image'
-      c.sub_type.should == 'jpeg'
-      c.parameters.should == {"name" => "IM 006.jpg"}
+      c.content_type.should eql 'image/jpeg'
+      c.main_type.should eql 'image'
+      c.sub_type.should eql 'jpeg'
+      c.parameters.should eql({"name" => "IM 006.jpg"})
     end
 
   end
@@ -585,13 +585,13 @@ describe Mail::ContentTypeField do
     it "should locate a filename if there is a filename" do
       string = %q{application/octet-stream; filename=mikel.jpg}
       c = Mail::ContentTypeField.new(string)
-      c.filename.should == 'mikel.jpg'
+      c.filename.should eql 'mikel.jpg'
     end
 
     it "should locate a name if there is no filename" do
       string = %q{application/octet-stream; name=mikel.jpg}
       c = Mail::ContentTypeField.new(string)
-      c.filename.should == 'mikel.jpg'
+      c.filename.should eql 'mikel.jpg'
     end
 
     it "should locate an encoded name as a filename" do
@@ -604,7 +604,7 @@ describe Mail::ContentTypeField do
         expected = "01 Quien Te Dij\221at. Pitbull.mp3"
         result = c.filename
       end
-      expected.should == result
+      expected.should eql result
     end
 
     it "should encode a non us-ascii filename" do
@@ -623,8 +623,8 @@ describe Mail::ContentTypeField do
         result = %Q{Content-Type: application/octet-stream;\r\n\sfilename*=sjis'jp'01%20Quien%20Te%20Dij%91at.%20Pitbull.mp3\r\n}
       end
       c.filename = string
-      c.parameters.should == {"filename" => string}
-      c.encoded.should == result
+      c.parameters.should eql({"filename" => string})
+      c.encoded.should eql result
       $KCODE = @original if RUBY_VERSION < '1.9'
     end
 
@@ -634,13 +634,13 @@ describe Mail::ContentTypeField do
 
     it "should handle missing sub-type on a text content type" do
       c = Mail::ContentTypeField.new('Content-Type: text')
-      c.content_type.should == 'text/plain'
+      c.content_type.should eql 'text/plain'
     end
 
     it "should handle missing ; after content-type" do
       c = Mail::ContentTypeField.new('Content-Type: multipart/mixed boundary="----=_NextPart_000_000F_01C17754.8C3CAF30"')
-      c.content_type.should == 'multipart/mixed'
-      c.parameters['boundary'].should == '----=_NextPart_000_000F_01C17754.8C3CAF30'
+      c.content_type.should eql 'multipart/mixed'
+      c.parameters['boundary'].should eql '----=_NextPart_000_000F_01C17754.8C3CAF30'
     end
 
   end
@@ -648,70 +648,70 @@ describe Mail::ContentTypeField do
   describe "initializing with an array" do
     it "should initialize with an array" do
       c = Mail::ContentTypeField.new(['text', 'html', {'charset' => 'UTF-8'}])
-      c.content_type.should == 'text/html'
-      c.parameters['charset'].should == 'UTF-8'
+      c.content_type.should eql 'text/html'
+      c.parameters['charset'].should eql 'UTF-8'
     end
 
     it "should allow many parameters to be passed in" do
       c = Mail::ContentTypeField.new(['text', 'html', {"format"=>"flowed", "charset"=>"utf-8"}])
-      c.content_type.should == 'text/html'
-      c.parameters['charset'].should == 'utf-8'
-      c.parameters['format'].should == 'flowed'
+      c.content_type.should eql 'text/html'
+      c.parameters['charset'].should eql 'utf-8'
+      c.parameters['format'].should eql 'flowed'
     end
   end
 
   describe "special case values needing sanity" do
     it "should handle 'text/plain;ISO-8559-1'" do
       c = Mail::ContentTypeField.new('text/plain;ISO-8559-1')
-      c.string.should == 'text/plain'
-      c.parameters['charset'].should == 'iso-8559-1'
+      c.string.should eql 'text/plain'
+      c.parameters['charset'].should eql 'iso-8559-1'
     end
 
     it "should handle text; params" do
       c = Mail::ContentTypeField.new('text; charset=utf-8')
-      c.string.should == 'text/plain'
-      c.parameters['charset'].should == 'utf-8'
+      c.string.should eql 'text/plain'
+      c.parameters['charset'].should eql 'utf-8'
     end
 
     it 'should handle text/html; charset="charset="GB2312""' do
       c = Mail::ContentTypeField.new('text/html; charset="charset="GB2312""')
-      c.string.should == 'text/html'
-      c.parameters['charset'].should == 'gb2312'
+      c.string.should eql 'text/html'
+      c.parameters['charset'].should eql 'gb2312'
     end
 
     it "should handle application/octet-stream; name=archiveshelp1[1].htm" do
       c = Mail::ContentTypeField.new('application/octet-stream; name=archiveshelp1[1].htm')
-      c.string.should == 'application/octet-stream'
-      c.parameters['name'].should == 'archiveshelp1[1].htm'
+      c.string.should eql 'application/octet-stream'
+      c.parameters['name'].should eql 'archiveshelp1[1].htm'
     end
 
     it 'should handle text/plain;; format="flowed"' do
       c = Mail::ContentTypeField.new('text/plain;; format="flowed"')
-      c.string.should == 'text/plain'
-      c.parameters['format'].should == 'flowed'
+      c.string.should eql 'text/plain'
+      c.parameters['format'].should eql 'flowed'
     end
 
     it 'set an empty content type to text/plain' do
       c = Mail::ContentTypeField.new('')
-      c.string.should == 'text/plain'
+      c.string.should eql 'text/plain'
     end
 
     it "should just ignore illegal params like audio/x-midi;\r\n\sname=Part .exe" do
       c = Mail::ContentTypeField.new("audio/x-midi;\r\n\sname=Part .exe")
-      c.string.should == 'audio/x-midi'
-      c.parameters['name'].should == nil
+      c.string.should eql 'audio/x-midi'
+      c.parameters['name'].should eql nil
     end
 
     it "should handle: rfc822; format=flowed; charset=iso-8859-15" do
       c = Mail::ContentTypeField.new("rfc822; format=flowed; charset=iso-8859-15")
-      c.string.should == 'text/plain'
-      c.parameters['format'].should == 'flowed'
-      c.parameters['charset'].should == 'iso-8859-15'
+      c.string.should eql 'text/plain'
+      c.parameters['format'].should eql 'flowed'
+      c.parameters['charset'].should eql 'iso-8859-15'
     end
 
     it "should just get the mime type if all else fails with some real garbage" do
       c = Mail::ContentTypeField.new("text/html; format=flowed; charset=iso-8859-15  Mime-Version: 1.0")
-      c.string.should == 'text/html'
+      c.string.should eql 'text/html'
     end
 
   end

--- a/spec/mail/fields/date_field_spec.rb
+++ b/spec/mail/fields/date_field_spec.rb
@@ -27,7 +27,7 @@ describe Mail::DateField do
     end
 
     it "should be able to tell the time" do
-      Mail::DateField.new("12 Aug 2009 00:00:02 GMT").date_time.class.should == DateTime
+      Mail::DateField.new("12 Aug 2009 00:00:02 GMT").date_time.class.should eql DateTime
     end
 
     it "should mix in the CommonAddress module" do
@@ -36,16 +36,16 @@ describe Mail::DateField do
 
     it "should accept a string with the field name" do
       t = Mail::DateField.new('Date: 12 Aug 2009 00:00:02 GMT')
-      t.name.should == 'Date'
-      t.value.should == 'Wed, 12 Aug 2009 00:00:02 +0000'
-      t.date_time.should == ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
+      t.name.should eql 'Date'
+      t.value.should eql 'Wed, 12 Aug 2009 00:00:02 +0000'
+      t.date_time.should eql ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
     end
 
     it "should accept a string without the field name" do
       t = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
-      t.name.should == 'Date'
-      t.value.should == 'Wed, 12 Aug 2009 00:00:02 +0000'
-      t.date_time.should == ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
+      t.name.should eql 'Date'
+      t.value.should eql 'Wed, 12 Aug 2009 00:00:02 +0000'
+      t.date_time.should eql ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
     end
     
     it "should accept nil as a value" do
@@ -55,23 +55,23 @@ describe Mail::DateField do
     
     it "should allow us to encode an date field" do
       field = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
-      field.encoded.should == "Date: Wed, 12 Aug 2009 00:00:02 +0000\r\n"
+      field.encoded.should eql "Date: Wed, 12 Aug 2009 00:00:02 +0000\r\n"
     end
     
     it "should allow us to decode an address field" do
       field = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
-      field.decoded.should == "Wed, 12 Aug 2009 00:00:02 +0000"
+      field.decoded.should eql "Wed, 12 Aug 2009 00:00:02 +0000"
     end
 
     it "should be able to parse a really bad spacing example" do
       field = Mail::DateField.new("Fri, 21 Nov 1997 09(comment):   55  :  06 -0600")
-      field.decoded.should == "Fri, 21 Nov 1997 09:55:06 -0600"
+      field.decoded.should eql "Fri, 21 Nov 1997 09:55:06 -0600"
     end
 
     it "should give today's date if no date is specified" do
       now = Time.now
       Time.stub!(:now).and_return(now)
-      Mail::DateField.new.date_time.should == ::DateTime.parse(now.to_s)
+      Mail::DateField.new.date_time.should eql ::DateTime.parse(now.to_s)
     end
     
   end

--- a/spec/mail/fields/from_field_spec.rb
+++ b/spec/mail/fields/from_field_spec.rb
@@ -18,14 +18,14 @@ describe Mail::FromField do
 
     it "should accept a string with the field name" do
       t = Mail::FromField.new('From: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'From'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'From'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::FromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'From'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'From'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -35,55 +35,55 @@ describe Mail::FromField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::FromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::FromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::FromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::FromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::FromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == "From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      t.encoded.should eql "From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
     it "should return the encoded line" do
       t = Mail::FromField.new("bob@me.com")
-      t.encoded.should == "From: bob@me.com\r\n"
+      t.encoded.should eql "From: bob@me.com\r\n"
     end
     
     it "should return the decoded line" do
       t = Mail::FromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.decoded.should == "sam@me.com, my_group: mikel@me.com, bob@you.com;"
+      t.decoded.should eql "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
     
   end
   
   it "should handle non ascii" do
     t = Mail::FromField.new('"Foo áëô îü" <extended@example.net>')
-    t.decoded.should == '"Foo áëô îü" <extended@example.net>'
-    t.encoded.should == "From: =?UTF-8?B?Rm9vIMOhw6vDtCDDrsO8?= <extended@example.net>\r\n"
+    t.decoded.should eql '"Foo áëô îü" <extended@example.net>'
+    t.encoded.should eql "From: =?UTF-8?B?Rm9vIMOhw6vDtCDDrsO8?= <extended@example.net>\r\n"
   end
   
   
   it "should work without quotes" do
     t = Mail::FromField.new('Foo áëô îü <extended@example.net>')
-    t.encoded.should == "From: Foo =?UTF-8?B?w6HDq8O0?= =?UTF-8?B?IMOuw7w=?= <extended@example.net>\r\n"
-    t.decoded.should == '"Foo áëô îü" <extended@example.net>'
+    t.encoded.should eql "From: Foo =?UTF-8?B?w6HDq8O0?= =?UTF-8?B?IMOuw7w=?= <extended@example.net>\r\n"
+    t.decoded.should eql '"Foo áëô îü" <extended@example.net>'
   end
 
 end

--- a/spec/mail/fields/in_reply_to_field_spec.rb
+++ b/spec/mail/fields/in_reply_to_field_spec.rb
@@ -18,42 +18,42 @@ describe Mail::InReplyToField do
 
     it "should accept a string with the field name" do
       t = Mail::InReplyToField.new('In-Reply-To: <1234@test.lindsaar.net>')
-      t.name.should == 'In-Reply-To'
-      t.value.should == '<1234@test.lindsaar.net>'
-      t.message_id.should == '1234@test.lindsaar.net'
+      t.name.should eql 'In-Reply-To'
+      t.value.should eql '<1234@test.lindsaar.net>'
+      t.message_id.should eql '1234@test.lindsaar.net'
     end
 
     it "should accept a string without the field name" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
-      t.name.should == 'In-Reply-To'
-      t.value.should == '<1234@test.lindsaar.net>'
-      t.message_id.should == '1234@test.lindsaar.net'
+      t.name.should eql 'In-Reply-To'
+      t.value.should eql '<1234@test.lindsaar.net>'
+      t.message_id.should eql '1234@test.lindsaar.net'
     end
     
     it "should provide encoded" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
-      t.encoded.should == "In-Reply-To: <1234@test.lindsaar.net>\r\n"
+      t.encoded.should eql "In-Reply-To: <1234@test.lindsaar.net>\r\n"
     end
     
     it "should handle many encoded message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      t.encoded.should == "In-Reply-To: <1234@test.lindsaar.net> <4567@test.lindsaar.net>\r\n"
+      t.encoded.should eql "In-Reply-To: <1234@test.lindsaar.net> <4567@test.lindsaar.net>\r\n"
     end
 
     it "should provide decoded" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
-      t.decoded.should == "<1234@test.lindsaar.net>"
+      t.decoded.should eql "<1234@test.lindsaar.net>"
     end
     
     it "should handle many decoded message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      t.decoded.should == '<1234@test.lindsaar.net> <4567@test.lindsaar.net>'
+      t.decoded.should eql '<1234@test.lindsaar.net> <4567@test.lindsaar.net>'
     end
     
     it "should handle an empty value" do
       t = Mail::InReplyToField.new('')
-      t.name.should == 'In-Reply-To'
-      t.decoded.should == nil
+      t.name.should eql 'In-Reply-To'
+      t.decoded.should eql nil
     end
     
   end
@@ -61,8 +61,8 @@ describe Mail::InReplyToField do
   describe "handlign multiple message ids" do
     it "should handle many message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      t.name.should == 'In-Reply-To'
-      t.message_ids.should == ['1234@test.lindsaar.net', '4567@test.lindsaar.net']
+      t.name.should eql 'In-Reply-To'
+      t.message_ids.should eql ['1234@test.lindsaar.net', '4567@test.lindsaar.net']
     end
   end
 end

--- a/spec/mail/fields/keywords_field_spec.rb
+++ b/spec/mail/fields/keywords_field_spec.rb
@@ -11,14 +11,14 @@ describe Mail::KeywordsField do
     
     it "should accept a string with the field name" do
       k = Mail::KeywordsField.new('Keywords: these are keywords, so there')
-      k.name.should == 'Keywords'
-      k.value.should == 'these are keywords, so there'
+      k.name.should eql 'Keywords'
+      k.value.should eql 'these are keywords, so there'
     end
     
     it "should accept a string with the field name" do
       k = Mail::KeywordsField.new('these are keywords, so there')
-      k.name.should == 'Keywords'
-      k.value.should == 'these are keywords, so there'
+      k.name.should eql 'Keywords'
+      k.value.should eql 'these are keywords, so there'
     end
     
   end
@@ -26,27 +26,27 @@ describe Mail::KeywordsField do
   describe "giving a list of keywords" do
     it "should return a list of keywords" do
       k = Mail::KeywordsField.new('these are keywords, so there')
-      k.keywords.should == ['these are keywords', 'so there']
+      k.keywords.should eql ['these are keywords', 'so there']
     end
     
     it "should handle phrases" do
       k = Mail::KeywordsField.new('"these, are keywords", so there')
-      k.keywords.should == ['these, are keywords', 'so there']
+      k.keywords.should eql ['these, are keywords', 'so there']
     end
     
     it "should handle comments" do
       k = Mail::KeywordsField.new('"these, are keywords", so there (This is an irrelevant comment)')
-      k.keywords.should == ['these, are keywords', 'so there (This is an irrelevant comment)']
+      k.keywords.should eql ['these, are keywords', 'so there (This is an irrelevant comment)']
     end
     
     it "should handle comments" do
       k = Mail::KeywordsField.new('"these, are keywords", so there (This is an irrelevant comment)')
-      k.keywords.should == ['these, are keywords', 'so there (This is an irrelevant comment)']
+      k.keywords.should eql ['these, are keywords', 'so there (This is an irrelevant comment)']
     end
     
     it "should handle comments in quotes" do
       k = Mail::KeywordsField.new('"these, are keywords (another comment to be ignored)", so there (This is an irrelevant comment)')
-      k.keywords.should == ['these, are keywords (another comment to be ignored)', 'so there (This is an irrelevant comment)']
+      k.keywords.should eql ['these, are keywords (another comment to be ignored)', 'so there (This is an irrelevant comment)']
     end
     
   end
@@ -54,12 +54,12 @@ describe Mail::KeywordsField do
   describe "encoding and decoding" do
     it "should encode" do
       k = Mail::KeywordsField.new('these are keywords, so there')
-      k.encoded.should == "Keywords: these are keywords, so there\r\n"
+      k.encoded.should eql "Keywords: these are keywords, so there\r\n"
     end
 
     it "should decode" do
       k = Mail::KeywordsField.new('these are keywords, so there')
-      k.decoded.should == "these are keywords, so there"
+      k.decoded.should eql "these are keywords, so there"
     end
   end
   

--- a/spec/mail/fields/message_id_field_spec.rb
+++ b/spec/mail/fields/message_id_field_spec.rb
@@ -62,21 +62,21 @@ describe Mail::MessageIdField do
 
     it "should accept a string with the field name" do
       m = Mail::MessageIdField.new('Message-ID: <1234@test.lindsaar.net>')
-      m.name.should == 'Message-ID'
-      m.value.should == '<1234@test.lindsaar.net>'
-      m.message_id.should == '1234@test.lindsaar.net'
+      m.name.should eql 'Message-ID'
+      m.value.should eql '<1234@test.lindsaar.net>'
+      m.message_id.should eql '1234@test.lindsaar.net'
     end
 
     it "should accept a string without the field name" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.name.should == 'Message-ID'
-      m.value.should == '<1234@test.lindsaar.net>'
-      m.message_id.should == '1234@test.lindsaar.net'
+      m.name.should eql 'Message-ID'
+      m.value.should eql '<1234@test.lindsaar.net>'
+      m.message_id.should eql '1234@test.lindsaar.net'
     end
 
     it "should accept a nil value and generate a message_id" do
       m = Mail::MessageIdField.new(nil)
-      m.name.should == 'Message-ID'
+      m.name.should eql 'Message-ID'
       m.value.should_not be_nil
     end
 
@@ -86,17 +86,17 @@ describe Mail::MessageIdField do
 
     it "should not accept a string with multiple message IDs but only return the first" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      m.name.should == 'Message-ID'
-      m.to_s.should == '<1234@test.lindsaar.net>'
-      m.message_id.should == '1234@test.lindsaar.net'
-      m.message_ids.should == ['1234@test.lindsaar.net']
+      m.name.should eql 'Message-ID'
+      m.to_s.should eql '<1234@test.lindsaar.net>'
+      m.message_id.should eql '1234@test.lindsaar.net'
+      m.message_ids.should eql ['1234@test.lindsaar.net']
     end
 
     it "should change the message id if given a new message id" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.to_s.should == '<1234@test.lindsaar.net>'
+      m.to_s.should eql '<1234@test.lindsaar.net>'
       m.value = '<4567@test.lindsaar.net>'
-      m.to_s.should == '<4567@test.lindsaar.net>'
+      m.to_s.should eql '<4567@test.lindsaar.net>'
     end
 
   end
@@ -104,18 +104,18 @@ describe Mail::MessageIdField do
   describe "instance methods" do
     it "should provide to_s" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.to_s.should == '<1234@test.lindsaar.net>'
-      m.message_id.to_s.should == '1234@test.lindsaar.net'
+      m.to_s.should eql '<1234@test.lindsaar.net>'
+      m.message_id.to_s.should eql '1234@test.lindsaar.net'
     end
 
     it "should provide encoded" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.encoded.should == "Message-ID: <1234@test.lindsaar.net>\r\n"
+      m.encoded.should eql "Message-ID: <1234@test.lindsaar.net>\r\n"
     end
 
     it "should provide decoded" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.decoded.should == "<1234@test.lindsaar.net>"
+      m.decoded.should eql "<1234@test.lindsaar.net>"
     end
     
     it "should respond to :responsible_for?" do
@@ -141,7 +141,7 @@ describe Mail::MessageIdField do
   describe "weird message IDs" do
     it "should be able to parse <000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com>" do
       m = Mail::MessageIdField.new('<000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com>')
-      m.message_id.should == '000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com'
+      m.message_id.should eql '000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com'
     end
   end
 end

--- a/spec/mail/fields/mime_version_field_spec.rb
+++ b/spec/mail/fields/mime_version_field_spec.rb
@@ -88,14 +88,14 @@ describe Mail::MimeVersionField do
 
     it "should accept a string with the field name" do
       t = Mail::MimeVersionField.new('Mime-Version: 1.0')
-      t.name.should == 'Mime-Version'
-      t.value.should == '1.0'
+      t.name.should eql 'Mime-Version'
+      t.value.should eql '1.0'
     end
 
     it "should accept a string without the field name" do
       t = Mail::MimeVersionField.new('1.0')
-      t.name.should == 'Mime-Version'
-      t.value.should == '1.0'
+      t.name.should eql 'Mime-Version'
+      t.value.should eql '1.0'
     end
 
   end
@@ -103,47 +103,47 @@ describe Mail::MimeVersionField do
   describe "parsing a version string" do
     it "should get a major value" do
       t = Mail::MimeVersionField.new('1.0')
-      t.major.should == 1
+      t.major.should eql 1
     end
 
     it "should get a minor value" do
       t = Mail::MimeVersionField.new('1.0')
-      t.minor.should == 0
+      t.minor.should eql 0
     end
 
     it "should get a version string" do
       t = Mail::MimeVersionField.new('1.0')
-      t.version.should == '1.0'
+      t.version.should eql '1.0'
     end
     
     it "should handle comments before the major version" do
       t = Mail::MimeVersionField.new('(This is a comment) 1.0')
-      t.version.should == '1.0'
+      t.version.should eql '1.0'
     end
 
     it "should handle comments before the major version without space" do
       t = Mail::MimeVersionField.new('(This is a comment)1.0')
-      t.version.should == '1.0'
+      t.version.should eql '1.0'
     end
 
     it "should handle comments after the major version without space" do
       t = Mail::MimeVersionField.new('1(This is a comment).0')
-      t.version.should == '1.0'
+      t.version.should eql '1.0'
     end
 
     it "should handle comments before the minor version without space" do
       t = Mail::MimeVersionField.new('1.(This is a comment)0')
-      t.version.should == '1.0'
+      t.version.should eql '1.0'
     end
 
     it "should handle comments after the minor version without space" do
       t = Mail::MimeVersionField.new('1.0(This is a comment)')
-      t.version.should == '1.0'
+      t.version.should eql '1.0'
     end
 
     it "should handle comments after the minor version" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
-      t.version.should == '1.0'
+      t.version.should eql '1.0'
     end
     
     it "should accept nil as a value" do
@@ -153,12 +153,12 @@ describe Mail::MimeVersionField do
     
     it "should provide an encoded value" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
-      t.encoded.should == "Mime-Version: 1.0\r\n"
+      t.encoded.should eql "Mime-Version: 1.0\r\n"
     end
 
     it "should provide an decoded value" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
-      t.decoded.should == '1.0'
+      t.decoded.should eql '1.0'
     end
 
   end

--- a/spec/mail/fields/received_field_spec.rb
+++ b/spec/mail/fields/received_field_spec.rb
@@ -8,44 +8,44 @@ describe Mail::ReceivedField do
   end
 
   it "should be able to tell the time" do
-    Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)").date_time.class.should == DateTime
+    Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)").date_time.class.should eql DateTime
   end
 
   it "should accept a string with the field name" do
     t = Mail::ReceivedField.new('Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    t.name.should == 'Received'
-    t.value.should == 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
-    t.info.should == 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
-    t.date_time.should == ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
+    t.name.should eql 'Received'
+    t.value.should eql 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
+    t.info.should eql 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
+    t.date_time.should eql ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
   end
   
   it "should accept a string without the field name" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    t.name.should == 'Received'
-    t.value.should == 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
-    t.info.should == 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
-    t.date_time.should == ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
+    t.name.should eql 'Received'
+    t.value.should eql 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
+    t.info.should eql 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
+    t.date_time.should eql ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
   end
 
   it "should provide an encoded value" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    t.encoded.should == "Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000\r\n"
+    t.encoded.should eql "Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000\r\n"
   end
 
   it "should provide an encoded value with correct timezone" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 -0500 (EST)')
-    t.encoded.should == "Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 -0500\r\n"
+    t.encoded.should eql "Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 -0500\r\n"
   end
 
   it "should provide an decoded value" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    t.decoded.should == 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000'
+    t.decoded.should eql 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000'
   end
   
   it "should handle a blank value" do
     t = Mail::ReceivedField.new('')
-    t.decoded.should == ''
-    t.encoded.should == "Received: \r\n"
+    t.decoded.should eql ''
+    t.encoded.should eql "Received: \r\n"
   end
   
 end

--- a/spec/mail/fields/references_field_spec.rb
+++ b/spec/mail/fields/references_field_spec.rb
@@ -20,31 +20,31 @@ describe Mail::ReferencesField do
 
   it "should accept a string with the field name" do
     t = Mail::ReferencesField.new('References: <1234@test.lindsaar.net>')
-    t.name.should == 'References'
-    t.value.should == '<1234@test.lindsaar.net>'
-    t.message_id.should == '1234@test.lindsaar.net'
+    t.name.should eql 'References'
+    t.value.should eql '<1234@test.lindsaar.net>'
+    t.message_id.should eql '1234@test.lindsaar.net'
   end
   
   it "should accept a string without the field name" do
     t = Mail::ReferencesField.new('<1234@test.lindsaar.net>')
-    t.name.should == 'References'
-    t.value.should == '<1234@test.lindsaar.net>'
-    t.message_id.should == '1234@test.lindsaar.net'
+    t.name.should eql 'References'
+    t.value.should eql '<1234@test.lindsaar.net>'
+    t.message_id.should eql '1234@test.lindsaar.net'
   end
 
   it "should accept multiple message ids" do
     t = Mail::ReferencesField.new('<1234@test.lindsaar.net> <5678@test.lindsaar.net>')
-    t.name.should == 'References'
-    t.value.should == '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
-    t.message_id.should == '1234@test.lindsaar.net'
-    t.message_ids.should == ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
-    t.to_s.should == '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
+    t.name.should eql 'References'
+    t.value.should eql '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
+    t.message_id.should eql '1234@test.lindsaar.net'
+    t.message_ids.should eql ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
+    t.to_s.should eql '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
   end
 
   it "should accept no message ids" do
     t = Mail::ReferencesField.new('')
-    t.name.should == 'References'
-    t.decoded.should == nil
+    t.name.should eql 'References'
+    t.decoded.should eql nil
   end
 
 end

--- a/spec/mail/fields/reply_to_field_spec.rb
+++ b/spec/mail/fields/reply_to_field_spec.rb
@@ -18,14 +18,14 @@ describe Mail::ReplyToField do
 
     it "should accept a string with the field name" do
       t = Mail::ReplyToField.new('Reply-To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Reply-To'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Reply-To'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ReplyToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Reply-To'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Reply-To'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -35,30 +35,30 @@ describe Mail::ReplyToField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ReplyToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ReplyToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ReplyToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ReplyToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ReplyToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == "Reply-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      t.encoded.should eql "Reply-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_bcc_field_spec.rb
+++ b/spec/mail/fields/resent_bcc_field_spec.rb
@@ -17,14 +17,14 @@ describe Mail::ResentBccField do
 
     it "should accept a string with the field name" do
       t = Mail::ResentBccField.new('Resent-Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-Bcc'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-Bcc'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentBccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-Bcc'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-Bcc'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,30 +34,30 @@ describe Mail::ResentBccField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentBccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentBccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ResentBccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentBccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentBccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == "Resent-Bcc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      t.encoded.should eql "Resent-Bcc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_cc_field_spec.rb
+++ b/spec/mail/fields/resent_cc_field_spec.rb
@@ -17,14 +17,14 @@ describe Mail::ResentCcField do
 
     it "should accept a string with the field name" do
       t = Mail::ResentCcField.new('Resent-Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-Cc'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-Cc'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentCcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-Cc'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-Cc'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,30 +34,30 @@ describe Mail::ResentCcField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentCcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentCcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ResentCcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentCcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentCcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == "Resent-Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      t.encoded.should eql "Resent-Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_date_field_spec.rb
+++ b/spec/mail/fields/resent_date_field_spec.rb
@@ -7,7 +7,7 @@ describe Mail::ResentDateField do
   end
   
   it "should be able to tell the time" do
-    Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT").date_time.class.should == DateTime
+    Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT").date_time.class.should eql DateTime
   end
   
   it "should mix in the CommonAddress module" do
@@ -16,24 +16,24 @@ describe Mail::ResentDateField do
 
   it "should accept a string with the field name" do
     t = Mail::ResentDateField.new('Resent-Date: 12 Aug 2009 00:00:02 GMT')
-    t.name.should == 'Resent-Date'
-    t.value.should == 'Wed, 12 Aug 2009 00:00:02 +0000'
-    t.date_time.should == ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
+    t.name.should eql 'Resent-Date'
+    t.value.should eql 'Wed, 12 Aug 2009 00:00:02 +0000'
+    t.date_time.should eql ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
   end
   
   it "should accept a string without the field name" do
     t = Mail::ResentDateField.new('12 Aug 2009 00:00:02 GMT')
-    t.name.should == 'Resent-Date'
-    t.value.should == 'Wed, 12 Aug 2009 00:00:02 +0000'
-    t.date_time.should == ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
+    t.name.should eql 'Resent-Date'
+    t.value.should eql 'Wed, 12 Aug 2009 00:00:02 +0000'
+    t.date_time.should eql ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
   end
   
   it "should give today's date if no date is specified" do
     now = Time.now
     Time.stub!(:now).and_return(now)
     t = Mail::ResentDateField.new
-    t.name.should == 'Resent-Date'
-    t.date_time.should == ::DateTime.parse(now.to_s)
+    t.name.should eql 'Resent-Date'
+    t.date_time.should eql ::DateTime.parse(now.to_s)
   end
 
 end

--- a/spec/mail/fields/resent_from_field_spec.rb
+++ b/spec/mail/fields/resent_from_field_spec.rb
@@ -17,14 +17,14 @@ describe Mail::ResentFromField do
 
     it "should accept a string with the field name" do
       t = Mail::ResentFromField.new('Resent-From: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-From'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-From'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentFromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-From'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-From'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,30 +34,30 @@ describe Mail::ResentFromField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentFromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentFromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ResentFromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentFromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentFromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == "Resent-From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      t.encoded.should eql "Resent-From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_message_id_field_spec.rb
+++ b/spec/mail/fields/resent_message_id_field_spec.rb
@@ -9,16 +9,16 @@ describe Mail::ResentMessageIdField do
 
   it "should accept a string with the field name" do
     t = Mail::ResentMessageIdField.new('Resent-Message-ID: <1234@test.lindsaar.net>')
-    t.name.should == 'Resent-Message-ID'
-    t.value.should == '<1234@test.lindsaar.net>'
-    t.message_id.should == '1234@test.lindsaar.net'
+    t.name.should eql 'Resent-Message-ID'
+    t.value.should eql '<1234@test.lindsaar.net>'
+    t.message_id.should eql '1234@test.lindsaar.net'
   end
   
   it "should accept a string without the field name" do
     t = Mail::ResentMessageIdField.new('<1234@test.lindsaar.net>')
-    t.name.should == 'Resent-Message-ID'
-    t.value.should == '<1234@test.lindsaar.net>'
-    t.message_id.should == '1234@test.lindsaar.net'
+    t.name.should eql 'Resent-Message-ID'
+    t.value.should eql '<1234@test.lindsaar.net>'
+    t.message_id.should eql '1234@test.lindsaar.net'
   end
 
 end

--- a/spec/mail/fields/resent_sender_field_spec.rb
+++ b/spec/mail/fields/resent_sender_field_spec.rb
@@ -17,14 +17,14 @@ describe Mail::ResentSenderField do
 
     it "should accept a string with the field name" do
       t = Mail::ResentSenderField.new('Resent-Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-Sender'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-Sender'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-Sender'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-Sender'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,22 +34,22 @@ describe Mail::ResentSenderField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.address.to_s.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.address.to_s.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.encoded.should == "Resent-Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
+      t.encoded.should eql "Resent-Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_to_field_spec.rb
+++ b/spec/mail/fields/resent_to_field_spec.rb
@@ -17,14 +17,14 @@ describe Mail::ResentToField do
 
     it "should accept a string with the field name" do
       t = Mail::ResentToField.new('Resent-To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-To'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-To'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Resent-To'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Resent-To'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,30 +34,30 @@ describe Mail::ResentToField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ResentToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == "Resent-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      t.encoded.should eql "Resent-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/sender_field_spec.rb
+++ b/spec/mail/fields/sender_field_spec.rb
@@ -17,14 +17,14 @@ describe Mail::SenderField do
 
     it "should accept a string with the field name" do
       t = Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Sender'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Sender'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'Sender'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'Sender'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,22 +34,22 @@ describe Mail::SenderField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.address.to_s.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.address.to_s.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
     
     it "should return the encoded line" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.encoded.should == "Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
+      t.encoded.should eql "Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
     end
     
   end

--- a/spec/mail/fields/to_field_spec.rb
+++ b/spec/mail/fields/to_field_spec.rb
@@ -18,14 +18,14 @@ describe Mail::ToField do
 
     it "should accept a string with the field name" do
       t = Mail::ToField.new('To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'To'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'To'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should == 'To'
-      t.value.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      t.name.should eql 'To'
+      t.value.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -35,50 +35,50 @@ describe Mail::ToField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should == ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      t.formatted.should eql ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should == 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should == 'ada@test.lindsaar.net'
+      t.formatted.first.should eql 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      t.addresses.last.should eql 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should == 'sam@me.com'
-      t.addresses[1].should == 'mikel@me.com'
-      t.addresses[2].should == 'bob@you.com'
+      t.addresses[0].should eql 'sam@me.com'
+      t.addresses[1].should eql 'mikel@me.com'
+      t.addresses[2].should eql 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should == 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      t.value.should eql 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should == "To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      t.encoded.should eql "To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
     it "should return the decoded line" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.decoded.should == "sam@me.com, my_group: mikel@me.com, bob@you.com;"
+      t.decoded.should eql "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
     
     it "should get multiple address out from a group list" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses.should == ["sam@me.com", "mikel@me.com", "bob@you.com"]
+      t.addresses.should eql ["sam@me.com", "mikel@me.com", "bob@you.com"]
     end
     
     it "should handle commas in the address" do
       t = Mail::ToField.new('"Long, stupid email address" <mikel@test.lindsaar.net>')
-      t.addresses.should == ["mikel@test.lindsaar.net"]
+      t.addresses.should eql ["mikel@test.lindsaar.net"]
     end
     
     it "should handle commas in the address for multiple fields" do
       t = Mail::ToField.new('"Long, stupid email address" <mikel@test.lindsaar.net>, "Another, really, really, long, stupid email address" <bob@test.lindsaar.net>')
-      t.addresses.should == ["mikel@test.lindsaar.net", "bob@test.lindsaar.net"]
+      t.addresses.should eql ["mikel@test.lindsaar.net", "bob@test.lindsaar.net"]
     end
     
   end

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -22,12 +22,12 @@ describe Mail::UnstructuredField do
     end
     
     it "should provide access to the text of the field once set" do
-      @field.value.should == "Hello Frank"
+      @field.value.should eql "Hello Frank"
     end
     
     it "should provide a means to change the value" do
       @field.value = "Goodbye Frank"
-      @field.value.should == "Goodbye Frank"
+      @field.value.should eql "Goodbye Frank"
     end
   end
 
@@ -38,59 +38,59 @@ describe Mail::UnstructuredField do
     end
     
     it "should provide a to_s function that returns the field name and value" do
-      @field.value.should == "Hello Frank"
+      @field.value.should eql "Hello Frank"
     end
     
     it "should return '' on to_s if there is no value" do
       @field.value = nil
-      @field.encoded.should == ''
+      @field.encoded.should eql ''
     end
     
     it "should give an encoded value ready to insert into an email" do
-      @field.encoded.should == "Subject: Hello Frank\r\n"
+      @field.encoded.should eql "Subject: Hello Frank\r\n"
     end
     
     it "should return nil on encoded if it has no value" do
       @field.value = nil
-      @field.encoded.should == ''
+      @field.encoded.should eql ''
     end
     
     it "should give an decoded value ready to insert into an email" do
-      @field.decoded.should == "Hello Frank"
+      @field.decoded.should eql "Hello Frank"
     end
     
     it "should return a nil on decoded if it has no value" do
       @field.value = nil
-      @field.decoded.should == nil
+      @field.decoded.should eql nil
     end
     
     it "should just add the CRLF at the end of the line" do
       @field = Mail::SubjectField.new("Subject: =?utf-8?Q?testing_testing_=D6=A4?=")
       result = "Subject: =?UTF8?Q?testing_testing_=D6=A4?=\r\n"
-      @field.encoded.gsub("UTF-8", "UTF8").should == result
-      @field.decoded.should == "testing testing \326\244"
+      @field.encoded.gsub("UTF-8", "UTF8").should eql result
+      @field.decoded.should eql "testing testing \326\244"
     end
 
     it "should do encoded-words encoding correctly without extra equal sign" do
       @field = Mail::SubjectField.new("testing testing æøå")
       result = "Subject: =?UTF8?Q?testing_testing_=C3=A6=C3=B8=C3=A5?=\r\n"
-      @field.encoded.gsub("UTF-8", "UTF8").should == result
-      @field.decoded.should == "testing testing æøå"
+      @field.encoded.gsub("UTF-8", "UTF8").should eql result
+      @field.decoded.should eql "testing testing æøå"
     end
     
     it "should encode the space between two adjacent encoded-words" do
       @field = Mail::SubjectField.new("Her er æ ø å")
       result = "Subject: =?UTF8?Q?Her_er_=C3=A6_=C3=B8_=C3=A5?=\r\n"
-      @field.encoded.gsub("UTF-8", "UTF8").should == result
-      @field.decoded.should == "Her er æ ø å"
+      @field.encoded.gsub("UTF-8", "UTF8").should eql result
+      @field.decoded.should eql "Her er æ ø å"
     end
 
     it "should encode additional special characters inside encoded-word-encoded strings" do
       string = %Q(Her er æ()<>@,;:\\"/[]?.=)
       @field = Mail::SubjectField.new(string)
       result = %Q(Subject: =?UTF8?Q?Her_er_=C3=A6=28=29<>@,;:\\=22/[]=3F.=3D?=\r\n)
-      @field.encoded.gsub("UTF-8", "UTF8").should == result
-      @field.decoded.should == string
+      @field.encoded.gsub("UTF-8", "UTF8").should eql result
+      @field.decoded.should eql string
     end
   end
 
@@ -98,13 +98,13 @@ describe Mail::UnstructuredField do
 
     it "should not fold itself if it is 78 chracters long" do
       @field = Mail::UnstructuredField.new("Subject", "This is a subject header message that is _exactly_ 78 characters....")
-      @field.encoded.should == "Subject: This is a subject header message that is _exactly_ 78 characters....\r\n"
+      @field.encoded.should eql "Subject: This is a subject header message that is _exactly_ 78 characters....\r\n"
     end
     
     it "should fold itself if it is 79 chracters long" do
       @field = Mail::UnstructuredField.new("Subject", "This is a subject header message that is absolutely 79 characters long")
       result = "Subject: This is a subject header message that is absolutely 79 characters\r\n\slong\r\n"
-      @field.encoded.should == result
+      @field.encoded.should eql result
     end
 
     it "should fold itself if it is 997 chracters long" do
@@ -137,8 +137,8 @@ describe Mail::UnstructuredField do
         $KCODE = 'u'
       end
       result = "Subject: =?UTF8?Q?This_is_=E3=81=82_really_long_string_This_is_=E3=81=82?=\r\n\s=?UTF8?Q?_really_long_string_This_is_=E3=81=82_really_long_string_This_is?=\r\n\s=?UTF8?Q?_=E3=81=82_really_long_string_This_is_=E3=81=82_really_long?=\r\n\s=?UTF8?Q?_string?=\r\n"
-      @field.encoded.gsub("UTF-8", "UTF8").should == result
-      @field.decoded.should == string
+      @field.encoded.gsub("UTF-8", "UTF8").should eql result
+      @field.decoded.should eql string
       $KCODE = @original if RUBY_VERSION < '1.9'
     end
 
@@ -152,8 +152,8 @@ describe Mail::UnstructuredField do
         $KCODE = 'u'
       end
       result = "X-SMTPAPI: =?UTF8?Q?{=22unique=5Fargs=22:_{=22mailing=5Fid=22:147,=22a?=\r\n =?UTF8?Q?ccount=5Fid=22:2},_=22to=22:_[=22larspind@gmail.com=22],_=22categ?=\r\n =?UTF8?Q?ory=22:_=22mailing=22,_=22filters=22:_{=22domainkeys=22:_{=22sett?=\r\n =?UTF8?Q?ings=22:_{=22domain=22:1,=22enable=22:1}}},_=22sub=22:_{=22{{op?=\r\n =?UTF8?Q?en=5Fimage=5Furl}}=22:_[=22http://betaling.larspind.local/O?=\r\n =?UTF8?Q?/token/147/Mailing::FakeRecipient=22],_=22{{name}}=22:_[=22[FIRST?=\r\n =?UTF8?Q?_NAME]=22],_=22{{signup=5Freminder}}=22:_[=22=28her_kommer_til_at?=\r\n =?UTF8?Q?_st=C3=A5_hvorn=C3=A5r_folk_har_skrevet_sig_op_...=29=22],?=\r\n =?UTF8?Q?_=22{{unsubscribe=5Furl}}=22:_[=22http://betaling.larspind.?=\r\n =?UTF8?Q?local/U/token/147/Mailing::FakeRecipient=22],_=22{{email}}=22:?=\r\n =?UTF8?Q?_[=22larspind@gmail.com=22],_=22{{link:308}}=22:_[=22http://beta?=\r\n =?UTF8?Q?ling.larspind.local/L/308/0/Mailing::FakeRecipient=22],_=22{{con?=\r\n =?UTF8?Q?firm=5Furl}}=22:_[=22=22],_=22{{ref}}=22:_[=22[REF]=22]}}?=\r\n"
-      @field.encoded.gsub("UTF-8", "UTF8").should == result
-      @field.decoded.should == string
+      @field.encoded.gsub("UTF-8", "UTF8").should eql result
+      @field.decoded.should eql string
       $KCODE = @original if RUBY_VERSION < '1.9'
     end
   
@@ -163,7 +163,7 @@ describe Mail::UnstructuredField do
     it "should encode an ascii string that has carriage returns if asked to" do
       result = "Subject: =0Aasdf=0A\r\n"
       @field = Mail::UnstructuredField.new("Subject", "\nasdf\n")
-      @field.encoded.should == result
+      @field.encoded.should eql "Subject: =0Aasdf=0A\r\n"
     end
   end
 

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -19,7 +19,7 @@ describe Mail::Header do
     
     it "should save away the raw source of the header that it is passed" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header.raw_source.should == "To: Mikel\r\nFrom: bob\r\n"
+      header.raw_source.should eql "To: Mikel\r\nFrom: bob\r\n"
     end
     
     it "should say if it has a message_id field defined" do
@@ -44,13 +44,13 @@ describe Mail::Header do
     
     it "should know it's own charset" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\nContent-ID: <1234@me.com>")
-      header.charset.should == nil
+      header.charset.should eql nil
     end
     
     it "should know it's own charset if set" do
       header = Mail::Header.new
       header['content-type'] = 'text/plain; charset=utf-8'
-      header.charset.should == 'utf-8'
+      header.charset.should eql 'utf-8'
     end
     
     it "shouldn't die when queried for a charset and the content-type header is invalid" do
@@ -64,164 +64,164 @@ describe Mail::Header do
       it "should recognise a bcc field" do
         header = Mail::Header.new
         header['bcc'] = 'mikel@test.lindsaar.net'
-        header['bcc'].field.class.should == Mail::BccField
+        header['bcc'].field.class.should eql Mail::BccField
       end
       
       it "should recognise a cc field" do
         header = Mail::Header.new
         header['cc'] = 'mikel@test.lindsaar.net'
-        header['cc'].field.class.should == Mail::CcField
+        header['cc'].field.class.should eql Mail::CcField
       end
       
       it "should recognise a content-description field" do
         header = Mail::Header.new
         header['content-description'] = 'Text'
-        header['content-description'].field.class.should == Mail::ContentDescriptionField
+        header['content-description'].field.class.should eql Mail::ContentDescriptionField
       end
       
       it "should recognise a content-disposition field" do
         header = Mail::Header.new
         header['content-disposition'] = 'attachment; filename=File'
-        header['content-disposition'].field.class.should == Mail::ContentDispositionField
+        header['content-disposition'].field.class.should eql Mail::ContentDispositionField
       end
 
       it "should recognise an inline content-disposition field" do
         header = Mail::Header.new
         header['content-disposition'] = 'inline'
-        header['content-disposition'].field.class.should == Mail::ContentDispositionField
+        header['content-disposition'].field.class.should eql Mail::ContentDispositionField
       end
 
 
       it "should recognise a content-id field" do
         header = Mail::Header.new
         header['content-id'] = '<1234@test.lindsaar.net>'
-        header['content-id'].field.class.should == Mail::ContentIdField
+        header['content-id'].field.class.should eql Mail::ContentIdField
       end
       
       it "should recognise a content-transfer-encoding field" do
         header = Mail::Header.new
         header['content-transfer-encoding'] = '7bit'
-        header['content-transfer-encoding'].field.class.should == Mail::ContentTransferEncodingField
+        header['content-transfer-encoding'].field.class.should eql Mail::ContentTransferEncodingField
       end
       
       it "should recognise a content-type field" do
         header = Mail::Header.new
         header['content-type'] = 'text/plain'
-        header['content-type'].field.class.should == Mail::ContentTypeField
+        header['content-type'].field.class.should eql Mail::ContentTypeField
       end
       
       it "should recognise a date field" do
         header = Mail::Header.new
         header['date'] = 'Fri, 21 Nov 1997 09:55:06 -0600'
-        header['date'].field.class.should == Mail::DateField
+        header['date'].field.class.should eql Mail::DateField
       end
       
       it "should recognise a from field" do
         header = Mail::Header.new
         header['from'] = 'mikel@test.lindsaar.net'
-        header['from'].field.class.should == Mail::FromField
+        header['from'].field.class.should eql Mail::FromField
       end
       
       it "should recognise a in-reply-to field" do
         header = Mail::Header.new
         header['in-reply-to'] = '<1234@test.lindsaar.net>'
-        header['in-reply-to'].field.class.should == Mail::InReplyToField
+        header['in-reply-to'].field.class.should eql Mail::InReplyToField
       end
       
       it "should recognise a keywords field" do
         header = Mail::Header.new
         header['keywords'] = 'mikel test lindsaar net'
-        header['keywords'].field.class.should == Mail::KeywordsField
+        header['keywords'].field.class.should eql Mail::KeywordsField
       end
       
       it "should recognise a message-id field" do
         header = Mail::Header.new
         header['message-id'] = '<1234@test.lindsaar.net>'
-        header['message-id'].field.class.should == Mail::MessageIdField
+        header['message-id'].field.class.should eql Mail::MessageIdField
       end
       
       it "should recognise a mime-version field" do
         header = Mail::Header.new
         header['mime-version'] = '1.0'
-        header['mime-version'].field.class.should == Mail::MimeVersionField
+        header['mime-version'].field.class.should eql Mail::MimeVersionField
       end
       
       it "should recognise a received field" do
         header = Mail::Header.new
         header['received'] = 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id C1B953B4CB6 for <xxxxx@Exxx.xxxx.xxx>; Tue, 10 May 2005 15:27:05 -0500'
-        header['received'].field.class.should == Mail::ReceivedField
+        header['received'].field.class.should eql Mail::ReceivedField
       end
       
       it "should recognise a references field" do
         header = Mail::Header.new
         header['references'] = '<1234@test.lindsaar.net>'
-        header['references'].field.class.should == Mail::ReferencesField
+        header['references'].field.class.should eql Mail::ReferencesField
       end
       
       it "should recognise a reply-to field" do
         header = Mail::Header.new
         header['reply-to'] = 'mikel@test.lindsaar.net'
-        header['reply-to'].field.class.should == Mail::ReplyToField
+        header['reply-to'].field.class.should eql Mail::ReplyToField
       end
       
       it "should recognise a resent-bcc field" do
         header = Mail::Header.new
         header['resent-bcc'] = 'mikel@test.lindsaar.net'
-        header['resent-bcc'].field.class.should == Mail::ResentBccField
+        header['resent-bcc'].field.class.should eql Mail::ResentBccField
       end
       
       it "should recognise a resent-cc field" do
         header = Mail::Header.new
         header['resent-cc'] = 'mikel@test.lindsaar.net'
-        header['resent-cc'].field.class.should == Mail::ResentCcField
+        header['resent-cc'].field.class.should eql Mail::ResentCcField
       end
       
       it "should recognise a resent-date field" do
         header = Mail::Header.new
         header['resent-date'] = 'Fri, 21 Nov 1997 09:55:06 -0600'
-        header['resent-date'].field.class.should == Mail::ResentDateField
+        header['resent-date'].field.class.should eql Mail::ResentDateField
       end
       
       it "should recognise a resent-from field" do
         header = Mail::Header.new
         header['resent-from'] = 'mikel@test.lindsaar.net'
-        header['resent-from'].field.class.should == Mail::ResentFromField
+        header['resent-from'].field.class.should eql Mail::ResentFromField
       end
       
       it "should recognise a resent-message-id field" do
         header = Mail::Header.new
         header['resent-message-id'] = '<1234@mail.baci.local>'
-        header['resent-message-id'].field.class.should == Mail::ResentMessageIdField
+        header['resent-message-id'].field.class.should eql Mail::ResentMessageIdField
       end
       
       it "should recognise a resent-sender field" do
         header = Mail::Header.new
         header['resent-sender'] = 'mikel@test.lindsaar.net'
-        header['resent-sender'].field.class.should == Mail::ResentSenderField
+        header['resent-sender'].field.class.should eql Mail::ResentSenderField
       end
       
       it "should recognise a resent-to field" do
         header = Mail::Header.new
         header['resent-to'] = 'mikel@test.lindsaar.net'
-        header['resent-to'].field.class.should == Mail::ResentToField
+        header['resent-to'].field.class.should eql Mail::ResentToField
       end
       
       it "should recognise a return-path field" do
         header = Mail::Header.new
         header['return-path'] = '<mikel@me.com>'
-        header['return-path'].field.class.should == Mail::ReturnPathField
+        header['return-path'].field.class.should eql Mail::ReturnPathField
       end
       
       it "should recognise a sender field" do
         header = Mail::Header.new
         header['sender'] = 'mikel@test.lindsaar.net'
-        header['sender'].field.class.should == Mail::SenderField
+        header['sender'].field.class.should eql Mail::SenderField
       end
       
       it "should recognise a to field" do
         header = Mail::Header.new
         header['to'] = 'mikel@test.lindsaar.net'
-        header['to'].field.class.should == Mail::ToField
+        header['to'].field.class.should eql Mail::ToField
       end
 
       it "should maintain header case" do
@@ -238,12 +238,12 @@ describe Mail::Header do
 
     it "should split the header into separate fields" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header.fields.length.should == 2
+      header.fields.length.should eql 2
     end
     
     it "should not split a wrapped header in two" do
       header = Mail::Header.new("To: mikel lindsaar\r\n\s<mikel@lindsaar>\r\nFrom: bob\r\nSubject: This is\r\n a long\r\n\s \t \t \t    badly formatted             \r\n       \t\t  \t       field")
-      header.fields.length.should == 3
+      header.fields.length.should eql 3
     end
     
     #  Header fields are lines composed of a field name, followed by a colon
@@ -269,32 +269,32 @@ describe Mail::Header do
 
     it "should split each field into an name and value" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header.fields[0].name.should == "From"
-      header.fields[0].value.should == "bob"
-      header.fields[1].name.should == "To"
-      header.fields[1].value.should == "Mikel"
+      header.fields[0].name.should eql "From"
+      header.fields[0].value.should eql "bob"
+      header.fields[1].name.should eql "To"
+      header.fields[1].value.should eql "Mikel"
     end
     
     it "should split each field into an name and value - even if whitespace is missing" do
       header = Mail::Header.new("To: Mikel\r\nFrom:bob\r\n")
-      header.fields[0].name.should == "From"
-      header.fields[0].value.should == "bob"
-      header.fields[1].name.should == "To"
-      header.fields[1].value.should == "Mikel"
+      header.fields[0].name.should eql "From"
+      header.fields[0].value.should eql "bob"
+      header.fields[1].name.should eql "To"
+      header.fields[1].value.should eql "Mikel"
     end
     
     it "should preserve the order of the fields it is given" do
       header = Mail::Header.new
       header.fields = ['From: mikel@me.com', 'To: bob@you.com', 'Subject: This is a badly formed email']
-      header.fields[0].name.should == 'From'
-      header.fields[1].name.should == 'To'
-      header.fields[2].name.should == 'Subject'
+      header.fields[0].name.should eql 'From'
+      header.fields[1].name.should eql 'To'
+      header.fields[2].name.should eql 'Subject'
     end
     
     it "should allow you to reference each field and value by literal string name" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header['To'].value.should == "Mikel"
-      header['From'].value.should == "bob"
+      header['To'].value.should eql "Mikel"
+      header['From'].value.should eql "bob"
     end
 
     it "should return an array of fields if there is more than one match" do
@@ -311,74 +311,74 @@ describe Mail::Header do
     it "should add a new field if the field does not exist" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
       header['Subject'] = "G'Day!"
-      header['Subject'].value.should == "G'Day!"
+      header['Subject'].value.should eql "G'Day!"
     end
     
     it "should allow you to pass in an array of raw fields" do
       header = Mail::Header.new
       header.fields = ['From: mikel@test.lindsaar.net', 'To: bob@you.com']
-      header['To'].value.should == 'bob@you.com'
-      header['From'].value.should == 'mikel@test.lindsaar.net'
+      header['To'].value.should eql 'bob@you.com'
+      header['From'].value.should eql 'mikel@test.lindsaar.net'
     end
     
     it "should reset the value of a single-only field if it already exists" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
       header['To'] = 'George'
-      header['To'].value.should == "George"
+      header['To'].value.should eql "George"
     end
     
     it "should allow you to delete a field by setting it to nil" do
       header = Mail::Header.new
       header.fields = ['To: bob@you.com']
-      header.fields.length.should == 1
+      header.fields.length.should eql 1
       header['To'] = nil
-      header.fields.length.should == 0
+      header.fields.length.should eql 0
     end
     
     it "should delete all matching fields found if there are multiple options" do
       header = Mail::Header.new
       header.fields = ['X-SPAM: 1000', 'X-SPAM: 20']
       header['X-SPAM'] = nil
-      header.fields.length.should == 0
+      header.fields.length.should eql 0
     end
     
     # Handle empty X-Optional header from Microsoft Exchange
     it "should handle an empty X-* header value" do
       header = Mail::Header.new("X-MS-TNEF-Correlator:\r\n")
-      header.fields.length.should == 1
-      header['X-MS-TNEF-Correlator'].decoded.should == nil
-      header['X-MS-TNEF-Correlator'].encoded.should == "X-MS-TNEF-Correlator: \r\n"
+      header.fields.length.should eql 1
+      header['X-MS-TNEF-Correlator'].decoded.should eql nil
+      header['X-MS-TNEF-Correlator'].encoded.should eql "X-MS-TNEF-Correlator: \r\n"
     end
     
     it "should accept X- option fields from MS-Exchange" do
       header = Mail::Header.new("X-Ms-Has-Attach:\r\nX-MS-TNEF-Correlator: \r\n")
-      header.fields.length.should == 2
-      header['X-Ms-Has-Attach'].decoded.should == nil
-      header['X-Ms-Has-Attach'].encoded.should == "X-Ms-Has-Attach: \r\n"
-      header['X-MS-TNEF-Correlator'].decoded.should == nil
-      header['X-MS-TNEF-Correlator'].encoded.should == "X-MS-TNEF-Correlator: \r\n"
+      header.fields.length.should eql 2
+      header['X-Ms-Has-Attach'].decoded.should eql nil
+      header['X-Ms-Has-Attach'].encoded.should eql "X-Ms-Has-Attach: \r\n"
+      header['X-MS-TNEF-Correlator'].decoded.should eql nil
+      header['X-MS-TNEF-Correlator'].encoded.should eql "X-MS-TNEF-Correlator: \r\n"
     end
     
     it "should return nil if asked for the value of a non existent field" do
       header = Mail::Header.new
-      header['Bobs-Field'].should == nil
+      header['Bobs-Field'].should eql nil
     end
     
     it "should allow you to replace a from field" do
       header = Mail::Header.new
-      header['From'].should == nil
+      header['From'].should eql nil
       header['From'] = 'mikel@test.lindsaar.net'
-      header['From'].decoded.should == 'mikel@test.lindsaar.net'
+      header['From'].decoded.should eql 'mikel@test.lindsaar.net'
       header['From'] = 'bob@test.lindsaar.net'
-      header['From'].decoded.should == 'bob@test.lindsaar.net'
+      header['From'].decoded.should eql 'bob@test.lindsaar.net'
     end
     
     it "should maintain the class of the field" do
       header = Mail::Header.new
       header['From'] = 'mikel@test.lindsaar.net'
-      header['From'].field.class.should == Mail::FromField
+      header['From'].field.class.should eql Mail::FromField
       header['From'] = 'bob@test.lindsaar.net'
-      header['From'].field.class.should == Mail::FromField
+      header['From'].field.class.should eql Mail::FromField
     end
   end
 
@@ -386,12 +386,12 @@ describe Mail::Header do
     
     it "should unfold a header" do
       header = Mail::Header.new("To: Mikel,\r\n Lindsaar, Bob")
-      header['To'].value.should == 'Mikel, Lindsaar, Bob'
+      header['To'].value.should eql 'Mikel, Lindsaar, Bob'
     end
     
     it "should remove multiple spaces during unfolding a header" do
       header = Mail::Header.new("To: Mikel,\r\n   Lindsaar,     Bob")
-      header['To'].value.should == 'Mikel, Lindsaar, Bob'
+      header['To'].value.should eql 'Mikel, Lindsaar, Bob'
     end
     
     it "should handle a crazy long folded header" do
@@ -403,7 +403,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\r\n"))
-      header['Received'].value.should == 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      header['Received'].value.should eql 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
     end
     
     it "should convert all lonesome LFs to CRLF" do
@@ -415,7 +415,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\n"))
-      header['Received'].value.should == 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      header['Received'].value.should eql 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
     end
     
     it "should convert all lonesome CRs to CRLF" do
@@ -427,7 +427,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\r"))
-      header['Received'].value.should == 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      header['Received'].value.should eql 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
     end
     
   end
@@ -436,11 +436,11 @@ HERE
     it "should collect up any of its fields' errors" do
       header = Mail::Header.new("Content-Transfer-Encoding: vlad\r\nReply-To: a b b")
       header.errors.should_not be_blank
-      header.errors.size.should == 2
-      header.errors[0][0].should == 'Content-Transfer-Encoding'
-      header.errors[0][1].should == 'vlad'
-      header.errors[1][0].should == 'Reply-To'
-      header.errors[1][1].should == 'a b b'
+      header.errors.size.should eql 2
+      header.errors[0][0].to_s.should eql 'Content-Transfer-Encoding'
+      header.errors[0][1].to_s.should eql 'vlad'
+      header.errors[1][0].to_s.should eql 'Reply-To'
+      header.errors[1][1].to_s.should eql 'a b b'
     end
   end
 
@@ -450,7 +450,7 @@ HERE
         header = Mail::Header.new
         header[field] = "Thu, 05 Jun 2008 10:53:29 -0700"
         header[field] = "Mon, 15 Nov 2010 11:05:29 -1100"
-        header[field].value.should == "Mon, 15 Nov 2010 11:05:29 -1100"
+        header[field].value.should eql "Mon, 15 Nov 2010 11:05:29 -1100"
       end
     end
   
@@ -459,7 +459,7 @@ HERE
         header = Mail::Header.new
         header[field] = "mikel@test.lindsaar.net"
         header[field] = "ada@test.lindsaar.net"
-        header[field].value.should == "ada@test.lindsaar.net"
+        header[field].value.should eql "ada@test.lindsaar.net"
       end
     end
 
@@ -475,7 +475,7 @@ HERE
         header = Mail::Header.new
         header[field] = "1234"
         header[field] = "5678"
-        header[field].map { |x| x.value }.should == ["1234", "5678"]
+        header[field].map { |x| x.value }.should eql(["1234", "5678"])
       end
     end
     
@@ -483,9 +483,9 @@ HERE
       header = Mail::Header.new
       header.fields = ['X-Mail-SPAM: 15', 'X-Mail-SPAM: 20']
       header['X-Mail-SPAM'] = '10000'
-      header['X-Mail-SPAM'].map { |x| x.value }.should == ['15', '20', '10000']
+      header['X-Mail-SPAM'].map { |x| x.value.to_s }.should eql(["15", "20", "10000"])
       header['X-Mail-SPAM'] = nil
-      header['X-Mail-SPAM'].should == nil
+      header['X-Mail-SPAM'].should eql nil
     end
   end
 
@@ -503,18 +503,18 @@ TRACEHEADER
     end
     
     it "should instantiate one trace field object per header" do
-      @traced_header.fields.length.should == 5
+      @traced_header.fields.length.should eql 5
     end
     
     it "should add a new received header after the other received headers if they exist" do
       @traced_header['To'] = "Mikel"
       @traced_header['Received'] = "from agw2 by xxx.xxxx.xxx; Sun, 8 May 2005 12:30:13 -0500"
-      @traced_header.fields[0].addresses.should == ['xxx@xxxx.xxxtest']
-      @traced_header.fields[1].info.should == 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>'
-      @traced_header.fields[2].info.should == 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id j48HUC213279 for <xxx@xxxx.xxx>'
-      @traced_header.fields[3].info.should == 'from conversion-xxx.xxxx.xxx.net by xxx.xxxx.xxx id <0IG600901LQ64I@xxx.xxxx.xxx> for <xxx@xxxx.xxx>'
-      @traced_header.fields[5].info.should == "from agw2 by xxx.xxxx.xxx"
-      @traced_header.fields[6].field.class.should == Mail::ToField
+      @traced_header.fields[0].addresses.should eql ['xxx@xxxx.xxxtest']
+      @traced_header.fields[1].info.should eql 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>'
+      @traced_header.fields[2].info.should eql 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id j48HUC213279 for <xxx@xxxx.xxx>'
+      @traced_header.fields[3].info.should eql 'from conversion-xxx.xxxx.xxx.net by xxx.xxxx.xxx id <0IG600901LQ64I@xxx.xxxx.xxx> for <xxx@xxxx.xxx>'
+      @traced_header.fields[5].info.should eql "from agw2 by xxx.xxxx.xxx"
+      @traced_header.fields[6].field.class.should eql Mail::ToField
     end
     
   end
@@ -523,7 +523,7 @@ TRACEHEADER
     it "should output a parsed version of itself to US-ASCII on encoded and tidy up and sort correctly" do
       header = Mail::Header.new("To: Mikel\r\n\sLindsaar <mikel@test.lindsaar.net>\r\nFrom: bob\r\n\s<bob@test.lindsaar.net>\r\nSubject: This is\r\n a long\r\n\s \t \t \t    badly formatted             \r\n       \t\t  \t       field")
       result = "From: bob <bob@test.lindsaar.net>\r\nTo: Mikel Lindsaar <mikel@test.lindsaar.net>\r\nSubject: This is a long badly formatted field\r\n"
-      header.encoded.should == result
+      header.encoded.should eql result
     end
   end
   
@@ -556,32 +556,32 @@ TRACEHEADER
   describe "mime version handling" do
     it "should return the mime version of the email" do
       header = Mail::Header.new("Mime-Version: 1.0")
-      header['mime-version'].value.should == '1.0'
+      header['mime-version'].value.should eql '1.0'
     end
     
     it "should return nil if no mime-version header field" do
       header = Mail::Header.new('To: bob')
-      header['mime_version'].should == nil
+      header['mime_version'].should eql nil
     end
     
     it "should return the transfer-encoding of the email" do
       header = Mail::Header.new("Content-Transfer-Encoding: Base64")
-      header['content-transfer-encoding'].value.should == 'Base64'
+      header['content-transfer-encoding'].value.should eql 'Base64'
     end
     
     it "should return nil if no transfer-encoding header field" do
       header = Mail::Header.new
-      header['content-transfer-encoding'].should == nil
+      header['content-transfer-encoding'].should eql nil
     end
     
     it "should return the content-description of the email" do
       header = Mail::Header.new("Content-Description: This is a description")
-      header['Content-Description'].value.should == 'This is a description'
+      header['Content-Description'].value.should eql 'This is a description'
     end
     
     it "should return nil if no content-description header field" do
       header = Mail::Header.new
-      header['Content-Description'].should == nil
+      header['Content-Description'].should eql nil
     end
     
   end

--- a/spec/mail/mail_spec.rb
+++ b/spec/mail/mail_spec.rb
@@ -8,7 +8,7 @@ describe "mail" do
   end
   
   it "should be able to make a new email" do
-    Mail.new.class.should == Mail::Message
+    Mail.new.class.should eql Mail::Message
   end
   
   it "should accept headers and body" do
@@ -19,16 +19,16 @@ describe "mail" do
       subject 'Hello there Mikel'
       body    'This is a body of text'
     end
-    message.from.should      == ['mikel@me.com']
-    message.to.should        == ['mikel@you.com']
-    message.subject.should   == 'Hello there Mikel'
-    message.body.to_s.should == 'This is a body of text'
+    message.from.should      eql ['mikel@me.com']
+    message.to.should        eql ['mikel@you.com']
+    message.subject.should   eql 'Hello there Mikel'
+    message.body.to_s.should eql 'This is a body of text'
   end
 
   it "should read a file" do
     wrap_method = Mail.read(fixture('emails', 'plain_emails', 'raw_email.eml')).to_s
     file_method = Mail.new(File.read(fixture('emails', 'plain_emails', 'raw_email.eml'))).to_s
-    wrap_method.should == file_method
+    wrap_method.should eql file_method
   end
 
 end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -10,7 +10,7 @@ describe Mail::Message do
   describe "initialization" do
 
     it "should instantiate empty" do
-      Mail::Message.new.class.should == Mail::Message
+      Mail::Message.new.class.should eql Mail::Message
     end
 
     it "should return a basic email" do
@@ -18,15 +18,15 @@ describe Mail::Message do
       mail = Mail.new(mail.to_s)
       mail.date.should_not be_blank
       mail.message_id.should_not be_blank
-      mail.mime_version.should == "1.0"
-      mail.content_type.should == "text/plain"
-      mail.content_transfer_encoding.should == "7bit"
+      mail.mime_version.should eql "1.0"
+      mail.content_type.should eql "text/plain"
+      mail.content_transfer_encoding.should eql "7bit"
       mail.subject.should be_blank
       mail.body.should be_blank
     end
 
     it "should instantiate with a string" do
-      Mail::Message.new(basic_email).class.should == Mail::Message
+      Mail::Message.new(basic_email).class.should eql Mail::Message
     end
 
     it "should allow us to pass it a block" do
@@ -34,14 +34,14 @@ describe Mail::Message do
         from 'mikel@me.com'
         to 'lindsaar@you.com'
       end
-      mail.from.should == ['mikel@me.com']
-      mail.to.should == ['lindsaar@you.com']
+      mail.from.should eql ['mikel@me.com']
+      mail.to.should eql ['lindsaar@you.com']
     end
 
     it "should initialize a body and header class even if called with nothing to begin with" do
       mail = Mail::Message.new
-      mail.header.class.should == Mail::Header
-      mail.body.class.should == Mail::Body
+      mail.header.class.should eql Mail::Header
+      mail.body.class.should eql Mail::Body
     end
 
     it "should not report basic emails as bounced" do
@@ -101,14 +101,14 @@ describe Mail::Message do
 
     it "should read in an email message and basically parse it" do
       mail = Mail::Message.new(File.read(fixture('emails', 'plain_emails', 'basic_email.eml')))
-      mail.to.should == ["raasdnil@gmail.com"]
+      mail.to.should eql ["raasdnil@gmail.com"]
     end
 
     it "should not fail parsing message with caps in content_type" do
       mail = Mail::Message.new(File.read(fixture('emails', 'plain_emails', 'mix_caps_content_type.eml')))
-      mail.content_type.should == 'text/plain; charset=iso-8859-1'
-      mail.main_type.should == 'text'
-      mail.sub_type.should == 'plain'
+      mail.content_type.should eql 'text/plain; charset=iso-8859-1'
+      mail.main_type.should eql 'text'
+      mail.sub_type.should eql 'plain'
     end
 
     it "should be able to pass an empty reply-to header" do
@@ -133,31 +133,31 @@ describe Mail::Message do
       it "should serialize the basic information to YAML" do
         yaml = @yaml_mail.to_yaml
         yaml_output = YAML.load(yaml)
-        yaml_output['headers']['To'].should       == "someone@somewhere.com"
-        yaml_output['headers']['Cc'].should       == "someoneelse@somewhere.com"
-        yaml_output['headers']['Subject'].should  == "subject"
-        yaml_output['headers']['Bcc'].should      == "someonesecret@somewhere.com"
-        yaml_output['@body_raw'].should           == "body"
+        yaml_output['headers']['To'].should eql "someone@somewhere.com"
+        yaml_output['headers']['Cc'].should eql "someoneelse@somewhere.com"
+        yaml_output['headers']['Subject'].should eql "subject"
+        yaml_output['headers']['Bcc'].should eql "someonesecret@somewhere.com"
+        yaml_output['@body_raw'].should eql "body"
         yaml_output['@delivery_method'].should_not be_blank
       end
 
       it "should deserialize after serializing" do
         deserialized = Mail::Message.from_yaml(@yaml_mail.to_yaml)
+        deserialized.delivery_method.settings.should eql @smtp_settings
         deserialized.should == @yaml_mail
-        deserialized.delivery_method.settings.should == @smtp_settings
       end
 
       it "should serialize a Message with a custom delivery_handler" do
         @yaml_mail.delivery_handler = DeliveryAgent
         yaml = @yaml_mail.to_yaml
         yaml_output = YAML.load(yaml)
-        yaml_output['delivery_handler'].should == "DeliveryAgent"
+        yaml_output['delivery_handler'].should eql "DeliveryAgent"
       end
 
       it "should load a serialized delivery handler" do
         @yaml_mail.delivery_handler = DeliveryAgent
         deserialized = Mail::Message.from_yaml(@yaml_mail.to_yaml)
-        deserialized.delivery_handler.should == DeliveryAgent
+        deserialized.delivery_handler.should eql DeliveryAgent
       end
 
       it "should not deserialize a delivery_handler that does not exist" do
@@ -177,31 +177,31 @@ describe Mail::Message do
 
     it "should strip off the envelope from field if present" do
       message = Mail::Message.new(File.read(fixture('emails', 'plain_emails', 'raw_email.eml')))
-      message.envelope_from.should == "jamis_buck@byu.edu"
-      message.envelope_date.should == ::DateTime.parse("Mon May  2 16:07:05 2005")
+      message.envelope_from.should eql "jamis_buck@byu.edu"
+      message.envelope_date.should eql ::DateTime.parse("Mon May  2 16:07:05 2005")
     end
 
     it "should strip off the envelope from field if present" do
       message = Mail::Message.new(File.read(fixture('emails', 'plain_emails', 'raw_email.eml')))
-      message.raw_envelope.should == "jamis_buck@byu.edu Mon May  2 16:07:05 2005"
-      message.from.should == ["jamis@37signals.com"]
+      message.raw_envelope.should eql "jamis_buck@byu.edu Mon May  2 16:07:05 2005"
+      message.from.should eql ["jamis@37signals.com"]
     end
 
     it "should not cause any problems if there is no envelope from present" do
       message = Mail::Message.new(File.read(fixture('emails', 'plain_emails', 'basic_email.eml')))
-      message.from.should == ["test@lindsaar.net"]
+      message.from.should eql ["test@lindsaar.net"]
     end
 
     it "should ignore a plain text body that starts with ^From" do
       m = Mail::Message.new("From: mikel@test.lindsaar.net\r\n\r\nThis is a way to break mail by putting\r\nFrom at the start of a body\r\nor elsewhere.")
       m.from.should_not be_nil
-      m.from.should == ['mikel@test.lindsaar.net']
+      m.from.should eql ['mikel@test.lindsaar.net']
     end
 
     it "should handle a multipart message that has ^From in it" do
       m = Mail::Message.new(File.read(fixture('emails', 'error_emails', 'cant_parse_from.eml')))
       m.from.should_not be_nil
-      m.from.should == ["News@InsideApple.Apple.com"]
+      m.from.should eql ["News@InsideApple.Apple.com"]
       m.should be_multipart
     end
 
@@ -211,17 +211,17 @@ describe Mail::Message do
 
     it "should accept some email text to parse and return an email" do
       mail = Mail::Message.new(basic_email)
-      mail.class.should == Mail::Message
+      mail.class.should eql Mail::Message
     end
 
     it "should set a raw source instance variable to equal the passed in message" do
       mail = Mail::Message.new(basic_email)
-      mail.raw_source.should == basic_email.strip
+      mail.raw_source.should eql basic_email.strip
     end
 
     it "should set the raw source instance variable to '' if no message is passed in" do
       mail = Mail::Message.new
-      mail.raw_source.should == ""
+      mail.raw_source.should eql ""
     end
 
     it "should give the header class the header to parse" do
@@ -269,14 +269,14 @@ describe Mail::Message do
 
     it "should allow for whitespace at the start of the email" do
       mail = Mail.new("\r\n\r\nFrom: mikel\r\n\r\nThis is the body")
-      mail.from.should == ['mikel']
-      mail.body.to_s.should == 'This is the body'
+      mail.from.should eql ['mikel']
+      mail.body.to_s.should eql 'This is the body'
     end
 
     it "should read in an email message with the word 'From' in it multiple times and parse it" do
       mail = Mail::Message.new(File.read(fixture('emails', 'mime_emails', 'two_from_in_message.eml')))
       mail.to.should_not be_nil
-      mail.to.should == ["tester2@test.com"]
+      mail.to.should eql ["tester2@test.com"]
     end
 
   end
@@ -290,21 +290,21 @@ describe Mail::Message do
       end
 
       it "should allow you to grab field objects if you really want to" do
-        @mail.header_fields.class.should == Mail::FieldList
+        @mail.header_fields.class.should eql Mail::FieldList
       end
 
       it "should give you back the fields in the header" do
         @mail['bar'] = 'abcd'
-        @mail.header_fields.length.should == 1
+        @mail.header_fields.length.should eql 1
         @mail['foo'] = '4321'
-        @mail.header_fields.length.should == 2
+        @mail.header_fields.length.should eql 2
       end
 
       it "should delete a field if it is set to nil" do
         @mail['foo'] = '4321'
-        @mail.header_fields.length.should == 1
+        @mail.header_fields.length.should eql 1
         @mail['foo'] = nil
-        @mail.header_fields.length.should == 0
+        @mail.header_fields.length.should eql 0
       end
 
     end
@@ -317,32 +317,32 @@ describe Mail::Message do
 
       it "should return the to field" do
         @mail.to = "mikel"
-        @mail.to.should == ["mikel"]
+        @mail.to.should eql ["mikel"]
       end
 
       it "should return the from field" do
         @mail.from = "bob"
-        @mail.from.should == ["bob"]
+        @mail.from.should eql ["bob"]
       end
 
       it "should return the subject" do
         @mail.subject = "Hello!"
-        @mail.subject.should == "Hello!"
+        @mail.subject.should eql "Hello!"
       end
 
       it "should return the body decoded with to_s" do
         @mail.body "email message\r\n"
-        @mail.body.to_s.should == "email message\n"
+        @mail.body.to_s.should eql "email message\n"
       end
 
       it "should return the body encoded if asked for" do
         @mail.body "email message\r\n"
-        @mail.body.encoded.should == "email message\r\n"
+        @mail.body.encoded.should eql "email message\r\n"
       end
 
       it "should return the body decoded if asked for" do
         @mail.body "email message\r\n"
-        @mail.body.decoded.should == "email message\n"
+        @mail.body.decoded.should eql "email message\n"
       end
     end
 
@@ -354,32 +354,32 @@ describe Mail::Message do
 
       it "should return the to field" do
         @mail.to "mikel"
-        @mail.to.should == ["mikel"]
+        @mail.to.should eql ["mikel"]
       end
 
       it "should return the from field" do
         @mail.from "bob"
-        @mail.from.should == ["bob"]
+        @mail.from.should eql ["bob"]
       end
 
       it "should return the subject" do
         @mail.subject "Hello!"
-        @mail.subject.should == "Hello!"
+        @mail.subject.should eql "Hello!"
       end
 
       it "should return the body decoded with to_s" do
         @mail.body "email message\r\n"
-        @mail.body.to_s.should == "email message\n"
+        @mail.body.to_s.should eql "email message\n"
       end
 
       it "should return the body encoded if asked for" do
         @mail.body "email message\r\n"
-        @mail.body.encoded.should == "email message\r\n"
+        @mail.body.encoded.should eql "email message\r\n"
       end
 
       it "should return the body decoded if asked for" do
         @mail.body "email message\r\n"
-        @mail.body.decoded.should == "email message\n"
+        @mail.body.decoded.should eql "email message\n"
       end
     end
 
@@ -395,12 +395,12 @@ describe Mail::Message do
 
       it "should allow you to read arbitrary headers" do
         @mail['foo'] = 1234
-        @mail['foo'].value.to_s.should == '1234'
+        @mail['foo'].value.to_s.should eql '1234'
       end
 
       it "should instantiate a new Header" do
         @mail['foo'] = 1234
-        @mail.header_fields.first.class.should == Mail::Field
+        @mail.header_fields.first.class.should eql Mail::Field
       end
     end
 
@@ -408,19 +408,19 @@ describe Mail::Message do
 
       it "should allow you to replace a from field" do
         mail = Mail.new
-        mail.from.should == nil
+        mail.from.should eql nil
         mail.from = 'mikel@test.lindsaar.net'
-        mail.from.should == ['mikel@test.lindsaar.net']
+        mail.from.should eql ['mikel@test.lindsaar.net']
         mail.from = 'bob@test.lindsaar.net'
-        mail.from.should == ['bob@test.lindsaar.net']
+        mail.from.should eql ['bob@test.lindsaar.net']
       end
 
       it "should maintain the class of the field" do
         mail = Mail.new
         mail.from = 'mikel@test.lindsaar.net'
-        mail[:from].field.class.should == Mail::FromField
+        mail[:from].field.class.should eql Mail::FromField
         mail.from = 'bob@test.lindsaar.net'
-        mail[:from].field.class.should == Mail::FromField
+        mail[:from].field.class.should eql Mail::FromField
       end
     end
 
@@ -458,34 +458,34 @@ describe Mail::Message do
           body          'This is a body of text'
         end
 
-        message.bcc.should           == ['mikel@bcc.lindsaar.net']
-        message.cc.should            == ['mikel@cc.lindsaar.net']
-        message.comments.should      == 'this is a comment'
-        message.date.should          == DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          == ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   == '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      == ["test", "of the new mail", "system"]
-        message.message_id.should    == '1234@message_id.lindsaar.net'
-        message.received.date_time.should      == DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    == '1234@references.lindsaar.net'
-        message.reply_to.should      == ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    == ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     == ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   == DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   == ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should == '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should == ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     == ['mikel@resent-to.lindsaar.net']
-        message.sender.should        == 'mikel@sender.lindsaar.net'
-        message.subject.should       == 'Hello there Mikel'
-        message.to.should            == ['mikel@to.lindsaar.net']
-        message.content_type.should              == 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should == '7bit'
-        message.content_description.should       == 'This is a test'
-        message.content_disposition.should       == 'attachment; filename=File'
-        message.content_id.should                == '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              == '1.0'
-        message.body.to_s.should          == 'This is a body of text'
+        message.bcc.should           eql ['mikel@bcc.lindsaar.net']
+        message.cc.should            eql ['mikel@cc.lindsaar.net']
+        message.comments.should      eql 'this is a comment'
+        message.date.should          eql DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        message.from.should          eql ['mikel@from.lindsaar.net']
+        message.in_reply_to.should   eql '1234@in_reply_to.lindsaar.net'
+        message.keywords.should      eql ["test", "of the new mail", "system"]
+        message.message_id.should    eql '1234@message_id.lindsaar.net'
+        message.received.date_time.should      eql DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        message.references.should    eql '1234@references.lindsaar.net'
+        message.reply_to.should      eql ['mikel@reply-to.lindsaar.net']
+        message.resent_bcc.should    eql ['mikel@resent-bcc.lindsaar.net']
+        message.resent_cc.should     eql ['mikel@resent-cc.lindsaar.net']
+        message.resent_date.should   eql DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        message.resent_from.should   eql ['mikel@resent-from.lindsaar.net']
+        message.resent_message_id.should eql '1234@resent_message_id.lindsaar.net'
+        message.resent_sender.should eql ['mikel@resent-sender.lindsaar.net']
+        message.resent_to.should     eql ['mikel@resent-to.lindsaar.net']
+        message.sender.should        eql 'mikel@sender.lindsaar.net'
+        message.subject.should       eql 'Hello there Mikel'
+        message.to.should            eql ['mikel@to.lindsaar.net']
+        message.content_type.should              eql 'text/plain; charset=UTF-8'
+        message.content_transfer_encoding.should eql '7bit'
+        message.content_description.should       eql 'This is a test'
+        message.content_disposition.should       eql 'attachment; filename=File'
+        message.content_id.should                eql '<1234@message_id.lindsaar.net>'
+        message.mime_version.should              eql '1.0'
+        message.body.to_s.should          eql 'This is a body of text'
       end
 
       it "should accept them in assignment form" do
@@ -519,34 +519,34 @@ describe Mail::Message do
         message.mime_version =  '1.0'
         message.body =          'This is a body of text'
 
-        message.bcc.should           == ['mikel@bcc.lindsaar.net']
-        message.cc.should            == ['mikel@cc.lindsaar.net']
-        message.comments.should      == 'this is a comment'
-        message.date.should          == DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          == ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   == '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      == ["test", "of the new mail", "system"]
-        message.message_id.should    == '1234@message_id.lindsaar.net'
-        message.received.date_time.should      == DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    == '1234@references.lindsaar.net'
-        message.reply_to.should      == ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    == ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     == ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   == DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   == ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should == '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should == ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     == ['mikel@resent-to.lindsaar.net']
-        message.sender.should        == 'mikel@sender.lindsaar.net'
-        message.subject.should       == 'Hello there Mikel'
-        message.to.should            == ['mikel@to.lindsaar.net']
-        message.content_type.should              == 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should == '7bit'
-        message.content_description.should       == 'This is a test'
-        message.content_disposition.should       == 'attachment; filename=File'
-        message.content_id.should                == '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              == '1.0'
-        message.body.to_s.should          == 'This is a body of text'
+        message.bcc.should           eql ['mikel@bcc.lindsaar.net']
+        message.cc.should            eql ['mikel@cc.lindsaar.net']
+        message.comments.should      eql 'this is a comment'
+        message.date.should          eql DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        message.from.should          eql ['mikel@from.lindsaar.net']
+        message.in_reply_to.should   eql '1234@in_reply_to.lindsaar.net'
+        message.keywords.should      eql ["test", "of the new mail", "system"]
+        message.message_id.should    eql '1234@message_id.lindsaar.net'
+        message.received.date_time.should      eql DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        message.references.should    eql '1234@references.lindsaar.net'
+        message.reply_to.should      eql ['mikel@reply-to.lindsaar.net']
+        message.resent_bcc.should    eql ['mikel@resent-bcc.lindsaar.net']
+        message.resent_cc.should     eql ['mikel@resent-cc.lindsaar.net']
+        message.resent_date.should   eql DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        message.resent_from.should   eql ['mikel@resent-from.lindsaar.net']
+        message.resent_message_id.should eql '1234@resent_message_id.lindsaar.net'
+        message.resent_sender.should eql ['mikel@resent-sender.lindsaar.net']
+        message.resent_to.should     eql ['mikel@resent-to.lindsaar.net']
+        message.sender.should        eql 'mikel@sender.lindsaar.net'
+        message.subject.should       eql 'Hello there Mikel'
+        message.to.should            eql ['mikel@to.lindsaar.net']
+        message.content_type.should              eql 'text/plain; charset=UTF-8'
+        message.content_transfer_encoding.should eql '7bit'
+        message.content_description.should       eql 'This is a test'
+        message.content_disposition.should       eql 'attachment; filename=File'
+        message.content_id.should                eql '<1234@message_id.lindsaar.net>'
+        message.mime_version.should              eql '1.0'
+        message.body.to_s.should          eql 'This is a body of text'
       end
 
       it "should accept them in key, value form as symbols" do
@@ -580,34 +580,34 @@ describe Mail::Message do
         message[:mime_version]=  '1.0'
         message[:body] =          'This is a body of text'
 
-        message.bcc.should           == ['mikel@bcc.lindsaar.net']
-        message.cc.should            == ['mikel@cc.lindsaar.net']
-        message.comments.should      == 'this is a comment'
-        message.date.should          == DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          == ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   == '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      == ["test", "of the new mail", "system"]
-        message.message_id.should    == '1234@message_id.lindsaar.net'
-        message.received.date_time.should      == DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    == '1234@references.lindsaar.net'
-        message.reply_to.should      == ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    == ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     == ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   == DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   == ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should == '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should == ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     == ['mikel@resent-to.lindsaar.net']
-        message.sender.should        == 'mikel@sender.lindsaar.net'
-        message.subject.should       == 'Hello there Mikel'
-        message.to.should            == ['mikel@to.lindsaar.net']
-        message.content_type.should              == 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should == '7bit'
-        message.content_description.should       == 'This is a test'
-        message.content_disposition.should       == 'attachment; filename=File'
-        message.content_id.should                == '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              == '1.0'
-        message.body.to_s.should          == 'This is a body of text'
+        message.bcc.should           eql ['mikel@bcc.lindsaar.net']
+        message.cc.should            eql ['mikel@cc.lindsaar.net']
+        message.comments.should      eql 'this is a comment'
+        message.date.should          eql DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        message.from.should          eql ['mikel@from.lindsaar.net']
+        message.in_reply_to.should   eql '1234@in_reply_to.lindsaar.net'
+        message.keywords.should      eql ["test", "of the new mail", "system"]
+        message.message_id.should    eql '1234@message_id.lindsaar.net'
+        message.received.date_time.should      eql DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        message.references.should    eql '1234@references.lindsaar.net'
+        message.reply_to.should      eql ['mikel@reply-to.lindsaar.net']
+        message.resent_bcc.should    eql ['mikel@resent-bcc.lindsaar.net']
+        message.resent_cc.should     eql ['mikel@resent-cc.lindsaar.net']
+        message.resent_date.should   eql DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        message.resent_from.should   eql ['mikel@resent-from.lindsaar.net']
+        message.resent_message_id.should eql '1234@resent_message_id.lindsaar.net'
+        message.resent_sender.should eql ['mikel@resent-sender.lindsaar.net']
+        message.resent_to.should     eql ['mikel@resent-to.lindsaar.net']
+        message.sender.should        eql 'mikel@sender.lindsaar.net'
+        message.subject.should       eql 'Hello there Mikel'
+        message.to.should            eql ['mikel@to.lindsaar.net']
+        message.content_type.should              eql 'text/plain; charset=UTF-8'
+        message.content_transfer_encoding.should eql '7bit'
+        message.content_description.should       eql 'This is a test'
+        message.content_disposition.should       eql 'attachment; filename=File'
+        message.content_id.should                eql '<1234@message_id.lindsaar.net>'
+        message.mime_version.should              eql '1.0'
+        message.body.to_s.should          eql 'This is a body of text'
       end
 
       it "should accept them in key, value form as strings" do
@@ -641,34 +641,34 @@ describe Mail::Message do
         message['mime_version'] =  '1.0'
         message['body'] =          'This is a body of text'
 
-        message.bcc.should           == ['mikel@bcc.lindsaar.net']
-        message.cc.should            == ['mikel@cc.lindsaar.net']
-        message.comments.should      == 'this is a comment'
-        message.date.should          == DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          == ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   == '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      == ["test", "of the new mail", "system"]
-        message.message_id.should    == '1234@message_id.lindsaar.net'
-        message.received.date_time.should      == DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    == '1234@references.lindsaar.net'
-        message.reply_to.should      == ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    == ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     == ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   == DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   == ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should == '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should == ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     == ['mikel@resent-to.lindsaar.net']
-        message.sender.should        == 'mikel@sender.lindsaar.net'
-        message.subject.should       == 'Hello there Mikel'
-        message.to.should            == ['mikel@to.lindsaar.net']
-        message.content_type.should              == 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should == '7bit'
-        message.content_description.should       == 'This is a test'
-        message.content_disposition.should       == 'attachment; filename=File'
-        message.content_id.should                == '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              == '1.0'
-        message.body.to_s.should          == 'This is a body of text'
+        message.bcc.should           eql ['mikel@bcc.lindsaar.net']
+        message.cc.should            eql ['mikel@cc.lindsaar.net']
+        message.comments.should      eql 'this is a comment'
+        message.date.should          eql DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        message.from.should          eql ['mikel@from.lindsaar.net']
+        message.in_reply_to.should   eql '1234@in_reply_to.lindsaar.net'
+        message.keywords.should      eql ["test", "of the new mail", "system"]
+        message.message_id.should    eql '1234@message_id.lindsaar.net'
+        message.received.date_time.should      eql DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        message.references.should    eql '1234@references.lindsaar.net'
+        message.reply_to.should      eql ['mikel@reply-to.lindsaar.net']
+        message.resent_bcc.should    eql ['mikel@resent-bcc.lindsaar.net']
+        message.resent_cc.should     eql ['mikel@resent-cc.lindsaar.net']
+        message.resent_date.should   eql DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        message.resent_from.should   eql ['mikel@resent-from.lindsaar.net']
+        message.resent_message_id.should eql '1234@resent_message_id.lindsaar.net'
+        message.resent_sender.should eql ['mikel@resent-sender.lindsaar.net']
+        message.resent_to.should     eql ['mikel@resent-to.lindsaar.net']
+        message.sender.should        eql 'mikel@sender.lindsaar.net'
+        message.subject.should       eql 'Hello there Mikel'
+        message.to.should            eql ['mikel@to.lindsaar.net']
+        message.content_type.should              eql 'text/plain; charset=UTF-8'
+        message.content_transfer_encoding.should eql '7bit'
+        message.content_description.should       eql 'This is a test'
+        message.content_disposition.should       eql 'attachment; filename=File'
+        message.content_id.should                eql '<1234@message_id.lindsaar.net>'
+        message.mime_version.should              eql '1.0'
+        message.body.to_s.should          eql 'This is a body of text'
       end
 
       it "should accept them as a hash with symbols" do
@@ -703,34 +703,34 @@ describe Mail::Message do
           :body =>          'This is a body of text'
         })
 
-        message.bcc.should           == ['mikel@bcc.lindsaar.net']
-        message.cc.should            == ['mikel@cc.lindsaar.net']
-        message.comments.should      == 'this is a comment'
-        message.date.should          == DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          == ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   == '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      == ["test", "of the new mail", "system"]
-        message.message_id.should    == '1234@message_id.lindsaar.net'
-        message.received.date_time.should      == DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    == '1234@references.lindsaar.net'
-        message.reply_to.should      == ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    == ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     == ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   == DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   == ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should == '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should == ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     == ['mikel@resent-to.lindsaar.net']
-        message.sender.should        == 'mikel@sender.lindsaar.net'
-        message.subject.should       == 'Hello there Mikel'
-        message.to.should            == ['mikel@to.lindsaar.net']
-        message.content_type.should              == 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should == '7bit'
-        message.content_description.should       == 'This is a test'
-        message.content_disposition.should       == 'attachment; filename=File'
-        message.content_id.should                == '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              == '1.0'
-        message.body.to_s.should          == 'This is a body of text'
+        message.bcc.should           eql ['mikel@bcc.lindsaar.net']
+        message.cc.should            eql ['mikel@cc.lindsaar.net']
+        message.comments.should      eql 'this is a comment'
+        message.date.should          eql DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        message.from.should          eql ['mikel@from.lindsaar.net']
+        message.in_reply_to.should   eql '1234@in_reply_to.lindsaar.net'
+        message.keywords.should      eql ["test", "of the new mail", "system"]
+        message.message_id.should    eql '1234@message_id.lindsaar.net'
+        message.received.date_time.should      eql DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        message.references.should    eql '1234@references.lindsaar.net'
+        message.reply_to.should      eql ['mikel@reply-to.lindsaar.net']
+        message.resent_bcc.should    eql ['mikel@resent-bcc.lindsaar.net']
+        message.resent_cc.should     eql ['mikel@resent-cc.lindsaar.net']
+        message.resent_date.should   eql DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        message.resent_from.should   eql ['mikel@resent-from.lindsaar.net']
+        message.resent_message_id.should eql '1234@resent_message_id.lindsaar.net'
+        message.resent_sender.should eql ['mikel@resent-sender.lindsaar.net']
+        message.resent_to.should     eql ['mikel@resent-to.lindsaar.net']
+        message.sender.should        eql 'mikel@sender.lindsaar.net'
+        message.subject.should       eql 'Hello there Mikel'
+        message.to.should            eql ['mikel@to.lindsaar.net']
+        message.content_type.should              eql 'text/plain; charset=UTF-8'
+        message.content_transfer_encoding.should eql '7bit'
+        message.content_description.should       eql 'This is a test'
+        message.content_disposition.should       eql 'attachment; filename=File'
+        message.content_id.should                eql '<1234@message_id.lindsaar.net>'
+        message.mime_version.should              eql '1.0'
+        message.body.to_s.should          eql 'This is a body of text'
       end
 
       it "should accept them as a hash with strings" do
@@ -765,46 +765,46 @@ describe Mail::Message do
           'body' =>          'This is a body of text'
         })
 
-        message.bcc.should           == ['mikel@bcc.lindsaar.net']
-        message.cc.should            == ['mikel@cc.lindsaar.net']
-        message.comments.should      == 'this is a comment'
-        message.date.should          == DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          == ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   == '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      == ["test", "of the new mail", "system"]
-        message.message_id.should    == '1234@message_id.lindsaar.net'
-        message.received.date_time.should      == DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    == '1234@references.lindsaar.net'
-        message.reply_to.should      == ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    == ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     == ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   == DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   == ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should == '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should == ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     == ['mikel@resent-to.lindsaar.net']
-        message.sender.should        == 'mikel@sender.lindsaar.net'
-        message.subject.should       == 'Hello there Mikel'
-        message.to.should            == ['mikel@to.lindsaar.net']
-        message.content_type.should              == 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should == '7bit'
-        message.content_description.should       == 'This is a test'
-        message.content_disposition.should       == 'attachment; filename=File'
-        message.content_id.should                == '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              == '1.0'
-        message.body.to_s.should          == 'This is a body of text'
+        message.bcc.should           eql ['mikel@bcc.lindsaar.net']
+        message.cc.should            eql ['mikel@cc.lindsaar.net']
+        message.comments.should      eql 'this is a comment'
+        message.date.should          eql DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        message.from.should          eql ['mikel@from.lindsaar.net']
+        message.in_reply_to.should   eql '1234@in_reply_to.lindsaar.net'
+        message.keywords.should      eql ["test", "of the new mail", "system"]
+        message.message_id.should    eql '1234@message_id.lindsaar.net'
+        message.received.date_time.should      eql DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        message.references.should    eql '1234@references.lindsaar.net'
+        message.reply_to.should      eql ['mikel@reply-to.lindsaar.net']
+        message.resent_bcc.should    eql ['mikel@resent-bcc.lindsaar.net']
+        message.resent_cc.should     eql ['mikel@resent-cc.lindsaar.net']
+        message.resent_date.should   eql DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        message.resent_from.should   eql ['mikel@resent-from.lindsaar.net']
+        message.resent_message_id.should eql '1234@resent_message_id.lindsaar.net'
+        message.resent_sender.should eql ['mikel@resent-sender.lindsaar.net']
+        message.resent_to.should     eql ['mikel@resent-to.lindsaar.net']
+        message.sender.should        eql 'mikel@sender.lindsaar.net'
+        message.subject.should       eql 'Hello there Mikel'
+        message.to.should            eql ['mikel@to.lindsaar.net']
+        message.content_type.should              eql 'text/plain; charset=UTF-8'
+        message.content_transfer_encoding.should eql '7bit'
+        message.content_description.should       eql 'This is a test'
+        message.content_disposition.should       eql 'attachment; filename=File'
+        message.content_id.should                eql '<1234@message_id.lindsaar.net>'
+        message.mime_version.should              eql '1.0'
+        message.body.to_s.should          eql 'This is a body of text'
       end
 
       it "should let you set custom headers with a :headers => {hash}" do
         message = Mail.new(:headers => {'custom-header' => 'mikel'})
-        message['custom-header'].decoded.should == 'mikel'
+        message['custom-header'].decoded.should eql 'mikel'
       end
 
       it "should assign the body to a part on creation" do
         message = Mail.new do
           part({:content_type=>"multipart/alternative", :content_disposition=>"inline", :body=>"Nothing to see here."})
         end
-        message.parts.first.body.decoded.should == "Nothing to see here."
+        message.parts.first.body.decoded.should eql "Nothing to see here."
       end
 
       it "should not overwrite bodies on creation" do
@@ -813,27 +813,27 @@ describe Mail::Message do
             p.part :content_type => "text/html", :body => "<b>test</b> HTML<br/>"
           end
         end
-        message.parts.first.parts[0].body.decoded.should == "Nothing to see here."
-        message.parts.first.parts[1].body.decoded.should == "<b>test</b> HTML<br/>"
+        message.parts.first.parts[0].body.decoded.should eql "Nothing to see here."
+        message.parts.first.parts[1].body.decoded.should eql "<b>test</b> HTML<br/>"
         message.encoded.should match %r{Nothing to see here\.}
         message.encoded.should match %r{<b>test</b> HTML<br/>}
       end
 
       it "should allow you to init on an array of addresses from a hash" do
         mail = Mail.new(:to => ['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>'])
-        mail.to.should == ['test1@lindsaar.net', 'test2@lindsaar.net']
+        mail.to.should eql ['test1@lindsaar.net', 'test2@lindsaar.net']
       end
 
       it "should allow you to init on an array of addresses directly" do
         mail = Mail.new
         mail.to = ['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>']
-        mail.to.should == ['test1@lindsaar.net', 'test2@lindsaar.net']
+        mail.to.should eql ['test1@lindsaar.net', 'test2@lindsaar.net']
       end
 
       it "should allow you to init on an array of addresses directly" do
         mail = Mail.new
         mail[:to] = ['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>']
-        mail.to.should == ['test1@lindsaar.net', 'test2@lindsaar.net']
+        mail.to.should eql ['test1@lindsaar.net', 'test2@lindsaar.net']
       end
 
     end
@@ -902,7 +902,7 @@ describe Mail::Message do
         it "should add a body part if it is missing" do
           mail = Mail.new
           mail.to_s
-          mail.body.class.should == Mail::Body
+          mail.body.class.should eql Mail::Body
         end
       end
 
@@ -1097,20 +1097,20 @@ describe Mail::Message do
         it "should be able to set a content type with an array and hash" do
           mail = Mail.new
           mail.content_type = ["text", "plain", { :charset => 'US-ASCII' }]
-          mail[:content_type].encoded.should == %Q[Content-Type: text/plain;\r\n\scharset=US-ASCII\r\n]
-          mail.content_type_parameters.should == {"charset" => "US-ASCII"}
+          mail[:content_type].encoded.should eql %Q[Content-Type: text/plain;\r\n\scharset=US-ASCII\r\n]
+          mail.content_type_parameters.should eql({"charset" => "US-ASCII"})
         end
 
         it "should be able to set a content type with an array and hash with a non-usascii field" do
           mail = Mail.new
           mail.content_type = ["text", "plain", { :charset => 'UTF-8' }]
-          mail[:content_type].encoded.should == %Q[Content-Type: text/plain;\r\n\scharset=UTF-8\r\n]
-          mail.content_type_parameters.should == {"charset" => "UTF-8"}
+          mail[:content_type].encoded.should eql %Q[Content-Type: text/plain;\r\n\scharset=UTF-8\r\n]
+          mail.content_type_parameters.should eql({"charset" => "UTF-8"})
         end
 
         it "should allow us to specify a content type in a block" do
           mail = Mail.new { content_type ["text", "plain", { "charset" => "UTF-8" }] }
-          mail.content_type_parameters.should == {"charset" => "UTF-8"}
+          mail.content_type_parameters.should eql({"charset" => "UTF-8"})
         end
 
       end
@@ -1197,7 +1197,7 @@ describe Mail::Message do
         content_transfer_encoding 'base64'
         body "VGhlIGJvZHk=\n"
       end
-      mail.decoded.should == "The body"
+      mail.decoded.should eql "The body"
     end
 
     describe "decoding bodies" do
@@ -1206,8 +1206,8 @@ describe Mail::Message do
         mail = Mail.new do
           body "The=3Dbody"
         end
-        mail.body.decoded.should == "The=3Dbody"
-        mail.body.encoded.should == "The=3Dbody"
+        mail.body.decoded.should eql "The=3Dbody"
+        mail.body.encoded.should eql "The=3Dbody"
       end
 
       it "should change a body on decode if given an encoding type to decode" do
@@ -1215,8 +1215,8 @@ describe Mail::Message do
           content_transfer_encoding 'quoted-printable'
           body "The=3Dbody"
         end
-        mail.body.decoded.should == "The=body"
-        mail.body.encoded.should == "The=3Dbody=\r\n"
+        mail.body.decoded.should eql "The=body"
+        mail.body.encoded.should eql "The=3Dbody=\r\n"
       end
 
       it "should change a body on decode if given an encoding type to decode" do
@@ -1224,8 +1224,8 @@ describe Mail::Message do
           content_transfer_encoding 'base64'
           body "VGhlIGJvZHk=\n"
         end
-        mail.body.decoded.should == "The body"
-        mail.body.encoded.should == "VGhlIGJvZHk=\r\n"
+        mail.body.decoded.should eql "The body"
+        mail.body.encoded.should eql "VGhlIGJvZHk=\r\n"
       end
 
     end
@@ -1260,29 +1260,29 @@ describe Mail::Message do
       it "should not be == if both emails have different Message IDs" do
         m1 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <4321@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
         m2 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <1234@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
-        m1.should_not == m2
+        m1.should_not eql m2
       end
 
       it "should preserve the message id of self if set" do
         m1 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <1234@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
         m2 = Mail.new("To: mikel@test.lindsaar.net\r\nSubject: Yo!\r\n\r\nHello there")
-        m1 == m2
-        m1.message_id.should == '1234@test.lindsaar.net'
+        m1.message_id.should eql '1234@test.lindsaar.net'
+        m1.should == m2
       end
 
       it "should preserve the message id of other if set" do
         m1 = Mail.new("To: mikel@test.lindsaar.net\r\nSubject: Yo!\r\n\r\nHello there")
         m2 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <1234@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
-        m1 == m2
-        m2.message_id.should == '1234@test.lindsaar.net'
+        m2.message_id.should eql '1234@test.lindsaar.net'
+        m1.should == m2
       end
 
       it "should preserve the message id of both if set" do
         m1 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <4321@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
         m2 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <1234@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
-        m1 == m2
-        m1.message_id.should == '4321@test.lindsaar.net'
-        m2.message_id.should == '1234@test.lindsaar.net'
+        m1.message_id.should eql '4321@test.lindsaar.net'
+        m2.message_id.should eql '1234@test.lindsaar.net'
+        m1.should_not == m2
       end
     end
 
@@ -1294,7 +1294,7 @@ describe Mail::Message do
       mail2 = Mail.new do
         date(now - 10) # Make mail2 10 seconds 'older'
       end
-      [mail2, mail1].sort.should == [mail2, mail1]
+      [mail2, mail1].sort.should eql [mail2, mail1]
     end
 
     it "should have a destinations method" do
@@ -1303,66 +1303,66 @@ describe Mail::Message do
         cc 'bob@test.lindsaar.net'
         bcc 'sam@test.lindsaar.net'
       end
-      mail.destinations.length.should == 3
+      mail.destinations.length.should eql 3
     end
 
     it "should have a from_addrs method" do
       mail = Mail.new do
         from 'mikel@test.lindsaar.net'
       end
-      mail.from_addrs.length.should == 1
+      mail.from_addrs.length.should eql 1
     end
 
     it "should have a from_addrs method that is empty if nil" do
       mail = Mail.new do
       end
-      mail.from_addrs.length.should == 0
+      mail.from_addrs.length.should eql 0
     end
 
     it "should have a to_addrs method" do
       mail = Mail.new do
         to 'mikel@test.lindsaar.net'
       end
-      mail.to_addrs.length.should == 1
+      mail.to_addrs.length.should eql 1
     end
 
     it "should have a to_addrs method that is empty if nil" do
       mail = Mail.new do
       end
-      mail.to_addrs.length.should == 0
+      mail.to_addrs.length.should eql 0
     end
 
     it "should have a cc_addrs method" do
       mail = Mail.new do
         cc 'bob@test.lindsaar.net'
       end
-      mail.cc_addrs.length.should == 1
+      mail.cc_addrs.length.should eql 1
     end
 
     it "should have a cc_addrs method that is empty if nil" do
       mail = Mail.new do
       end
-      mail.cc_addrs.length.should == 0
+      mail.cc_addrs.length.should eql 0
     end
 
     it "should have a bcc_addrs method" do
       mail = Mail.new do
         bcc 'sam@test.lindsaar.net'
       end
-      mail.bcc_addrs.length.should == 1
+      mail.bcc_addrs.length.should eql 1
     end
 
     it "should have a bcc_addrs method that is empty if nil" do
       mail = Mail.new do
       end
-      mail.bcc_addrs.length.should == 0
+      mail.bcc_addrs.length.should eql 0
     end
 
     it "should give destinations even if some of the fields are blank" do
       mail = Mail.new do
         to 'mikel@test.lindsaar.net'
       end
-      mail.destinations.length.should == 1
+      mail.destinations.length.should eql 1
     end
 
     it "should be able to encode with only one destination" do
@@ -1390,11 +1390,11 @@ describe Mail::Message do
       end
 
       mail.parts.first.should be_multipart
-      mail.parts.first.parts.length.should == 2
-      mail.parts.first.parts[0][:content_type].string.should == "text/plain"
-      mail.parts.first.parts[0].body.decoded.should == "test text\nline #2"
-      mail.parts.first.parts[1][:content_type].string.should == "text/html"
-      mail.parts.first.parts[1].body.decoded.should == "<b>test</b> HTML<br/>\nline #2"
+      mail.parts.first.parts.length.should eql 2
+      mail.parts.first.parts[0][:content_type].string.should eql "text/plain"
+      mail.parts.first.parts[0].body.decoded.should eql "test text\nline #2"
+      mail.parts.first.parts[1][:content_type].string.should eql "text/html"
+      mail.parts.first.parts[1].body.decoded.should eql "<b>test</b> HTML<br/>\nline #2"
     end
   end
 
@@ -1402,7 +1402,7 @@ describe Mail::Message do
     it "should return self after delivery" do
       mail = Mail.new
       mail.perform_deliveries = false
-      mail.deliver.should == mail
+      mail.deliver.should eql mail
     end
 
     class DeliveryAgent
@@ -1468,7 +1468,7 @@ describe Mail::Message do
       InterceptorAgent.intercept = true
       mail.deliver
       InterceptorAgent.intercept = false
-      mail.to.should == ['bob@example.com']
+      mail.to.should eql ['bob@example.com']
     end
 
   end
@@ -1477,11 +1477,11 @@ describe Mail::Message do
     it "should collect up any of its fields' errors" do
       mail = Mail.new("Content-Transfer-Encoding: vlad\r\nReply-To: a b b\r\n")
       mail.errors.should_not be_blank
-      mail.errors.size.should == 2
-      mail.errors[0][0].should == 'Content-Transfer-Encoding'
-      mail.errors[0][1].should == 'vlad'
-      mail.errors[1][0].should == 'Reply-To'
-      mail.errors[1][1].should == 'a b b'
+      mail.errors.size.should eql 2
+      mail.errors[0][0].to_s.should eql 'Content-Transfer-Encoding'
+      mail.errors[0][1].to_s.should eql 'vlad'
+      mail.errors[1][0].to_s.should eql 'Reply-To'
+      mail.errors[1][1].to_s.should eql 'a b b'
     end
   end
 
@@ -1496,9 +1496,9 @@ describe Mail::Message do
   describe "parsing emails with non usascii in the header" do
     it "should work" do
       mail = Mail.new('From: "Foo áëô îü" <extended@example.net>')
-      mail.from.should == ['extended@example.net']
-      mail[:from].decoded.should == '"Foo áëô îü" <extended@example.net>'
-      mail[:from].encoded.should == "From: =?UTF-8?B?Rm9vIMOhw6vDtCDDrsO8?= <extended@example.net>\r\n"
+      mail.from.should eql ['extended@example.net']
+      mail[:from].decoded.should eql '"Foo áëô îü" <extended@example.net>'
+      mail[:from].encoded.should eql "From: =?UTF-8?B?Rm9vIMOhw6vDtCDDrsO8?= <extended@example.net>\r\n"
     end
   end
 
@@ -1512,10 +1512,10 @@ describe Mail::Message do
       p.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
       mail.add_part(p)
       mail.encoded
-      mail.parts[0].mime_type.should == "multipart/alternative"
-      mail.parts[0].parts[0].mime_type.should == "text/plain"
-      mail.parts[0].parts[1].mime_type.should == "text/html"
-      mail.parts[1].mime_type.should == "image/png"
+      mail.parts[0].mime_type.should eql "multipart/alternative"
+      mail.parts[0].parts[0].mime_type.should eql "text/plain"
+      mail.parts[0].parts[1].mime_type.should eql "text/html"
+      mail.parts[1].mime_type.should eql "image/png"
     end
   end
 
@@ -1546,33 +1546,33 @@ describe Mail::Message do
       end
 
       it "should be in-reply-to the original message" do
-        @mail.reply.in_reply_to.should == '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
+        @mail.reply.in_reply_to.should eql '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
       end
 
       it "should reference the original message" do
-        @mail.reply.references.should == '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
+        @mail.reply.references.should eql '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
       end
 
       it "should RE: the original subject" do
-        @mail.reply.subject.should == 'RE: Testing 123'
+        @mail.reply.subject.should eql 'RE: Testing 123'
       end
 
       it "should be sent to the original sender" do
-        @mail.reply.to.should == ['test@lindsaar.net']
-        @mail.reply[:to].to_s.should == 'Mikel Lindsaar <test@lindsaar.net>'
+        @mail.reply.to.should eql ['test@lindsaar.net']
+        @mail.reply[:to].to_s.should eql 'Mikel Lindsaar <test@lindsaar.net>'
       end
 
       it "should be sent from the original recipient" do
-        @mail.reply.from.should == ['raasdnil@gmail.com']
-        @mail.reply[:from].to_s.should == 'Mikel Lindsaar <raasdnil@gmail.com>'
+        @mail.reply.from.should eql ['raasdnil@gmail.com']
+        @mail.reply[:from].to_s.should eql 'Mikel Lindsaar <raasdnil@gmail.com>'
       end
 
       it "should accept args" do
-        @mail.reply(:from => 'Donald Ball <donald.ball@gmail.com>').from.should == ['donald.ball@gmail.com']
+        @mail.reply(:from => 'Donald Ball <donald.ball@gmail.com>').from.should eql ['donald.ball@gmail.com']
       end
 
       it "should accept a block" do
-        @mail.reply { from('Donald Ball <donald.ball@gmail.com>') }.from.should == ['donald.ball@gmail.com']
+        @mail.reply { from('Donald Ball <donald.ball@gmail.com>') }.from.should eql ['donald.ball@gmail.com']
       end
 
     end
@@ -1584,7 +1584,7 @@ describe Mail::Message do
       end
 
       it "should be sent to the reply-to address" do
-        @mail.reply[:to].to_s.should == '"Mary Smith: Personal Account" <smith@home.example>'
+        @mail.reply[:to].to_s.should eql '"Mary Smith: Personal Account" <smith@home.example>'
       end
 
     end
@@ -1596,7 +1596,7 @@ describe Mail::Message do
       end
 
       it "should be sent from the first to address" do
-        @mail.reply[:from].to_s.should == 'Mary Smith <mary@x.test>'
+        @mail.reply[:from].to_s.should eql 'Mary Smith <mary@x.test>'
       end
 
     end
@@ -1608,15 +1608,15 @@ describe Mail::Message do
       end
 
       it "should be in-reply-to the original message" do
-        @mail.reply.in_reply_to.should == '473FFE27.20003@xxx.org'
+        @mail.reply.in_reply_to.should eql '473FFE27.20003@xxx.org'
       end
 
       it "should append to the original's references list" do
-        @mail.reply[:references].message_ids.should == ['473FF3B8.9020707@xxx.org', '348F04F142D69C21-291E56D292BC@xxxx.net', '473FFE27.20003@xxx.org']
+        @mail.reply[:references].message_ids.should eql ['473FF3B8.9020707@xxx.org', '348F04F142D69C21-291E56D292BC@xxxx.net', '473FFE27.20003@xxx.org']
       end
 
       it "should not append another RE:" do
-        @mail.reply.subject.should == "Re: Test reply email"
+        @mail.reply.subject.should eql "Re: Test reply email"
       end
 
     end
@@ -1631,7 +1631,7 @@ describe Mail::Message do
       end
 
       it "should have a references consisting of the in-reply-to and message_id fields" do
-        @mail.reply[:references].message_ids.should == ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
+        @mail.reply[:references].message_ids.should eql ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
       end
 
     end

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -7,53 +7,53 @@ describe "MIME Emails" do
 
       it "should read a mime version from an email" do
         mail = Mail.new("Mime-Version: 1.0")
-        mail.mime_version.should == '1.0'
+        mail.mime_version.should eql '1.0'
       end
 
       it "should return nil if the email has no mime version" do
         mail = Mail.new("To: bob")
-        mail.mime_version.should == nil
+        mail.mime_version.should eql nil
       end
 
       it "should read the content-transfer-encoding" do
         mail = Mail.new("Content-Transfer-Encoding: quoted-printable")
-        mail.content_transfer_encoding.should == 'quoted-printable'
+        mail.content_transfer_encoding.should eql 'quoted-printable'
       end
 
       it "should read the content-description" do
         mail = Mail.new("Content-Description: This is a description")
-        mail.content_description.should == 'This is a description'
+        mail.content_description.should eql 'This is a description'
       end
 
       it "should return the content-type" do
         mail = Mail.new("Content-Type: text/plain")
-        mail.mime_type.should == 'text/plain'
+        mail.mime_type.should eql 'text/plain'
       end
 
       it "should return the charset" do
         mail = Mail.new("Content-Type: text/plain; charset=utf-8")
-        mail.charset.should == 'utf-8'
+        mail.charset.should eql 'utf-8'
       end
 
       it "should allow you to set the charset" do
         mail = Mail.new
         mail.charset = 'utf-8'
-        mail.charset.should == 'utf-8'
+        mail.charset.should eql 'utf-8'
       end
 
       it "should return the main content-type" do
         mail = Mail.new("Content-Type: text/plain")
-        mail.main_type.should == 'text'
+        mail.main_type.should eql 'text'
       end
 
       it "should return the sub content-type" do
         mail = Mail.new("Content-Type: text/plain")
-        mail.sub_type.should == 'plain'
+        mail.sub_type.should eql 'plain'
       end
 
       it "should return the content-type parameters" do
         mail = Mail.new("Content-Type: text/plain; charset=US-ASCII; format=flowed")
-        mail.content_type_parameters.should == {"charset" => 'US-ASCII', "format" => 'flowed'}
+        mail.content_type_parameters.should eql({"charset" => 'US-ASCII', "format" => 'flowed'})
       end
 
       it "should recognize a multipart email" do
@@ -68,31 +68,31 @@ describe "MIME Emails" do
 
       it "should not report the email as :attachment?" do
         mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_pdf.eml')))
-        mail.attachment?.should == false
+        mail.attachment?.should eql false
       end
 
       it "should report the email as :attachment?" do
         mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_only_email.eml')))
-        mail.attachment?.should == true
+        mail.attachment?.should eql true
       end
 
       it "should recognize an attachment part" do
         mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_pdf.eml')))
         mail.should_not be_attachment
-        mail.parts[0].attachment?.should == false
-        mail.parts[1].attachment?.should == true
+        mail.parts[0].attachment?.should eql false
+        mail.parts[1].attachment?.should eql true
       end
 
       it "should give how may (top level) parts there are" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email7.eml'))
-        mail.parts.length.should == 2
+        mail.parts.length.should eql 2
       end
 
       it "should give the content_type of each part" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email11.eml'))
-        mail.mime_type.should == 'multipart/alternative'
-        mail.parts[0].mime_type.should == 'text/plain'
-        mail.parts[1].mime_type.should == 'text/enriched'
+        mail.mime_type.should eql 'multipart/alternative'
+        mail.parts[0].mime_type.should eql 'text/plain'
+        mail.parts[1].mime_type.should eql 'text/enriched'
       end
 
       it "should report the mail :has_attachments?" do
@@ -122,12 +122,12 @@ describe "MIME Emails" do
 
       it "should know what it's boundary is if it is a multipart document" do
         mail = Mail.new('Content-Type: multipart/mixed; boundary="--==Boundary"')
-        mail.boundary.should == "--==Boundary"
+        mail.boundary.should eql "--==Boundary"
       end
 
       it "should return nil if there is no content-type defined" do
         mail = Mail.new
-        mail.boundary.should == nil
+        mail.boundary.should eql nil
       end
 
       it "should allow you to assign a text part" do
@@ -140,7 +140,7 @@ describe "MIME Emails" do
         mail = Mail.new
         text_mail = Mail.new("This is Text")
         mail.text_part = text_mail
-        mail.text_part.should == text_mail
+        mail.text_part.should eql text_mail
       end
 
       it "should allow you to assign a html part" do
@@ -153,7 +153,7 @@ describe "MIME Emails" do
         mail = Mail.new
         html_mail = Mail.new("<b>This is HTML</b>")
         mail.html_part = html_mail
-        mail.html_part.should == html_mail
+        mail.html_part.should eql html_mail
       end
 
       it "should add the html part and text part" do
@@ -165,9 +165,9 @@ describe "MIME Emails" do
           content_type = "text/html; charset=US-ASCII"
           body = "<b>This is HTML</b>"
         end
-        mail.parts.length.should == 2
-        mail.parts.first.class.should == Mail::Part
-        mail.parts.last.class.should == Mail::Part
+        mail.parts.length.should eql 2
+        mail.parts.first.class.should eql Mail::Part
+        mail.parts.last.class.should eql Mail::Part
       end
 
       it "should set the content type to multipart/alternative if you use the html_part and text_part helpers" do
@@ -222,19 +222,19 @@ describe "MIME Emails" do
           end
         end
         mail.should be_multipart
-        mail.parts.length.should == 2
-        mail.text_part.class.should == Mail::Part
-        mail.text_part.body.to_s.should == 'This is plain text'
-        mail.html_part.class.should == Mail::Part
-        mail.html_part.body.to_s.should == '<h1>This is HTML</h1>'
+        mail.parts.length.should eql 2
+        mail.text_part.class.should eql Mail::Part
+        mail.text_part.body.to_s.should eql 'This is plain text'
+        mail.html_part.class.should eql Mail::Part
+        mail.html_part.body.to_s.should eql '<h1>This is HTML</h1>'
       end
 
       it "should detect an html_part in an existing email" do
         m = Mail.new(:content_type => 'multipart/alternative')
         m.add_part(Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT'))
         m.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
-        m.text_part.body.decoded.should == 'PLAIN TEXT'
-        m.html_part.body.decoded.should == 'HTML TEXT'
+        m.text_part.body.decoded.should eql 'PLAIN TEXT'
+        m.html_part.body.decoded.should eql 'HTML TEXT'
       end
 
       it "should detect a text_part in an existing email with plain text attachment" do
@@ -242,8 +242,8 @@ describe "MIME Emails" do
         m.add_file(fixture('attachments', 'てすと.txt'))
         m.add_part(Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT'))
         m.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
-        m.text_part.body.decoded.should == 'PLAIN TEXT'
-        m.html_part.body.decoded.should == 'HTML TEXT'
+        m.text_part.body.decoded.should eql 'PLAIN TEXT'
+        m.html_part.body.decoded.should eql 'HTML TEXT'
       end
 
       it "should detect an html_part in a multi level mime email" do
@@ -254,8 +254,8 @@ describe "MIME Emails" do
         p.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
         m.add_part(p)
         m.add_part(a)
-        m.text_part.body.decoded.should == 'PLAIN TEXT'
-        m.html_part.body.decoded.should == 'HTML TEXT'
+        m.text_part.body.decoded.should eql 'PLAIN TEXT'
+        m.html_part.body.decoded.should eql 'HTML TEXT'
       end
 
       it "should only the first part on a stupidly overly complex email" do
@@ -278,8 +278,8 @@ describe "MIME Emails" do
         d.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN 3 TEXT'))
         b.add_part(d)
 
-        m.text_part.body.decoded.should == 'PLAIN TEXT'
-        m.html_part.body.decoded.should == 'HTML TEXT'
+        m.text_part.body.decoded.should eql 'PLAIN TEXT'
+        m.html_part.body.decoded.should eql 'HTML TEXT'
       end
 
     end
@@ -288,15 +288,15 @@ describe "MIME Emails" do
 
       it "should return an array of attachments" do
         mail = Mail.read(fixture('emails', 'attachment_emails', 'attachment_content_disposition.eml'))
-        mail.attachments.length.should == 1
-        mail.attachments.first.filename.should == 'hello.rb'
+        mail.attachments.length.should eql 1
+        mail.attachments.first.filename.should eql 'hello.rb'
       end
 
       it "should return an array of attachments" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email_with_nested_attachment.eml'))
-        mail.attachments.length.should == 2
-        mail.attachments[0].filename.should == 'byo-ror-cover.png'
-        mail.attachments[1].filename.should == 'smime.p7s'
+        mail.attachments.length.should eql 2
+        mail.attachments[0].filename.should eql 'byo-ror-cover.png'
+        mail.attachments[1].filename.should eql 'smime.p7s'
       end
 
     end
@@ -307,32 +307,32 @@ describe "MIME Emails" do
         mail = Mail::Message.new
         mail.text_part { body("log message goes here") }
         mail.add_file(fixture('attachments', 'test.png'))
-        mail.mime_type.should == 'multipart/mixed'
+        mail.mime_type.should eql 'multipart/mixed'
       end
 
       it "should set to multipart/mixed if you add an attachment and then a text part" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'test.png'))
         mail.text_part { body("log message goes here") }
-        mail.mime_type.should == 'multipart/mixed'
+        mail.mime_type.should eql 'multipart/mixed'
       end
 
       it "should add a part given a filename" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'test.png'))
-        mail.parts.length.should == 1 # First part is an empty text body
+        mail.parts.length.should eql 1 # First part is an empty text body
       end
 
       it "should give the part the right content type" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'test.png'))
-        mail.parts.first[:content_type].content_type.should == 'image/png'
+        mail.parts.first[:content_type].content_type.should eql 'image/png'
       end
 
       it "should return attachment objects" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'test.png'))
-        mail.attachments.first.class.should == Mail::Part
+        mail.attachments.first.class.should eql Mail::Part
       end
 
       it "should be return an aray of attachments" do
@@ -345,8 +345,8 @@ describe "MIME Emails" do
           add_file fixture('attachments', 'test.pdf')
           add_file fixture('attachments', 'test.zip')
         end
-        mail.attachments.length.should == 4
-        mail.attachments.each { |a| a.class.should == Mail::Part }
+        mail.attachments.length.should eql 4
+        mail.attachments.each { |a| a.class.should eql Mail::Part }
       end
 
       it "should return the filename of each attachment" do
@@ -359,10 +359,10 @@ describe "MIME Emails" do
           add_file fixture('attachments', 'test.pdf')
           add_file fixture('attachments', 'test.zip')
         end
-        mail.attachments[0].filename.should == 'test.png'
-        mail.attachments[1].filename.should == 'test.jpg'
-        mail.attachments[2].filename.should == 'test.pdf'
-        mail.attachments[3].filename.should == 'test.zip'
+        mail.attachments[0].filename.should eql 'test.png'
+        mail.attachments[1].filename.should eql 'test.jpg'
+        mail.attachments[2].filename.should eql 'test.pdf'
+        mail.attachments[3].filename.should eql 'test.zip'
       end
 
       it "should return the type/subtype of each attachment" do
@@ -375,10 +375,10 @@ describe "MIME Emails" do
           add_file fixture('attachments', 'test.pdf')
           add_file fixture('attachments', 'test.zip')
         end
-        mail.attachments[0].mime_type.should == 'image/png'
-        mail.attachments[1].mime_type.should == 'image/jpeg'
-        mail.attachments[2].mime_type.should == 'application/pdf'
-        mail.attachments[3].mime_type.should == 'application/zip'
+        mail.attachments[0].mime_type.should eql 'image/png'
+        mail.attachments[1].mime_type.should eql 'image/jpeg'
+        mail.attachments[2].mime_type.should eql 'application/pdf'
+        mail.attachments[3].mime_type.should eql 'application/zip'
       end
 
       it "should return the content of each attachment" do
@@ -394,21 +394,21 @@ describe "MIME Emails" do
         if RUBY_VERSION >= '1.9'
           tripped = mail.attachments[0].decoded
           original = File.read(fixture('attachments', 'test.png')).force_encoding(Encoding::BINARY)
-          tripped.should == original
+          tripped.should eql original
           tripped = mail.attachments[1].decoded
           original = File.read(fixture('attachments', 'test.jpg')).force_encoding(Encoding::BINARY)
-          tripped.should == original
+          tripped.should eql original
           tripped = mail.attachments[2].decoded
           original = File.read(fixture('attachments', 'test.pdf')).force_encoding(Encoding::BINARY)
-          tripped.should == original
+          tripped.should eql original
           tripped = mail.attachments[3].decoded
           original = File.read(fixture('attachments', 'test.zip')).force_encoding(Encoding::BINARY)
-          tripped.should == original
+          tripped.should eql original
         else
-          mail.attachments[0].decoded.should == File.read(fixture('attachments', 'test.png'))
-          mail.attachments[1].decoded.should == File.read(fixture('attachments', 'test.jpg'))
-          mail.attachments[2].decoded.should == File.read(fixture('attachments', 'test.pdf'))
-          mail.attachments[3].decoded.should == File.read(fixture('attachments', 'test.zip'))
+          mail.attachments[0].decoded.should eql File.read(fixture('attachments', 'test.png'))
+          mail.attachments[1].decoded.should eql File.read(fixture('attachments', 'test.jpg'))
+          mail.attachments[2].decoded.should eql File.read(fixture('attachments', 'test.pdf'))
+          mail.attachments[3].decoded.should eql File.read(fixture('attachments', 'test.zip'))
         end
       end
 
@@ -423,9 +423,9 @@ describe "MIME Emails" do
         if RUBY_VERSION >= '1.9'
           tripped = mail.attachments[0].decoded
           original = File.read(fixture('attachments', 'test.png')).force_encoding(Encoding::BINARY)
-          tripped.should == original
+          tripped.should eql original
         else
-          mail.attachments[0].decoded.should == File.read(fixture('attachments', 'test.png'))
+          mail.attachments[0].decoded.should eql File.read(fixture('attachments', 'test.png'))
         end
       end
 
@@ -437,10 +437,10 @@ describe "MIME Emails" do
           body    "Attached"
           add_file fixture('attachments', 'test.png')
         end
-        m.attachments.length.should == 1
-        m.parts.length.should == 2
-        m.parts[0].body.should == "Attached"
-        m.parts[1].filename.should == "test.png"
+        m.attachments.length.should eql 1
+        m.parts.length.should eql 2
+        m.parts[0].body.to_s.should eql "Attached"
+        m.parts[1].filename.to_s.should eql "test.png"
       end
 
       it "should allow you to add a body as text part if you have added a file" do
@@ -451,9 +451,9 @@ describe "MIME Emails" do
           add_file fixture('attachments', 'test.png')
           body    "Attached"
         end
-        m.parts.length.should == 2
-        m.parts.first[:content_type].content_type.should == 'image/png'
-        m.parts.last[:content_type].content_type.should == 'text/plain'
+        m.parts.length.should eql 2
+        m.parts.first[:content_type].content_type.should eql 'image/png'
+        m.parts.last[:content_type].content_type.should eql 'text/plain'
       end
 
       it "should allow you to add a body as text part if you have added a file and not truncate after newlines - issue 208" do
@@ -465,10 +465,10 @@ describe "MIME Emails" do
           body    "First Line\n\nSecond Line\n\nThird Line\n\n"
           #Note: trailing \n\n is stripped off by Mail::Part initialization
         end
-        m.parts.length.should == 2
-        m.parts.first[:content_type].content_type.should == 'image/png'
-        m.parts.last[:content_type].content_type.should == 'text/plain'
-        m.parts.last.to_s.should match /^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/
+        m.parts.length.should eql 2
+        m.parts.first[:content_type].content_type.should eql 'image/png'
+        m.parts.last[:content_type].content_type.should eql 'text/plain'
+        m.parts.last.to_s.should match(/^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/)
       end
 
       it "should not raise a warning if there is a charset defined and there are non ascii chars in the body" do

--- a/spec/mail/network/delivery_methods/file_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/file_delivery_spec.rb
@@ -39,7 +39,7 @@ describe "SMTP Delivery Method" do
       
       delivery = File.join(Mail.delivery_method.settings[:location], 'marcel@amont.com')
       
-      File.read(delivery).should == mail.encoded
+      File.read(delivery).should eql mail.encoded
     end
 
     it "should send multiple emails to multiple files" do
@@ -56,8 +56,8 @@ describe "SMTP Delivery Method" do
       delivery_one = File.join(Mail.delivery_method.settings[:location], 'marcel@amont.com')
       delivery_two = File.join(Mail.delivery_method.settings[:location], 'bob@me.com')
       
-      File.read(delivery_one).should == mail.encoded
-      File.read(delivery_two).should == mail.encoded
+      File.read(delivery_one).should eql mail.encoded
+      File.read(delivery_two).should eql mail.encoded
     end
 
     it "should only create files based on the addr_spec of the destination" do

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -21,9 +21,9 @@ describe "SMTP Delivery Method" do
       subject 'invalid RFC2822'
     end
 
-    MockSMTP.deliveries[0][0].should == mail.encoded
-    MockSMTP.deliveries[0][1].should == mail.from[0]
-    MockSMTP.deliveries[0][2].should == mail.destinations    
+    MockSMTP.deliveries[0][0].should eql mail.encoded
+    MockSMTP.deliveries[0][1].should eql mail.from[0]
+    MockSMTP.deliveries[0][2].should eql mail.destinations    
   end
   
   it "should be able to return actual SMTP protocol response" do

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -28,9 +28,9 @@ describe "SMTP Delivery Method" do
         subject 'invalid RFC2822'
       end
 
-      MockSMTP.deliveries[0][0].should == mail.encoded
-      MockSMTP.deliveries[0][1].should == mail.from[0]
-      MockSMTP.deliveries[0][2].should == mail.destinations
+      MockSMTP.deliveries[0][0].should eql mail.encoded
+      MockSMTP.deliveries[0][1].should eql mail.from[0]
+      MockSMTP.deliveries[0][2].should eql mail.destinations
     end
 
     it "should be able to send itself" do
@@ -42,9 +42,9 @@ describe "SMTP Delivery Method" do
 
       mail.deliver!
 
-      MockSMTP.deliveries[0][0].should == mail.encoded
-      MockSMTP.deliveries[0][1].should == mail.from[0]
-      MockSMTP.deliveries[0][2].should == mail.destinations
+      MockSMTP.deliveries[0][0].should eql mail.encoded
+      MockSMTP.deliveries[0][1].should eql mail.from[0]
+      MockSMTP.deliveries[0][2].should eql mail.destinations
     end
     
     it "should be able to return actual SMTP protocol response" do
@@ -118,7 +118,7 @@ describe "SMTP Delivery Method" do
         message_id "<1234@someemail.com>"
         body "body"
       end
-      MockSMTP.deliveries[0][1].should == "bounce@someemail.com"
+      MockSMTP.deliveries[0][1].should eql "bounce@someemail.com"
     end
 
     it "should use the sender address is no return path is specified" do
@@ -130,7 +130,7 @@ describe "SMTP Delivery Method" do
         message_id "<1234@someemail.com>"
         body "body"
       end
-      MockSMTP.deliveries[0][1].should == "sender@test.lindsaar.net"
+      MockSMTP.deliveries[0][1].should eql "sender@test.lindsaar.net"
     end
     
     it "should use the from address is no return path or sender is specified" do
@@ -141,7 +141,7 @@ describe "SMTP Delivery Method" do
         message_id "<1234@someemail.com>"
         body "body"
       end
-      MockSMTP.deliveries[0][1].should == "from@someemail.com"
+      MockSMTP.deliveries[0][1].should eql "from@someemail.com"
     end
     
   end

--- a/spec/mail/network/delivery_methods/test_mailer_spec.rb
+++ b/spec/mail/network/delivery_methods/test_mailer_spec.rb
@@ -34,8 +34,8 @@ describe "Mail::TestMailer" do
       body 'hello'
     end
     mail.deliver
-    Mail::TestMailer.deliveries.length.should == 1
-    Mail::TestMailer.deliveries.first.should == mail
+    Mail::TestMailer.deliveries.length.should eql 1
+    Mail::TestMailer.deliveries.first.should eql mail
   end
   
   it "should clear the deliveries when told to" do
@@ -49,7 +49,7 @@ describe "Mail::TestMailer" do
       body 'hello'
     end
     mail.deliver
-    Mail::TestMailer.deliveries.length.should == 1
+    Mail::TestMailer.deliveries.length.should eql 1
     Mail::TestMailer.deliveries.clear
     Mail::TestMailer.deliveries.should be_empty
   end

--- a/spec/mail/network/retriever_methods/imap_spec.rb
+++ b/spec/mail/network/retriever_methods/imap_spec.rb
@@ -21,7 +21,7 @@ describe "IMAP Retriever" do
       Mail.all do |message|
         messages << message
       end
-      messages.map { |m| m.raw_source }.sort.should == MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
+      messages.map { |m| m.raw_source }.sort.should eql MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
 
       MockIMAP.should be_disconnected
     end
@@ -29,7 +29,7 @@ describe "IMAP Retriever" do
       MockIMAP.should be_disconnected
 
       messages = Mail.all
-      messages.map { |m| m.raw_source }.sort.should == MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
+      messages.map { |m| m.raw_source }.sort.should eql MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
 
       MockIMAP.should be_disconnected
     end
@@ -43,8 +43,8 @@ describe "IMAP Retriever" do
         messages << message
         uids << uid
       end
-      messages.map { |m| m.raw_source }.sort.should == MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
-      uids.sort.should == MockIMAP.examples.map { |m| m.number }.sort
+      messages.map { |m| m.raw_source }.sort.should eql MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
+      uids.sort.should eql MockIMAP.examples.map { |m| m.number }.sort
 
       MockIMAP.should be_disconnected
     end
@@ -53,58 +53,58 @@ describe "IMAP Retriever" do
   describe "find and options" do
     it "should handle the :count option" do
       messages = Mail.find(:count => :all, :what => :last, :order => :asc)
-      messages.map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822'] }
+      messages.map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822'] }
 
       message = Mail.find(:count => 1, :what => :last)
-      message.raw_source.should == MockIMAP.examples.last.attr['RFC822']
+      message.raw_source.should eql MockIMAP.examples.last.attr['RFC822']
 
       messages = Mail.find(:count => 2, :what => :last, :order => :asc)
-      messages[0..1].map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822'] }[-2..-1]
+      messages[0..1].map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822'] }[-2..-1]
     end
     it "should handle the :what option" do
       messages = Mail.find(:count => :all, :what => :last)
-      messages.map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822'] }
+      messages.map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822'] }
 
       messages = Mail.find(:count => 2, :what => :first, :order => :asc)
-      messages.map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822'] }[0..1]
+      messages.map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822'] }[0..1]
     end
     it "should handle the :order option" do
       messages = Mail.find(:order => :desc, :count => 5, :what => :last)
-      messages.map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822'] }[-5..-1].reverse
+      messages.map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822'] }[-5..-1].reverse
 
       messages = Mail.find(:order => :asc, :count => 5, :what => :last)
-      messages.map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822'] }[-5..-1]
+      messages.map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822'] }[-5..-1]
     end
     it "should handle the :mailbox option" do
       messages = Mail.find(:mailbox => 'SOME-RANDOM-MAILBOX')
 
-      MockIMAP.mailbox.should == 'SOME-RANDOM-MAILBOX'
+      MockIMAP.mailbox.should eql 'SOME-RANDOM-MAILBOX'
     end
     it "should find the last 10 messages by default" do
       messages = Mail.find
 
-      messages.size.should == 10
+      messages.size.should eql 10
     end
     it "should search the mailbox 'INBOX' by default" do
       messages = Mail.find
 
-      MockIMAP.mailbox.should == 'INBOX'
+      MockIMAP.mailbox.should eql 'INBOX'
     end
 
     it "should handle the delete_after_find_option" do
       Mail.find(:delete_after_find => false)
-      MockIMAP.examples.size.should == 20
+      MockIMAP.examples.size.should eql 20
 
       Mail.find(:delete_after_find => true)
-      MockIMAP.examples.size.should == 10
+      MockIMAP.examples.size.should eql 10
 
       Mail.find(:delete_after_find => true) { |message| }
-      MockIMAP.examples.size.should == 10
+      MockIMAP.examples.size.should eql 10
     end
 
     it "should handle the find_and_delete method" do
       Mail.find_and_delete(:count => 15)
-      MockIMAP.examples.size.should == 5
+      MockIMAP.examples.size.should eql 5
     end
     
   end
@@ -114,12 +114,12 @@ describe "IMAP Retriever" do
       messages = Mail.last(:count => 5)
 
       messages.should be_instance_of(Array)
-      messages.map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822']}[-5..-1]
+      messages.map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822']}[-5..-1]
     end
     it "should find the last received message" do
       message = Mail.last
 
-      message.raw_source.should == MockIMAP.examples.last.attr['RFC822']
+      message.raw_source.should eql MockIMAP.examples.last.attr['RFC822']
     end
   end
 
@@ -128,12 +128,12 @@ describe "IMAP Retriever" do
       messages = Mail.first(:count => 5)
 
       messages.should be_instance_of(Array)
-      messages.map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822']}[0..4]
+      messages.map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822']}[0..4]
     end
     it "should find the first received message" do
       message = Mail.first
 
-      message.raw_source.should == MockIMAP.examples.first.attr['RFC822']
+      message.raw_source.should eql MockIMAP.examples.first.attr['RFC822']
     end
   end
 
@@ -141,8 +141,8 @@ describe "IMAP Retriever" do
     it "should find all messages" do
       messages = Mail.all
 
-      messages.size.should == MockIMAP.examples.size
-      messages.map { |m| m.raw_source }.should == MockIMAP.examples.map { |m| m.attr['RFC822'] }
+      messages.size.should eql MockIMAP.examples.size
+      messages.map { |m| m.raw_source }.should eql MockIMAP.examples.map { |m| m.attr['RFC822'] }
     end
   end
 
@@ -153,7 +153,7 @@ describe "IMAP Retriever" do
       Net::IMAP.should_receive(:encode_utf7).once
       Mail.delete_all
 
-      MockIMAP.examples.size.should == 0
+      MockIMAP.examples.size.should eql 0
     end
   end 
 
@@ -174,16 +174,16 @@ describe "IMAP Retriever" do
       options = retrievable.send(:validate_options, {})
 
       options[:count].should_not be_blank
-      options[:count].should == 10
+      options[:count].should eql 10
 
       options[:order].should_not be_blank
-      options[:order].should == :asc
+      options[:order].should eql :asc
 
       options[:what].should_not be_blank
-      options[:what].should == :first
+      options[:what].should eql :first
 
       options[:mailbox].should_not be_blank
-      options[:mailbox].should == 'INBOX'
+      options[:mailbox].should eql 'INBOX'
     end
     it "should not replace given configuration" do
       retrievable = Mail::IMAP.new({})
@@ -195,16 +195,16 @@ describe "IMAP Retriever" do
       })
 
       options[:count].should_not be_blank
-      options[:count].should == 2
+      options[:count].should eql 2
 
       options[:order].should_not be_blank
-      options[:order].should == :asc
+      options[:order].should eql :asc
 
       options[:what].should_not be_blank
-      options[:what].should == :first
+      options[:what].should eql :first
 
       options[:mailbox].should_not be_blank
-      options[:mailbox].should == 'some/mail/box'
+      options[:mailbox].should eql 'some/mail/box'
     end
     it "should ensure utf7 conversion for mailbox names" do
       retrievable = Mail::IMAP.new({})
@@ -213,7 +213,7 @@ describe "IMAP Retriever" do
       options = retrievable.send(:validate_options, {
         :mailbox => 'UTF8_STRING'
       })
-      options[:mailbox].should == 'UTF7_STRING'
+      options[:mailbox].should eql 'UTF7_STRING'
     end
   end
 

--- a/spec/mail/network/retriever_methods/pop3_spec.rb
+++ b/spec/mail/network/retriever_methods/pop3_spec.rb
@@ -25,7 +25,7 @@ describe "POP3 Retriever" do
         messages << message
       end
       
-      messages.map { |m| m.raw_source }.sort.should == MockPOP3.popmails.map { |p| p.pop }.sort
+      messages.map { |m| m.raw_source }.sort.should eql MockPOP3.popmails.map { |p| p.pop }.sort
       MockPOP3.should_not be_started
     end
     
@@ -37,7 +37,7 @@ describe "POP3 Retriever" do
         messages << message
       end
       
-      messages.map { |m| m.raw_source }.sort.should == MockPOP3.popmails.map { |p| p.pop }.sort
+      messages.map { |m| m.raw_source }.sort.should eql MockPOP3.popmails.map { |p| p.pop }.sort
       MockPOP3.should_not be_started
     end
   
@@ -47,35 +47,35 @@ describe "POP3 Retriever" do
     
     it "should handle the :count option" do
       messages = Mail.find(:count => :all, :what => :last, :order => :asc)
-      messages.map { |m| m.raw_source }.sort.should == MockPOP3.popmails.map { |p| p.pop }
+      messages.map { |m| m.raw_source }.sort.should eql MockPOP3.popmails.map { |p| p.pop }
       
       message = Mail.find(:count => 1, :what => :last)
-      message.raw_source.should == MockPOP3.popmails.map { |p| p.pop }.last
+      message.raw_source.should eql MockPOP3.popmails.map { |p| p.pop }.last
       
       messages = Mail.find(:count => 2, :what => :last, :order => :asc)
-      messages[0..1].collect {|m| m.raw_source}.should == MockPOP3.popmails.map { |p| p.pop }[-2..-1]
+      messages[0..1].collect {|m| m.raw_source}.should eql MockPOP3.popmails.map { |p| p.pop }[-2..-1]
     end
     
     it "should handle the :what option" do
       messages = Mail.find(:count => :all, :what => :last)
-      messages.map { |m| m.raw_source }.sort.should == MockPOP3.popmails.map { |p| p.pop }
+      messages.map { |m| m.raw_source }.sort.should eql MockPOP3.popmails.map { |p| p.pop }
       
       messages = Mail.find(:count => 2, :what => :first, :order => :asc)
-      messages.map { |m| m.raw_source }.should == MockPOP3.popmails.map { |p| p.pop }[0..1]
+      messages.map { |m| m.raw_source }.should eql MockPOP3.popmails.map { |p| p.pop }[0..1]
     end
     
     it "should handle the :order option" do
       messages = Mail.find(:order => :desc, :count => 5, :what => :last)
-      messages.map { |m| m.raw_source }.should == MockPOP3.popmails.map { |p| p.pop }[-5..-1].reverse
+      messages.map { |m| m.raw_source }.should eql MockPOP3.popmails.map { |p| p.pop }[-5..-1].reverse
       
       messages = Mail.find(:order => :asc, :count => 5, :what => :last)
-      messages.map { |m| m.raw_source }.should == MockPOP3.popmails.map { |p| p.pop }[-5..-1]
+      messages.map { |m| m.raw_source }.should eql MockPOP3.popmails.map { |p| p.pop }[-5..-1]
     end
     
     it "should find the last 10 messages by default" do
       messages = Mail.find
       
-      messages.size.should == 10
+      messages.size.should eql 10
     end
 
     it "should handle the delete_after_find option" do
@@ -105,14 +105,14 @@ describe "POP3 Retriever" do
       messages = Mail.last(:count => 5)
       
       messages.should be_instance_of(Array)
-      messages.map { |m| m.raw_source }.should == MockPOP3.popmails.map { |p| p.pop }[-5..-1]
+      messages.map { |m| m.raw_source }.should eql MockPOP3.popmails.map { |p| p.pop }[-5..-1]
     end
     
     it "should find the last received message" do
       message = Mail.last
       
       message.should be_instance_of(Mail::Message)
-      message.raw_source.should == MockPOP3.popmails.last.pop
+      message.raw_source.should eql MockPOP3.popmails.last.pop
     end
     
   end
@@ -123,14 +123,14 @@ describe "POP3 Retriever" do
       messages = Mail.first(:count => 5)
       
       messages.should be_instance_of(Array)
-      messages.map { |m| m.raw_source }.should == MockPOP3.popmails.map { |p| p.pop }[0..4]
+      messages.map { |m| m.raw_source }.should eql MockPOP3.popmails.map { |p| p.pop }[0..4]
     end
     
     it "should find the first received message" do
       message = Mail.first
       
       message.should be_instance_of(Mail::Message)
-      message.raw_source.should == MockPOP3.popmails.first.pop
+      message.raw_source.should eql MockPOP3.popmails.first.pop
     end
     
   end
@@ -140,8 +140,8 @@ describe "POP3 Retriever" do
     it "should find all messages" do
       messages = Mail.all
       
-      messages.size.should == MockPOP3.popmails.size
-      messages.map { |m| m.raw_source }.should == MockPOP3.popmails.map { |p| p.pop }
+      messages.size.should eql MockPOP3.popmails.size
+      messages.map { |m| m.raw_source }.should eql MockPOP3.popmails.map { |p| p.pop }
     end
     
   end
@@ -151,7 +151,7 @@ describe "POP3 Retriever" do
       messages = Mail.all
       Mail.delete_all
     
-      MockPOP3.popmails.size.should == 0
+      MockPOP3.popmails.size.should eql 0
     end
   end
   
@@ -173,13 +173,13 @@ describe "POP3 Retriever" do
       options = retrievable.send(:validate_options, {})
       
       options[:count].should_not be_blank
-      options[:count].should == 10
+      options[:count].should eql 10
       
       options[:order].should_not be_blank
-      options[:order].should == :asc
+      options[:order].should eql :asc
       
       options[:what].should_not be_blank
-      options[:what].should == :first
+      options[:what].should eql :first
     end
     
     it "should not replace given configuration" do
@@ -191,13 +191,13 @@ describe "POP3 Retriever" do
       })
       
       options[:count].should_not be_blank
-      options[:count].should == 2
+      options[:count].should eql 2
       
       options[:order].should_not be_blank
-      options[:order].should == :asc
+      options[:order].should eql :asc
       
       options[:what].should_not be_blank
-      options[:what].should == :first
+      options[:what].should eql :first
     end
     
   end

--- a/spec/mail/network/retriever_methods/test_retriever_spec.rb
+++ b/spec/mail/network/retriever_methods/test_retriever_spec.rb
@@ -19,13 +19,13 @@ describe "Test Retriever" do
     end
 
     it "should return all emails without a block" do
-      Mail.all.should == @emails
+      Mail.all.should eql @emails
     end
 
     it "should return all emails with a block" do
       messages = []
       Mail.all { |message| messages << message }
-      messages.should == @emails
+      messages.should eql @emails
     end
 
   end
@@ -37,27 +37,27 @@ describe "Test Retriever" do
     end
 
     it "should handle the :count option" do
-      Mail.find(:count => :all).should == @emails
-      Mail.find(:count => 1).should == @emails.first
-      Mail.find(:count => 5).should == @emails[0, 5]
+      Mail.find(:count => :all).should eql @emails
+      Mail.find(:count => 1).should eql @emails.first
+      Mail.find(:count => 5).should eql @emails[0, 5]
     end
 
     it "should handle the :order option" do
-      Mail.find(:order => :asc).should == @emails
-      Mail.find(:order => :desc).should == @emails.reverse
+      Mail.find(:order => :asc).should eql @emails
+      Mail.find(:order => :desc).should eql @emails.reverse
     end
 
     it "should handle the :what option" do
-      Mail.find(:what => :first).should == @emails
-      Mail.find(:what => :first, :count => 5).should == @emails[0, 5]
-      Mail.find(:what => :last).should == @emails
-      Mail.find(:what => :last, :count => 5).should == @emails[10, 5]
+      Mail.find(:what => :first).should eql @emails
+      Mail.find(:what => :first, :count => 5).should eql @emails[0, 5]
+      Mail.find(:what => :last).should eql @emails
+      Mail.find(:what => :last, :count => 5).should eql @emails[10, 5]
     end
 
     it "should handle the :delete_after_find option" do
-      Mail.find(:delete_after_find => false).should == @emails
-      Mail.find(:delete_after_find => false).should == @emails
-      Mail.find(:delete_after_find => true).should == @emails
+      Mail.find(:delete_after_find => false).should eql @emails
+      Mail.find(:delete_after_find => false).should eql @emails
+      Mail.find(:delete_after_find => true).should eql @emails
       Mail.find(:delete_after_find => false).should be_empty
     end
 
@@ -71,7 +71,7 @@ describe "Test Retriever" do
         end
         i += 1
       end
-      Mail.all.should == messages
+      Mail.all.should eql messages
     end
 
   end

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -32,59 +32,59 @@ describe "Mail" do
       Mail.defaults do
         delivery_method :smtp
       end
-      Mail.delivery_method.class.should == Mail::SMTP
+      Mail.delivery_method.class.should eql Mail::SMTP
     end
     
     it "should default to settings for smtp" do
-      Mail.delivery_method.class.should == Mail::SMTP
-      Mail.delivery_method.settings.should == { :address              => "localhost",
+      Mail.delivery_method.class.should eql Mail::SMTP
+      Mail.delivery_method.settings.should eql({ :address              => "localhost",
                                                 :port                 => 25,
                                                 :domain               => 'localhost.localdomain',
                                                 :user_name            => nil,
                                                 :password             => nil,
                                                 :authentication       => nil,
                                                 :enable_starttls_auto => true,
-                                                :openssl_verify_mode  => nil }
+                                                :openssl_verify_mode  => nil })
     end
 
     it "should set the retriever method" do
       Mail.defaults do
         retriever_method :pop3
       end
-      Mail.retriever_method.class.should == Mail::POP3
+      Mail.retriever_method.class.should eql Mail::POP3
     end
 
     it "should default to settings for pop3" do
-      Mail.retriever_method.class.should == Mail::POP3
-      Mail.retriever_method.settings.should == { :address              => "localhost",
+      Mail.retriever_method.class.should eql Mail::POP3
+      Mail.retriever_method.settings.should eql({ :address              => "localhost",
                                                  :port                 => 110,
                                                  :user_name            => nil,
                                                  :password             => nil,
                                                  :authentication       => nil,
-                                                 :enable_ssl           => true  }
+                                                 :enable_ssl           => true  })
     end
 
     it "should allow us to overwrite anything we need on SMTP" do
       Mail.defaults do
         delivery_method :smtp, :port => 999
       end
-      Mail.delivery_method.settings[:address].should == 'localhost'
-      Mail.delivery_method.settings[:port].should == 999
+      Mail.delivery_method.settings[:address].should eql 'localhost'
+      Mail.delivery_method.settings[:port].should eql 999
     end
 
     it "should allow us to overwrite anything we need on POP3" do
       Mail.defaults do
         retriever_method :pop3, :address => 'foo.bar.com'
       end
-      Mail.retriever_method.settings[:address].should == 'foo.bar.com'
-      Mail.retriever_method.settings[:port].should == 110
+      Mail.retriever_method.settings[:address].should eql 'foo.bar.com'
+      Mail.retriever_method.settings[:port].should eql 110
     end
 
     it "should allow you to pass in your own delivery method" do
       Mail.defaults do
         delivery_method MyDelivery
       end
-      Mail.delivery_method.class.should == MyDelivery
+      Mail.delivery_method.class.should eql MyDelivery
     end
 
     it "should ask the custom delivery agent for it's settings" do
@@ -94,14 +94,14 @@ describe "Mail" do
       Mail.defaults do
         delivery_method MyDelivery
       end
-      Mail.delivery_method.settings.should == {:these_are => :settings}
+      Mail.delivery_method.settings.should eql({:these_are => :settings})
     end
 
     it "should allow you to pass in your own retriever method" do
       Mail.defaults do
         retriever_method MyRetriever
       end
-      Mail.retriever_method.class.should == MyRetriever
+      Mail.retriever_method.class.should eql MyRetriever
     end
 
     it "should ask the custom retriever agent for it's settings" do
@@ -111,7 +111,7 @@ describe "Mail" do
       Mail.defaults do
         retriever_method MyRetriever
       end
-      Mail.retriever_method.settings.should == {:these_are => :settings}
+      Mail.retriever_method.settings.should eql({:these_are => :settings})
     end
 
   end
@@ -120,39 +120,39 @@ describe "Mail" do
     
     it "should copy the defaults defined by Mail.defaults" do
       mail = Mail.new
-      mail.delivery_method.class.should == Mail::SMTP
+      mail.delivery_method.class.should eql Mail::SMTP
     end
   
     it "should be able to change the delivery_method" do
       mail = Mail.new
       mail.delivery_method :file
-      mail.delivery_method.class.should == Mail::FileDelivery
+      mail.delivery_method.class.should eql Mail::FileDelivery
     end
 
     it "should be able to change the delivery_method and pass in settings" do
       mail = Mail.new
       tmpdir = File.expand_path('../../../tmp/mail', __FILE__)
       mail.delivery_method :file, :location => tmpdir
-      mail.delivery_method.class.should == Mail::FileDelivery
-      mail.delivery_method.settings.should == {:location => tmpdir}
+      mail.delivery_method.class.should eql Mail::FileDelivery
+      mail.delivery_method.settings.should eql({:location => tmpdir})
     end
   
     it "should not change the default when it changes the delivery_method" do
       mail1 = Mail.new
       mail2 = Mail.new
       mail1.delivery_method :file
-      Mail.delivery_method.class.should == Mail::SMTP
-      mail1.delivery_method.class.should == Mail::FileDelivery
-      mail2.delivery_method.class.should == Mail::SMTP
+      Mail.delivery_method.class.should eql Mail::SMTP
+      mail1.delivery_method.class.should eql Mail::FileDelivery
+      mail2.delivery_method.class.should eql Mail::SMTP
     end
   
     it "should not change the default settings when it changes the delivery_method settings" do
       mail1 = Mail.new
       mail2 = Mail.new
       mail1.delivery_method :smtp, :address => 'my.own.address'
-      Mail.delivery_method.settings[:address].should == 'localhost'
-      mail1.delivery_method.settings[:address].should == 'my.own.address'
-      mail2.delivery_method.settings[:address].should == 'localhost'
+      Mail.delivery_method.settings[:address].should eql 'localhost'
+      mail1.delivery_method.settings[:address].should eql 'my.own.address'
+      mail2.delivery_method.settings[:address].should eql 'localhost'
     end
 
   end
@@ -184,9 +184,9 @@ describe "Mail" do
         # add_file 'New Header Image', '/somefile.png'
       end
 
-      MockSMTP.deliveries[0][0].should == message.encoded
-      MockSMTP.deliveries[0][1].should == "mikel@test.lindsaar.net"
-      MockSMTP.deliveries[0][2].should == ["ada@test.lindsaar.net"]
+      MockSMTP.deliveries[0][0].should eql message.encoded
+      MockSMTP.deliveries[0][1].should eql "mikel@test.lindsaar.net"
+      MockSMTP.deliveries[0][2].should eql ["ada@test.lindsaar.net"]
     end
 
     it "should deliver itself" do
@@ -200,9 +200,9 @@ describe "Mail" do
       
       message.deliver!
 
-      MockSMTP.deliveries[0][0].should == message.encoded
-      MockSMTP.deliveries[0][1].should == "mikel@test.lindsaar.net"
-      MockSMTP.deliveries[0][2].should == ["ada@test.lindsaar.net"]
+      MockSMTP.deliveries[0][0].should eql message.encoded
+      MockSMTP.deliveries[0][1].should eql "mikel@test.lindsaar.net"
+      MockSMTP.deliveries[0][2].should eql ["ada@test.lindsaar.net"]
     end
     
   end

--- a/spec/mail/part_spec.rb
+++ b/spec/mail/part_spec.rb
@@ -15,7 +15,7 @@ describe Mail::Part do
       content_id "<thisis@acontentid>"
       body "This is Text"
     end
-    part.content_id.should == "<thisis@acontentid>"
+    part.content_id.should eql "<thisis@acontentid>"
   end
   
   it "should return an inline content_id" do
@@ -23,9 +23,9 @@ describe Mail::Part do
       content_id "<thisis@acontentid>"
       body "This is Text"
     end
-    part.cid.should == "thisis@acontentid"
+    part.cid.should eql "thisis@acontentid"
     STDERR.should_receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
-    part.inline_content_id.should == "thisis@acontentid"
+    part.inline_content_id.should eql "thisis@acontentid"
   end
   
   
@@ -34,9 +34,9 @@ describe Mail::Part do
       content_id "<thi%%sis@acontentid>"
       body "This is Text"
     end
-    part.cid.should == "thi%25%25sis@acontentid"
+    part.cid.should eql "thi%25%25sis@acontentid"
     STDERR.should_receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
-    part.inline_content_id.should == "thi%25%25sis@acontentid"
+    part.inline_content_id.should eql "thi%25%25sis@acontentid"
   end
   
   it "should add a content_id if there is none and is asked for an inline_content_id" do
@@ -117,23 +117,23 @@ ENDPART
     end
     
     it "should say action 'delayed'" do
-      @delivery_report.action.should == 'failed'
+      @delivery_report.action.to_s.should eql 'failed'
     end
     
     it "should give a final recipient" do
-      @delivery_report.final_recipient.should == 'RFC822; edwin@zzzzzzz.com'
+      @delivery_report.final_recipient.to_s.should eql 'RFC822; edwin@zzzzzzz.com'
     end
     
     it "should give an error code" do
-      @delivery_report.error_status.should == '5.3.0'
+      @delivery_report.error_status.to_s.should eql '5.3.0'
     end
     
     it "should give a diagostic code" do
-      @delivery_report.diagnostic_code.should == 'SMTP; 553 5.3.0 <edwin@zzzzzzz.com>... Unknown E-Mail Address'
+      @delivery_report.diagnostic_code.to_s.should eql 'SMTP; 553 5.3.0 <edwin@zzzzzzz.com>... Unknown E-Mail Address'
     end
     
     it "should give a remote-mta" do
-      @delivery_report.remote_mta.should == 'DNS; mail.zzzzzz.com'
+      @delivery_report.remote_mta.to_s.should eql 'DNS; mail.zzzzzz.com'
     end
     
     it "should be retryable" do
@@ -146,8 +146,8 @@ ENDPART
     plain_text = "First Line\n\nSecond Line\n\nThird Line\n\n"
     #Note: trailing \n\n is stripped off by Mail::Part initialization
     part = Mail::Part.new(plain_text)
-    part[:content_type].content_type.should == 'text/plain'
-    part.to_s.should match /^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/
+    part[:content_type].content_type.should eql 'text/plain'
+    part.to_s.should match(/^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/)
   end
 
 end

--- a/spec/mail/round_tripping_spec.rb
+++ b/spec/mail/round_tripping_spec.rb
@@ -7,8 +7,8 @@ describe "Round Tripping" do
     mail = Mail.new('Subject: FooBar')
     mail.body "This is Text"
     parsed_mail = Mail.new(mail.to_s)
-    parsed_mail.subject.to_s.should == "FooBar"
-    parsed_mail.body.to_s.should == "This is Text"
+    parsed_mail.subject.to_s.should eql "FooBar"
+    parsed_mail.body.to_s.should eql "This is Text"
   end
 
   it "should round trip a html multipart email" do
@@ -21,11 +21,11 @@ describe "Round Tripping" do
       body "<b>This is HTML</b>"
     end
     parsed_mail = Mail.new(mail.to_s)
-    parsed_mail.mime_type.should == 'multipart/alternative'
-    parsed_mail.boundary.should == mail.boundary
-    parsed_mail.parts.length.should == 2
-    parsed_mail.parts[0].body.to_s.should == "This is Text"
-    parsed_mail.parts[1].body.to_s.should == "<b>This is HTML</b>"
+    parsed_mail.mime_type.should eql 'multipart/alternative'
+    parsed_mail.boundary.should eql mail.boundary
+    parsed_mail.parts.length.should eql 2
+    parsed_mail.parts[0].body.to_s.should eql "This is Text"
+    parsed_mail.parts[1].body.to_s.should eql "<b>This is HTML</b>"
   end
 
   it "should round trip an email" do
@@ -38,7 +38,7 @@ describe "Round Tripping" do
       bcc       "bob@test.lindsaar.net"
       date      Time.local(2009, 11, 6)
     end
-    Mail.new(initial.encoded).encoded.should == initial.encoded
+    Mail.new(initial.encoded).encoded.should eql initial.encoded
   end
 
 end

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -24,16 +24,16 @@ describe "Utilities Module" do
 
     describe "quoting" do
       it "should return true if a string is token safe" do
-        quote_token('.abc').should == '.abc'
+        quote_token('.abc').should eql '.abc'
       end
 
       it "should return false if a string is token safe" do
-        quote_token('?=abc').should == '"?=abc"'
+        quote_token('?=abc').should eql '"?=abc"'
       end
 
       it "should work with mb_chars" do
-        quote_token('.abc'.mb_chars).should == '.abc'
-        quote_token('?=abc'.mb_chars).should == '"?=abc"'
+        quote_token('.abc'.mb_chars).to_s.should eql '.abc'
+        quote_token('?=abc'.mb_chars).to_s.should eql '"?=abc"'
       end
     end
 
@@ -58,26 +58,26 @@ describe "Utilities Module" do
 
     describe "quoting" do
       it "should return true if a string is token safe" do
-        quote_atom('?=abc').should == '?=abc'
+        quote_atom('?=abc').should eql '?=abc'
       end
 
       it "should return false if a string is token safe" do
-        quote_atom('.abc').should == '".abc"'
+        quote_atom('.abc').should eql '".abc"'
       end
 
       it "should work with mb_chars" do
-        quote_atom('?=abc'.mb_chars).should == '?=abc'
-        quote_atom('.abc'.mb_chars).should == '".abc"'
+        quote_atom('?=abc'.mb_chars).to_s.should eql '?=abc'
+        quote_atom('.abc'.mb_chars).to_s.should eql '".abc"'
       end
 
       it "should work with mb_chars" do
-        quote_atom('?=abc'.mb_chars).should == '?=abc'
-        quote_atom('.abc'.mb_chars).should == '".abc"'
+        quote_atom('?=abc'.mb_chars).to_s.should eql '?=abc'
+        quote_atom('.abc'.mb_chars).to_s.should eql '".abc"'
       end
       
       it "should quote white space" do
-        quote_atom('ab abc'.mb_chars).should == '"ab abc"'
-        quote_atom("a\sb\ta\r\nbc".mb_chars).should == %{"a\sb\ta\r\nbc"}
+        quote_atom('ab abc'.mb_chars).should eql '"ab abc"'
+        quote_atom("a\sb\ta\r\nbc".mb_chars).should eql %{"a\sb\ta\r\nbc"}
       end
     end
 
@@ -87,19 +87,19 @@ describe "Utilities Module" do
     it "should escape parens" do
       test = 'This is not (escaped)'
       result = 'This is not \(escaped\)'
-      escape_paren(test).should == result
+      escape_paren(test).should eql result
     end
 
     it "should not double escape parens" do
       test = 'This is not \(escaped\)'
       result = 'This is not \(escaped\)'
-      escape_paren(test).should == result
+      escape_paren(test).should eql result
     end
 
     it "should escape all parens" do
       test = 'This is not \()escaped(\)'
       result = 'This is not \(\)escaped\(\)'
-      escape_paren(test).should == result
+      escape_paren(test).should eql result
     end
     
   end
@@ -109,25 +109,25 @@ describe "Utilities Module" do
     it "should work" do
       test = '(This is a string)'
       result = 'This is a string'
-      unparen(test).should == result
+      unparen(test).should eql result
     end
 
     it "should work without parens" do
       test = 'This is a string'
       result = 'This is a string'
-      unparen(test).should == result
+      unparen(test).should eql result
     end
 
     it "should work using ActiveSupport mb_chars" do
       test = '(This is a string)'.mb_chars
       result = 'This is a string'
-      unparen(test).should == result
+      unparen(test).should eql result
     end
 
     it "should work without parens using ActiveSupport mb_chars" do
       test = 'This is a string'.mb_chars
       result = 'This is a string'
-      unparen(test).should == result
+      unparen(test).to_s.should eql result
     end
 
   end
@@ -137,25 +137,25 @@ describe "Utilities Module" do
     it "should work" do
       test = '<This is a string>'
       result = 'This is a string'
-      unbracket(test).should == result
+      unbracket(test).should eql result
     end
 
     it "should work without brackets" do
       test = 'This is a string'
       result = 'This is a string'
-      unbracket(test).should == result
+      unbracket(test).should eql result
     end
 
     it "should work using ActiveSupport mb_chars" do
       test = '<This is a string>'.mb_chars
       result = 'This is a string'
-      unbracket(test).should == result
+      unbracket(test).should eql result
     end
 
     it "should work without parens using ActiveSupport mb_chars" do
       test = 'This is a string'.mb_chars
       result = 'This is a string'
-      unbracket(test).should == result
+      unbracket(test).to_s.should eql result
     end
 
   end
@@ -164,25 +164,25 @@ describe "Utilities Module" do
     it "should quote a phrase if it is unsafe" do
       test = 'this.needs quoting'
       result = '"this.needs quoting"'
-      dquote(test).should == result
+      dquote(test).should eql result
     end
 
     it "should properly quote a string, even if quoted but not escaped properly" do
       test = '"this needs "escaping"'
       result = '"this needs \"escaping"'
-      dquote(test).should == result
+      dquote(test).should eql result
     end
     
     it "should quote correctly a phrase with an escaped quote in it" do
       test = 'this needs \"quoting'
       result = '"this needs \"quoting"'
-      dquote(test).should == result
+      dquote(test).should eql result
     end
     
     it "should quote correctly a phrase with an escaped backslash followed by an escaped quote in it" do
       test = 'this needs \\\"quoting'
       result = '"this needs \\\"quoting"'
-      dquote(test).should == result
+      dquote(test).should eql result
     end
   end
   
@@ -191,61 +191,61 @@ describe "Utilities Module" do
     it "should parenthesize a phrase" do
       test = 'this.needs parenthesizing'
       result = '(this.needs parenthesizing)'
-      paren(test).should == result
+      paren(test).should eql result
     end
 
     it "should properly parenthesize a string, and escape properly" do
       test = 'this needs (escaping'
       result = '(this needs \(escaping)'
-      paren(test).should == result
+      paren(test).should eql result
     end
 
     it "should properly parenthesize a string, and escape properly (other way)" do
       test = 'this needs )escaping'
       result = '(this needs \)escaping)'
-      paren(test).should == result
+      paren(test).should eql result
     end
 
     it "should properly parenthesize a string, even if parenthesized but not escaped properly" do
       test = '(this needs (escaping)'
       result = '(this needs \(escaping)'
-      paren(test).should == result
+      paren(test).should eql result
     end
 
     it "should properly parenthesize a string, even if parenthesized but not escaped properly (other way)" do
       test = '(this needs )escaping)'
       result = '(this needs \)escaping)'
-      paren(test).should == result
+      paren(test).should eql result
     end
     
     it "should parenthesize correctly a phrase with an escaped parentheses in it" do
       test = 'this needs \(parenthesizing'
       result = '(this needs \(parenthesizing)'
-      paren(test).should == result
+      paren(test).should eql result
     end
     
     it "should parenthesize correctly a phrase with an escaped parentheses in it (other way)" do
       test = 'this needs \)parenthesizing'
       result = '(this needs \)parenthesizing)'
-      paren(test).should == result
+      paren(test).should eql result
     end
     
     it "should parenthesize correctly a phrase with an escaped backslash followed by an escaped parentheses in it" do
       test = 'this needs \\\(parenthesizing'
       result = '(this needs \\\(parenthesizing)'
-      paren(test).should == result
+      paren(test).should eql result
     end
     
     it "should parenthesize correctly a phrase with an escaped backslash followed by an escaped parentheses in it (other way)" do
       test = 'this needs \\\)parenthesizing'
       result = '(this needs \\\)parenthesizing)'
-      paren(test).should == result
+      paren(test).should eql result
     end
 
     it "should parenthesize correctly a phrase with a set of parentheses" do
       test = 'this (needs) parenthesizing'
       result = '(this \(needs\) parenthesizing)'
-      paren(test).should == result
+      paren(test).should eql result
     end
     
   end
@@ -255,61 +255,61 @@ describe "Utilities Module" do
     it "should bracketize a phrase" do
       test = 'this.needs bracketizing'
       result = '<this.needs bracketizing>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
 
     it "should properly bracketize a string, and escape properly" do
       test = 'this needs <escaping'
       result = '<this needs \<escaping>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
 
     it "should properly bracketize a string, and escape properly (other way)" do
       test = 'this needs >escaping'
       result = '<this needs \>escaping>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
 
     it "should properly bracketize a string, even if bracketized but not escaped properly" do
       test = '<this needs <escaping>'
       result = '<this needs \<escaping>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
 
     it "should properly bracketize a string, even if bracketized but not escaped properly (other way)" do
       test = '<this needs >escaping>'
       result = '<this needs \>escaping>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
     
     it "should bracketize correctly a phrase with an escaped brackets in it" do
       test = 'this needs \<bracketizing'
       result = '<this needs \<bracketizing>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
     
     it "should bracketize correctly a phrase with an escaped brackets in it (other way)" do
       test = 'this needs \>bracketizing'
       result = '<this needs \>bracketizing>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
     
     it "should bracketize correctly a phrase with an escaped backslash followed by an escaped brackets in it" do
       test = 'this needs \\\<bracketizing'
       result = '<this needs \\\<bracketizing>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
     
     it "should bracketize correctly a phrase with an escaped backslash followed by an escaped brackets in it (other way)" do
       test = 'this needs \\\>bracketizing'
       result = '<this needs \\\>bracketizing>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
 
     it "should bracketize correctly a phrase with a set of brackets" do
       test = 'this <needs> bracketizing'
       result = '<this \<needs\> bracketizing>'
-      bracket(test).should == result
+      bracket(test).should eql result
     end
     
   end
@@ -318,11 +318,11 @@ describe "Utilities Module" do
     uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
 
     it "should have a wrapper on URI.escape" do
-      uri_escape("@?@!").should == uri_parser.escape("@?@!")
+      uri_escape("@?@!").should eql uri_parser.escape("@?@!")
     end
 
     it "should have a wrapper on URI.unescape" do
-      uri_unescape("@?@!").should == uri_parser.unescape("@?@!")
+      uri_unescape("@?@!").should eql uri_parser.unescape("@?@!")
     end
   end
   


### PR DESCRIPTION
sorry, commit bomb..

This patch is fixing warning.

```
warning: useless use of == in void context
```

I use `eql` method instead of `==`.
