### PR TITLE
fix Mail::CommonAddress#value=, Mail::CommonAddress#<< and Mail::Encodings.encode_non_usascii

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -189,7 +189,7 @@ module Mail
       return address if address.ascii_only? or charset.nil?
       us_ascii = %Q{\x00-\x7f}
       # Encode any non usascii strings embedded inside of quotes
-      address.gsub!(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
+      address = address.gsub(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
       # Then loop through all remaining items and encode as needed
       tokens = address.split(/\s/)
       map_with_index(tokens) do |word, i|

--- a/lib/mail/fields/common/common_address.rb
+++ b/lib/mail/fields/common/common_address.rb
@@ -81,8 +81,13 @@ module Mail
       when val.blank?
         parse(encoded)
       else
-        parse((formatted + [val]).join(", "))
+        self.value = [self.value, val].reject {|a| a.blank? }.join(", ")
       end
+    end
+
+    def value=(val)
+      super
+      parse(self.value)
     end
   
     private

--- a/spec/mail/fields/common/common_field_spec.rb
+++ b/spec/mail/fields/common/common_field_spec.rb
@@ -61,7 +61,6 @@ describe Mail::CommonField do
       field = Mail::FromField.new(value)
       field.encoded.should eq result
       field.decoded.should eq value
-      field.value.should eq "=?UTF-8?B?44GL44GN44GP44GR44GT?= <mikel@test.lindsaar.net>"
     end
     
   end


### PR DESCRIPTION
Mail::CommonAddress#value= and #<< don't work properly.

```
* Mail::CommonAddress#value= should be available for multi-byte addresses.

* Mail::CommonAddress#<< should be available for multi-byte addresses.

* Mail::CommonAddress#<< should affect its value.

* Mail::Encodings.encode_non_usascii should not change the argument
      to make Mail::CommonAddress#value= preserve the contents of its argument.
```
