### PR TITLE
fixed an issue with long strings getting wrapped when using base64 encoding

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -215,9 +215,7 @@ module Mail
     def Encodings.b_value_encode(encoded_str, encoding = nil)
       return encoded_str if encoded_str.to_s.ascii_only?
       string, encoding = RubyVer.b_value_encode(encoded_str, encoding)
-      map_lines(string) do |str|
-        "=?#{encoding}?B?#{str.chomp}?="
-      end.join(" ")
+      "=?#{encoding}?B?#{map_lines(string) {|str| str.chomp }.join}?="
     end
 
     # Encode a string with Quoted-Printable Encoding and returns it ready to be inserted

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -111,15 +111,16 @@ describe Mail::Encodings do
       end
     end
 
-    it "should split the string up into bite sized chunks that can be wrapped easily" do
+    it "should not split the string up into bite sized chunks" do
+      string = "This is あ really long string This is あ really long string This is あ really long string This is あ really long string This is あ really long string"
+      expected = '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJlYWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJpbmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJlYWxseSBsb25nIHN0cmluZw==?='
+
       if RUBY_VERSION >= "1.9.1"
-        string = "This is あ really long string This is あ really long string This is あ really long string This is あ really long string This is あ really long string"
         string = string.force_encoding('UTF-8')
-        Mail::Encodings.b_value_encode(string).should eq '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
+        Mail::Encodings.b_value_encode(string).should eq expected
       else
-        string = "This is あ really long string This is あ really long string This is あ really long string This is あ really long string This is あ really long string"
         encoding = 'UTF-8'
-        Mail::Encodings.b_value_encode(string, encoding).should eq '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
+        Mail::Encodings.b_value_encode(string, encoding).should expected
       end
     end
 


### PR DESCRIPTION
For long base64 encoded strings in the From field (for instance), the encoded string was divided in several chunks, such as:

```
=?UTF-8?B?VHJhc2ggLSDmraPmsJfjgpLjgrTjg5/nrrHjgavnp7vli5XjgZfjgZ/jgorj?= =?UTF-8?B?gIHnl5vjgb/jgafmrbvjgawgW0Rvb3JrZWVwZXIgU1RBR0lOR10=?=
```

This is causing issues with several mail clients (including Apple's mail.app and Thunderbird) not showing the From name correctly. I assume this is because the splitting does not respect the character boundaries (i.e. each chunk cannot be decoded individually).

By not splitting the encoded string in chunks, the From name is shown correctly. This is the change in this pull request.
