### PR TITLE
Headers parsing performance optimization

### DIFF
--- a/lib/mail/fields/common/common_field.rb
+++ b/lib/mail/fields/common/common_field.rb
@@ -34,7 +34,7 @@ module Mail
     end
 
     def responsible_for?( val )
-      name.to_s.downcase == val.to_s.downcase
+      name.to_s.casecmp(val.to_s) == 0
     end
 
     private

--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -78,9 +78,7 @@ module Mail
 
         field = Field.new(field, nil, charset)
         field.errors.each { |error| self.errors << error }
-        selected = select_field_for(field.name)
-
-        if selected.any? && limited_field?(field.name)
+        if limited_field?(field.name) && (selected = select_field_for(field.name)) && selected.any? 
           selected.first.update(field.name, field.value)
         else
           @fields << field
@@ -254,7 +252,7 @@ module Mail
     end
     
     def select_field_for(name)
-      fields.select { |f| f.responsible_for?(name.to_s) }
+      fields.select { |f| f.responsible_for?(name) }
     end
     
     def limited_field?(name)


### PR DESCRIPTION
Among other tiny changes this PR contains the following optimization:

``` diff
-        selected = select_field_for(field.name)
-
-        if selected.any? && limited_field?(field.name) 
+        if limited_field?(field.name) && (selected = select_field_for(field.name)) && selected.any?
```

This allows `select_field_for`(that is pretty slow when number of headers is high) be called only when `limited_field?` returns true.

About 30% performance improvement for `Mail::Header.new` method when there are a lot of unknown headers.
