### PR TITLE
support ascii strings in unstructured fields

### DIFF
--- a/lib/mail/fields/unstructured_field.rb
+++ b/lib/mail/fields/unstructured_field.rb
@@ -71,9 +71,7 @@ module Mail
     end
     
     def do_decode
-      result = value.blank? ? nil : Encodings.decode_encode(value, :decode)
-      result.encode!(value.encoding || "UTF-8") if RUBY_VERSION >= '1.9' && !result.blank?
-      result
+      value.blank? ? nil : Encodings.decode_encode(value, :decode)
     end
     
     # 2.2.3. Long Header Fields

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -240,6 +240,29 @@ describe Mail::Field do
       subject = Mail::SubjectField.new("=?Windows1252?Q?It=92s_a_test=3F?=", 'utf-8')
       subject.decoded.should == "It’s a test?"
     end
+
+    it "should support ascii encoded utf-8 subjects" do
+      pending if RUBY_VERSION < '1.9'
+      s = "=?utf-8?Q?simp?= =?utf-8?Q?le_=E2=80=93_dash_=E2=80=93_?="
+      s.force_encoding 'us-ascii'
+      s.encoding.to_s.should == 'US-ASCII'
+      s.valid_encoding?.should be_true
+
+      subject = Mail::SubjectField.new(s, 'utf-8')
+      subject.decoded.should == "simple – dash – "
+    end
+
+    it "should support ascii encoded windows subjects" do
+      pending if RUBY_VERSION < '1.9'
+      s = "=?utf-8?Q?simp?= =?utf-8?Q?le_=E2=80=93_dash_=E2=80=93_?="
+      s = "=?WINDOWS-1252?Q?simp?= =?WINDOWS-1252?Q?le_=96_dash_=96_?="
+      s.force_encoding 'us-ascii'
+      s.encoding.to_s.should == 'US-ASCII'
+      s.valid_encoding?.should be_true
+
+      subject = Mail::SubjectField.new(s, 'utf-8')
+      subject.decoded.should == "simple – dash – "
+    end
   end
 
 end


### PR DESCRIPTION
Our team ran into an issue where passing valid ascii encoded strings to Mail::SubjectField.new caused encoding exceptions (U+2013 from UTF-8 to US-ASCII (Encoding::UndefinedConversionError)).

The offending code was `result.encode!(value.encoding || "UTF-8")` found here: https://github.com/mikel/mail/blob/master/lib/mail/fields/unstructured_field.rb#L65

I don't know how to prove the correctness of this change, but removing that line:
1. fixed our problem
2. did not cause any tests to break (I tried ruby 1.8 and 1.9)

The new specs are an accurate representation of what we were experiencing and fail w/ the old code.

I'm looking for feedback on whether this is a reasonable change or if there is an alternative way of getting around the problem we experienced.
