### PR TITLE
Update Rubinius aliases in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
   - 1.9.3
   - ree
   - jruby
-  - rbx
-  - rbx-2.0
+  - rbx-18mode
+  - rbx-19mode


### PR DESCRIPTION
rbx and rbx-2.0 still work but are both just aliases for rbx-18mode. I added rbx-19mode, it still may be quite
unstable for you. Feel free to disable. Finally, maybe try adding ruby-head.
