### PR TITLE
The behavior of value_decode method is difference between ruby 1.8 and ruby 1.9.

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -147,19 +147,17 @@ module Mail
 
     # Takes an encoded string of the format =?<encoding>?[QB]?<string>?=
     def Encodings.unquote_and_convert_to(str, to_encoding)
-      original_encoding = split_encoding_from_string( str )
-
-      output = value_decode( str ).to_s
-
-      if original_encoding.to_s.downcase.gsub("-", "") == to_encoding.to_s.downcase.gsub("-", "")
+      output = value_decode( str ).to_s # output is already converted to UTF-8
+      
+      if 'utf8' == to_encoding.to_s.downcase.gsub("-", "")
         output
-      elsif original_encoding && to_encoding
+      elsif to_encoding
         begin
           if RUBY_VERSION >= '1.9'
             output.encode(to_encoding)
           else
             require 'iconv'
-            Iconv.iconv(to_encoding, original_encoding, output).first
+            Iconv.iconv(to_encoding, 'UTF-8', output).first 
           end
         rescue Iconv::IllegalSequence, Iconv::InvalidEncoding, Errno::EINVAL
           # the 'from' parameter specifies a charset other than what the text

--- a/lib/mail/version_specific/ruby_1_8.rb
+++ b/lib/mail/version_specific/ruby_1_8.rb
@@ -3,6 +3,7 @@
 module Mail
   class Ruby18
     require 'base64'
+    require 'iconv'
 
     # Escapes any parenthesis in a string that are unescaped. This can't
     # use the Ruby 1.9.1 regexp feature of negative look behind so we have
@@ -59,12 +60,13 @@ module Mail
       encoding = encoding.to_s.upcase.gsub('_', '-')
       [Encodings::Base64.encode(str), encoding]
     end
-
+    
     def Ruby18.b_value_decode(str)
       match = str.match(/\=\?(.+)?\?[Bb]\?(.+)?\?\=/m)
       if match
         encoding = match[1]
         str = Ruby18.decode_base64(match[2])
+        str = Iconv.conv('UTF-8//IGNORE', fix_encoding(encoding), str)
       end
       str
     end
@@ -81,6 +83,7 @@ module Mail
       if match
         encoding = match[1]
         str = Encodings::QuotedPrintable.decode(match[2].gsub(/_/, '=20'))
+        str = Iconv.conv('UTF-8//IGNORE', fix_encoding(encoding), str)
       end
       str
     end
@@ -93,6 +96,17 @@ module Mail
       encoding = $KCODE.to_s.downcase
       language = Configuration.instance.param_encode_language
       "#{encoding}'#{language}'#{URI.escape(str)}"
+    end
+
+    private
+
+    def Ruby18.fix_encoding(encoding)
+      case encoding.upcase
+      when 'UTF8'
+        'UTF-8'
+      else
+        encoding
+      end
     end
   end
 end

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -192,7 +192,7 @@ describe "mail encoding" do
     if RUBY_VERSION > '1.9'
       lambda { m.subject.should be_valid_encoding }.should_not raise_error
     else
-      m.subject.should eq "Hello \226 World"
+      m.subject.should eq "Hello  World"
     end
   end
 end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -138,29 +138,15 @@ describe Mail::Encodings do
     end
 
     it "should decode UTF-16 encoded string" do
-      if RUBY_VERSION >= '1.9'
-        string = "=?UTF-16?B?MEIwRDBGMEgwSg==?="
-        result = "あいうえお"
-        result.force_encoding('UTF-8')
-        Mail::Encodings.value_decode(string).should == result
-      else
-        string = "=?UTF-16?B?MEIwRDBGMEgwSg==?="
-        result = "0B0D0F0H0J"
-        Mail::Encodings.value_decode(string).should == result
-      end
+      string = "=?UTF-16?B?MEIwRDBGMEgwSg==?="
+      result = "あいうえお"
+      Mail::Encodings.value_decode(string).should == result
     end
 
     it "should decode UTF-32 encoded string" do
-      if RUBY_VERSION >= '1.9'
-        string = "=?UTF-32?B?AAAwQgAAMEQAADBGAAAwSAAAMEo=?="
-        result = "あいうえお"
-        result.force_encoding('UTF-8')
-        Mail::Encodings.value_decode(string).should == result
-      else
-        string = "=?UTF-32?B?AAAwQgAAMEQAADBGAAAwSAAAMEo=?="
-        result = "\000\0000B\000\0000D\000\0000F\000\0000H\000\0000J"
-        Mail::Encodings.value_decode(string).should == result
-      end
+      string = "=?UTF-32?B?AAAwQgAAMEQAADBGAAAwSAAAMEo=?="
+      result = "あいうえお"
+      Mail::Encodings.value_decode(string).should == result
     end
   end
 
