### PR TITLE
Fix for undefined method 'constantize' error when no ActiveSupport loaded

### DIFF
--- a/lib/mail/core_extensions/string/access.rb
+++ b/lib/mail/core_extensions/string/access.rb
@@ -101,4 +101,45 @@ class String
       end
     end
   end
+
+  if Module.method(:const_get).arity == 1
+    # Tries to find a constant with the name specified in the argument string:
+    #
+    #   "Module".constantize     # => Module
+    #   "Test::Unit".constantize # => Test::Unit
+    #
+    # The name is assumed to be the one of a top-level constant, no matter whether
+    # it starts with "::" or not. No lexical context is taken into account:
+    #
+    #   C = 'outside'
+    #   module M
+    #     C = 'inside'
+    #     C               # => 'inside'
+    #     "C".constantize # => 'outside', same as ::C
+    #   end
+    #
+    # NameError is raised when the name is not in CamelCase or the constant is
+    # unknown.
+    def constantize
+      names = self.split('::')
+      names.shift if names.empty? || names.first.empty?
+
+      constant = Object
+      names.each do |name|
+        constant = constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
+      end
+      constant
+    end
+  else
+    def constantize #:nodoc:
+      names = self.split('::')
+      names.shift if names.empty? || names.first.empty?
+
+      constant = Object
+      names.each do |name|
+        constant = constant.const_defined?(name, false) ? constant.const_get(name) : constant.const_missing(name)
+      end
+      constant
+    end
+  end
 end

--- a/spec/mail/core_extensions/string_spec.rb
+++ b/spec/mail/core_extensions/string_spec.rb
@@ -59,4 +59,10 @@ describe 'core_extensions/string' do
     end
   end
 
+  describe 'constantize' do
+    it 'should converts string to constant' do
+      "Kernel".constantize.should == Kernel
+    end
+  end
+
 end


### PR DESCRIPTION
There is an exception when :openssl_verify_mode is set for e.g. delivery_method but no active_support loaded.

An example:

``` ruby

require 'rubygems'
require 'mail'


Mail.defaults do
  delivery_method :smtp, {
    :address => 'rax.anteus.hu',
    :port    => 2525,
    :domain  => 'anteus.hu',
    :user_name => 'user@example.com',
    :password => '******',
    :authentication => 'plain',
    :openssl_verify_mode => 'none',
  }
end


Mail.deliver do
  to 'sam@example.com'
  from 'user@example.com'
  subject 'test ezmail'
  body 'this is just a small test'
end
```

It throws:

```
/Library/Ruby/Gems/1.8/gems/mail-2.3.0/lib/mail/network/delivery_methods/smtp.rb:118:in `deliver!': undefined method `constantize' for "OpenSSL::SSL::VERIFY_NONE":String (NoMethodError)
    from /Library/Ruby/Gems/1.8/gems/mail-2.3.0/lib/mail/message.rb:1989:in `do_delivery'
    from /Library/Ruby/Gems/1.8/gems/mail-2.3.0/lib/mail/message.rb:232:in `deliver'
    from /Library/Ruby/Gems/1.8/gems/mail-2.3.0/lib/mail/mail.rb:140:in `deliver'
    from /Users/hron/bin/ezmail:20
```
