### PR TITLE
Normalize parse error

### DIFF
--- a/lib/mail/elements/address_list.rb
+++ b/lib/mail/elements/address_list.rb
@@ -26,7 +26,7 @@ module Mail
       if tree = parser.parse(string)
         @address_nodes = tree.addresses
       else
-        raise Mail::Field::ParseError, "AddressListsParser can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(AddressListsParser, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/content_disposition_element.rb
+++ b/lib/mail/elements/content_disposition_element.rb
@@ -10,7 +10,7 @@ module Mail
         @disposition_type = tree.disposition_type.text_value.downcase
         @parameters = tree.parameters
       else
-        raise Mail::Field::ParseError, "ContentDispositionElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(ContentDispositionElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/content_location_element.rb
+++ b/lib/mail/elements/content_location_element.rb
@@ -9,7 +9,7 @@ module Mail
       if tree = parser.parse(string)
         @location = tree.location.text_value
       else
-        raise Mail::Field::ParseError, "ContentLocationElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(ContentLocationElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/content_transfer_encoding_element.rb
+++ b/lib/mail/elements/content_transfer_encoding_element.rb
@@ -12,7 +12,7 @@ module Mail
       when tree = parser.parse(string.to_s.downcase)
         @encoding = tree.encoding.text_value
       else
-        raise Mail::Field::ParseError, "ContentTransferEncodingElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(ContentTransferEncodingElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/content_type_element.rb
+++ b/lib/mail/elements/content_type_element.rb
@@ -11,7 +11,7 @@ module Mail
         @sub_type = tree.sub_type.text_value.downcase
         @parameters = tree.parameters
       else
-        raise Mail::Field::ParseError, "ContentTypeElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(ContentTypeElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/date_time_element.rb
+++ b/lib/mail/elements/date_time_element.rb
@@ -10,7 +10,7 @@ module Mail
         @date_string = tree.date.text_value
         @time_string = tree.time.text_value
       else
-        raise Mail::Field::ParseError, "DateTimeElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(DateTimeElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/envelope_from_element.rb
+++ b/lib/mail/elements/envelope_from_element.rb
@@ -10,7 +10,7 @@ module Mail
         @address = tree.addr_spec.text_value.strip
         @date_time = ::DateTime.parse("#{tree.ctime_date.text_value}")
       else
-        raise Mail::Field::ParseError, "EnvelopeFromElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(EnvelopeFromElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/message_ids_element.rb
+++ b/lib/mail/elements/message_ids_element.rb
@@ -9,7 +9,7 @@ module Mail
       if tree = parser.parse(string)
         @message_ids = tree.message_ids.map { |msg_id| clean_msg_id(msg_id.text_value) }
       else
-        raise Mail::Field::ParseError, "MessageIdsElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(MessageIdsElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/mime_version_element.rb
+++ b/lib/mail/elements/mime_version_element.rb
@@ -10,7 +10,7 @@ module Mail
         @major = tree.major.text_value
         @minor = tree.minor.text_value
       else
-        raise Mail::Field::ParseError, "MimeVersionElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(MimeVersionElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/phrase_list.rb
+++ b/lib/mail/elements/phrase_list.rb
@@ -9,7 +9,7 @@ module Mail
       if tree = parser.parse(string)
         @phrases = tree.phrases
       else
-        raise Mail::Field::ParseError, "PhraseList can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(PhraseList, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/elements/received_element.rb
+++ b/lib/mail/elements/received_element.rb
@@ -10,7 +10,7 @@ module Mail
         @date_time = ::DateTime.parse("#{tree.date_time.date.text_value} #{tree.date_time.time.text_value}")
         @info = tree.name_val_list.text_value
       else
-        raise Mail::Field::ParseError, "ReceivedElement can not parse |#{string}|\nReason was: #{parser.failure_reason}\n"
+        raise Mail::Field::ParseError.new(ReceivedElement, string, parser.failure_reason)
       end
     end
     

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -42,6 +42,14 @@ module Mail
     # Raised when a parsing error has occurred (ie, a StructuredField has tried
     # to parse a field that is invalid or improperly written)
     class ParseError < FieldError #:nodoc:
+      attr_accessor :element, :value, :reason
+
+      def initialize(element, value, reason)
+        @element = element
+        @value = value
+        @reason = reason
+        super("#{element} can not parse |#{value}|\nReason was: #{reason}")
+      end
     end
 
     # Raised when attempting to set a structured field's contents to an invalid syntax

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -79,7 +79,7 @@ describe Mail::Field do
     end
 
     it "should return an unstuctured field if the structured field parsing raises an error" do
-      Mail::ToField.should_receive(:new).and_raise(Mail::Field::ParseError)
+      Mail::ToField.should_receive(:new).and_raise(Mail::Field::ParseError.new(Mail::ToField, 'To: Bob, ,,, Frank, Smith', "Some reason"))
       field = Mail::Field.new('To: Bob, ,,, Frank, Smith')
       field.field.class.should eq Mail::UnstructuredField
       field.name.should eq 'To'
@@ -249,6 +249,22 @@ describe Mail::Field do
       subject = Mail::SubjectField.new("=?Windows1252?Q?It=92s_a_test=3F?=", 'utf-8')
       subject.decoded.should eq "It’s a test?"
     end
+  end
+
+  describe Mail::Field::ParseError do
+    it "should be structured" do
+      error = nil
+      begin
+        Mail::DateTimeElement.new("invalid")
+      rescue Mail::Field::ParseError => e
+        error = e
+      end
+      error.should_not be_nil
+      error.element.should == Mail::DateTimeElement
+      error.value.should == "invalid"
+      error.reason.should_not be_nil
+    end
+
   end
 
 end


### PR DESCRIPTION
Looks like `ParseError` has some kind of structure for a message that need to parse at application level.

This patch normalizes the data of `ParseError` and making all it available with accessor methods.
Some copypaste removed as side effect)
