### PR TITLE
Encodings.value_decode(str): Treat lines with mixed encoding correctly when the line ends with a plain text part.

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -130,7 +130,7 @@ module Mail
           text.scan(/(                                  # Group around entire regex to include it in matches
                        \=\?[^?]+\?([QB])\?[^?]+?\?\=  # Quoted String with subgroup for encoding method
                        |                                # or
-                       .+?(?=\=\?)                      # Plain String
+                       .+?(?=\=\?|$)                    # Plain String
                      )/xmi).map do |matches|
             string, method = *matches
             if    method == 'b' || method == 'B'

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -621,6 +621,12 @@ describe Mail::Encodings do
         b.should eq "瑞庵2→最近門松を飾る家がほとんど見当たらない！寂しいことですね。日本のいいところ、わびさびの世界が失われつつある現在、なんとか後世に残さねば、勿体ない！とままは思うのだ。"
       end
 
+      it "should handle quoted string with mixed content that have a plain string at the end" do
+        a = 'Der Kunde ist K=?utf-8?B?w7Y=?=nig'
+        b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
+        b.should eq "Der Kunde ist König"
+      end
+
     end
   end
   


### PR DESCRIPTION
Fixes mikel/mail#338
