### PR TITLE
Support 8bit encoding for ruby 1.9

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -73,6 +73,8 @@ module Mail
       end
       decoded = str.encode("utf-8", :invalid => :replace, :replace => "")
       decoded.valid_encoding? ? decoded : decoded.encode("utf-16le", :invalid => :replace, :replace => "").encode("utf-8")
+    rescue Encoding::UndefinedConversionError
+      str.dup.force_encoding("utf-8")
     end
 
     def Ruby19.param_decode(str, encoding)
@@ -105,6 +107,7 @@ module Mail
         when /utf-?(\d{1,2})?(\w{1,2})/i then return "UTF-#{$1}#{$2}".gsub(/\A(UTF-(?:16|32))\z/, '\\1BE')
         # Windows-1252 and alike
         when /Windows-?(.*)/i then return "Windows-#{$1}"
+        when /^8bit$/ then return "ASCII-8BIT"
         #more aliases to be added if needed
         else return encoding
       end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -162,6 +162,14 @@ describe Mail::Encodings do
         Mail::Encodings.value_decode(string).should == result
       end
     end
+
+    it "should decode 8bit encoded string" do
+      if RUBY_VERSION >= '1.9'
+        string = "=?8bit?Q?ALPH=C3=89E?="
+        result = "ALPH\xC3\x89E"
+        Mail::Encodings.value_decode(string).should == result
+      end
+    end
   end
 
   describe "Q encodings" do


### PR DESCRIPTION
One of the email I work with have the following sequence in body:

```
=?8bit?Q?ALPH=C3=89E?=
```

8bit encoding in mail should be converted into `ASCII-8BIT` in ruby.
This is kinda no doubt change.

Also this string is really UTF string, but encoding is set to 8bit maybe because it came from some serial device like network printer. 
That is why there is also some rescue code in this PR:
When 8bit encoded string can not be encoded to UTF-8, we can at least convert it to UTF manually.

For Ruby1.8 this works, I just didn't have a chance to run test suite on ruby 1.8 because of #360.
