### PR TITLE
it "should accept a plug-in delivery method"

### DIFF
--- a/spec/mail/configuration_spec.rb
+++ b/spec/mail/configuration_spec.rb
@@ -21,6 +21,21 @@ describe Mail::Configuration do
       Mail.delivery_method.class.should == Mail::SMTPConnection
       Mail.delivery_method.smtp.should == smtp
     end
+
+    it "should accept a plug-in delivery method" do
+      class MyDeliveryMethod
+        attr_accessor :settings
+
+        def initialize(values)
+          self.settings = {}.merge!(values)
+        end
+      end
+
+      Mail.defaults { delivery_method MyDeliveryMethod, { :option1 => "one", :option2 => "two" }}
+      Mail.delivery_method.class.should == MyDeliveryMethod
+      Mail.delivery_method.settings[:option1].should == "one"
+      Mail.delivery_method.settings[:option2].should == "two"
+    end
     
   end
 end


### PR DESCRIPTION
Hi Mikel!  I wanted to try out a delivery method plugin, and noticed that the gem didn't yet have a spec for that, so I added one.  See spec/mail/configuration_spec.rb

Let me know if you can merge it.

Happy holidays!