@@ -272,7 +258,7 @@ describe Mail::Encodings do
     it "should round trip another complex string (koi-8)" do
       original = "Слово 9999 и число"
       mail = Mail.new
-      mail.subject = (RUBY_VERSION >= "1.9" ? original.encode('koi8-r') : original)
+      mail.subject = (RUBY_VERSION >= "1.9" ? original.encode('koi8-r') : Iconv.conv('koi8-r', 'UTF-8', original))
       mail[:subject].charset = 'koi8-r'
       wrapped = mail[:subject].wrapped_value
       unwrapped = Mail::Encodings.value_decode(wrapped)
@@ -423,29 +409,15 @@ describe Mail::Encodings do
     end
 
     it "should decode UTF-16 encoded string" do
-      if RUBY_VERSION >= '1.9'
-        string = "=?UTF-16?Q?0B0D0F0H0J=?="
-        result = "あいうえお"
-        result.force_encoding('UTF-8')
-        Mail::Encodings.value_decode(string).should == result
-      else
-        string = "=?UTF-16?Q?0B0D0F0H0J=?="
-        result = "0B0D0F0H0J"
-        Mail::Encodings.value_decode(string).should == result
-      end
+      string = "=?UTF-16?Q?0B0D0F0H0J=?="
+      result = "あいうえお"
+      Mail::Encodings.value_decode(string).should == result
     end
 
     it "should decode UTF-32 encoded string" do
-      if RUBY_VERSION >= '1.9'
-        string = "=?UTF-32?Q?=00=000B=00=000D=00=000F=00=000H=00=000J=?="
-        result = "あいうえお"
-        result.force_encoding('UTF-8')
-        Mail::Encodings.value_decode(string).should == result
-      else
-        string = "=?UTF-32?Q?=00=000B=00=000D=00=000F=00=000H=00=000J=?="
-        result = "\x00\x000B\x00\x000D\x00\x000F\x00\x000H\x00\x000J"
-        Mail::Encodings.value_decode(string).should == result
-      end
+      string = "=?UTF-32?Q?=00=000B=00=000D=00=000F=00=000H=00=000J=?="
+      result = "あいうえお"
+      Mail::Encodings.value_decode(string).should == result
     end
 
     it "should detect multiple encoded QP string to the decoded string" do
@@ -602,10 +574,10 @@ describe Mail::Encodings do
       end
 
       it "should unquote and change to an ISO encoding if we really want" do
-        a ="=?ISO-8859-1?Q?Brosch=FCre_Rand?="
+        a = "=?ISO-8859-1?Q?Brosch=FCre_Rand?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'iso-8859-1')
         expected = "Brosch\374re Rand"
-        expected.force_encoding('iso-8859-1').encode!('utf-8') if expected.respond_to?(:force_encoding)
+        expected.force_encoding('iso-8859-1') if expected.respond_to?(:force_encoding)
         b.should eq expected
       end
 
@@ -645,7 +617,7 @@ describe Mail::Encodings do
       if RUBY_VERSION >= '1.9'
         expected = "\nRe: ol\341".force_encoding('ISO-8859-1').encode('utf-8')
       else
-        expected = "\nRe: ol\341"
+        expected = Iconv.conv("UTF-8", "ISO-8859-1", "\nRe: ol\341")
       end
       encoded = "=?ISO-8859-1?Q?\nRe=3A_ol=E1?="
       Mail::Encodings.value_decode(encoded).should eq expected

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -233,13 +233,13 @@ describe Mail::Field do
     end
 
     it "more tolerable to encoding definitions, UTF (issue 120)" do
-      to = Mail::ToField.new("=?utf8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>", 'utf-8')
-      to.encoded.should eq "To: =?utf8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      to = Mail::ToField.new("=?utf-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>", 'utf-8')
+      to.encoded.should eq "To: =?utf-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
       to.decoded.should eq "\"あdあ\" <ada@test.lindsaar.net>"
     end
 
     it "more tolerable to encoding definitions, ISO (issue 120)" do
-      subject = Mail::SubjectField.new("=?UTF8?B?UmU6IHRlc3QgZW52w61vIG1lbnNhamUgY29u?=", 'utf-8')
+      subject = Mail::SubjectField.new("=?UTF-8?B?UmU6IHRlc3QgZW52w61vIG1lbnNhamUgY29u?=", 'utf-8')
       subject.decoded.should eq "Re: test envío mensaje con"
     end
 


### PR DESCRIPTION
value_decode method should return a UTF-8 encoded string in ruby 1.8.

BTW, If you merge this PR, It seems that we'll merge PR #277 too.
