### PR TITLE
Make Mail::Header properly Enumerable

### DIFF
--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -260,6 +260,13 @@ module Mail
     def limited_field?(name)
       LIMITED_FIELDS.include?(name.to_s.downcase)
     end
-    
+
+    # Enumerable support; yield each field in order to the block if there is one,
+    # or return an Enumerator for them if there isn't.
+    def each( &block )
+      return self.fields.each( &block ) if block
+      self.fields.each
+    end
+
   end
 end

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -58,6 +58,11 @@ describe Mail::Header do
       header['Content-Type'] = 'invalid/invalid; charset="iso-8859-1"'
       doing { header.charset }.should_not raise_error
     end
+
+    it "should be Enumerable" do
+      header = Mail::Header.new("To: James Random\r\nFrom: Santa Claus\r\n")
+      header.find {|f| f.responsible_for?('From') }.should be_a(Mail::Field)
+    end
   end
 
   describe "creating fields" do


### PR DESCRIPTION
Mail::Header doesn't implement #each even though it includes Enumerable, which causes any of the Enumerable methods to raise an exception:

```
address_fields = message.header.find_all {|h| h.field.respond_to?(:address) }
NoMethodError: undefined method `each' for #<Mail::Header:0x007fbe739864b0>
```

The commit in question adds a spec that tests for #each via the Enumerable API, and a fix that delegates Header's #each to its fields.
