### PR TITLE
Enable TLS support under Ruby 1.8.x.

### DIFF
--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -133,9 +133,13 @@ module Mail
             if openssl_verify_mode.kind_of?(String)
               openssl_verify_mode = "OpenSSL::SSL::VERIFY_#{openssl_verify_mode.upcase}".constantize
             end
-            context = Net::SMTP.default_ssl_context
-            context.verify_mode = openssl_verify_mode
-            smtp.enable_starttls_auto(context)
+            if RUBY_VERSION >= '1.9.0'
+              context = Net::SMTP.default_ssl_context
+              context.verify_mode = openssl_verify_mode
+              smtp.enable_tls(context)
+            else
+              smtp.enable_tls(openssl_verify_mode)
+            end
           end
         end
       end


### PR DESCRIPTION
There needs to be a check for which version of ruby is being used
when trying to enable tls support.   Ruby 1.8 Net::SMTP does not
support the context object for enabling the TLS support, you
need to pass the OPEN::SSL::VERIFY related constant directly.

This patch checks for the version of Ruby and enables it as appropriate.
