### PR TITLE
fix mail reading: don't raise invalid byte sequence in UTF-8 when reading non-UTF-8 emails

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1884,6 +1884,7 @@ module Mail
     end
 
     def raw_source=(value)
+      value.force_encoding("binary") if RUBY_VERSION >= "1.9.1"
       @raw_source = value.to_crlf
     end
 

--- a/spec/fixtures/emails/multi_charset/japanese_shiftjis.eml
+++ b/spec/fixtures/emails/multi_charset/japanese_shiftjis.eml
@@ -1,0 +1,10 @@
+MIME-Version: 1.0
+Subject: =?UTF-8?B?44G+44G/44KA44KB44KC?=
+From: Mikel Lindsaar <raasdnil@gmail.com>
+To: =?UTF-8?B?44G/44GR44KL?= <raasdnil@gmail.com>
+Content-Type: text/plain;
+ charset=iso-2022-jp
+Content-Transfer-Encoding: 7bit
+
+すみません。
+

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -292,6 +292,12 @@ describe Mail::Message do
       mail.to.should eq ["tester2@test.com"]
     end
 
+    it "should parse non-UTF8 sources" do
+      mail = Mail::Message.new(File.read(fixture('emails', 'multi_charset', 'japanese_shiftjis.eml')))
+      mail.to.should eq ["raasdnil@gmail.com"]
+      body_text = mail.body.decoded.force_encoding("iso-2022-jp").encode("UTF-8")
+      body_text.should eq "すみません。"
+    end
   end
 
   describe "directly setting values of a message" do


### PR DESCRIPTION
recreated the pull request I did in #341 to fix #340. This version should also be fine with ruby 1.8.7 - if not, please adjust.
