### PR TITLE
Add maximum_amount of parsed headers configuration parameter

### DIFF
--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -21,6 +21,20 @@ module Mail
     include Utilities
     include Enumerable
     
+    @@maximum_amount = 1000
+
+    # Large amount of headers in Email might create extra high CPU load
+    # Use this parameter to limit number of headers that will be parsed by 
+    # mail library.
+    # Default: 1000
+    def self.maximum_amount
+      @@maximum_amount
+    end
+
+    def self.maximum_amount=(value)
+      @@maximum_amount = value
+    end
+
     # Creates a new header object.
     # 
     # Accepts raw text or nothing.  If given raw text will attempt to parse
@@ -73,8 +87,8 @@ module Mail
     #  h.fields = ['From: mikel@me.com', 'To: bob@you.com']
     def fields=(unfolded_fields)
       @fields = Mail::FieldList.new
-      warn "Warning: more than 1000 header fields only using the first 1000" if unfolded_fields.length > 1000
-      unfolded_fields[0..1000].each do |field|
+      warn "Warning: more than #{self.class.maximum_amount} header fields only using the first #{self.class.maximum_amount}" if unfolded_fields.length > self.class.maximum_amount
+      unfolded_fields[0..(self.class.maximum_amount-1)].each do |field|
 
         field = Field.new(field, nil, charset)
         field.errors.each { |error| self.errors << error }

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'spec_helper'
+require "active_support/core_ext/kernel/reporting"
 
 describe Mail::Header do
 
@@ -590,6 +591,27 @@ TRACEHEADER
     it "should return nil if no content-description header field" do
       header = Mail::Header.new
       header['Content-Description'].should eq nil
+    end
+    
+  end
+
+  describe "configuration option .maximum_amount" do
+
+    it "should be 1000 by default" do
+      Mail::Header.maximum_amount.should == 1000
+    end
+
+    it "should limit amount of parsed headers" do
+      old_maximum_amount = Mail::Header.maximum_amount
+      begin
+        Mail::Header.maximum_amount = 10
+        silence_warnings do
+          header = Mail::Header.new("X-SubscriberID: 345\n" * 11)
+          header.fields.size.should == 10
+        end
+      ensure
+        Mail::Header.maximum_amount = old_maximum_amount
+      end
     end
     
   end


### PR DESCRIPTION
Improving the work done in #206.

As per #206 - maximum amount of parsed headers is set to 1000. In my case this is a lot, because I dispaly 10 mails per page and need to parse them all during request. Acceptable value for me is 100 headers per email.

So I made it configurable.

Some tests bundled - as @mikel requested in #206.

Thanks @scsmith for raising this question.
