### PR TITLE
define NilClass#blank? only if not defined yet

### DIFF
--- a/lib/mail/core_extensions/nil.rb
+++ b/lib/mail/core_extensions/nil.rb
@@ -3,8 +3,10 @@
 # This is not loaded if ActiveSupport is already loaded
 
 class NilClass #:nodoc:
-  def blank?
-    true
+  unless nil.respond_to? :blank?
+    def blank?
+      true
+    end
   end
 
   def to_crlf


### PR DESCRIPTION
NilClass version of ac3af6431d16d1853d2b77e0d1edd8e09ad90bf1, as this overwrites existing `NilClass#blank?` added by ActiveSupport, and spreads warnings when running Rails apps with `-w` flag.
