### PR TITLE
Mail::Header: resolve performance issue

### DIFF
--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -159,15 +159,15 @@ module Mail
         # Need to insert in correct order for trace fields
         self.fields << Field.new(name.to_s, value, charset)
       end
+      if dasherize(fn) == "content-type"
+        # Update charset if specified in Content-Type
+        params = self[:content_type].parameters rescue nil
+        @charset = params && params[:charset]
+      end
     end
     
     def charset
-      params = self[:content_type].parameters rescue nil
-      if params
-        params[:charset]
-      else
-        @charset
-      end
+      @charset
     end
     
     def charset=(val)


### PR DESCRIPTION
`Mail::Header#charset` is called pretty often during header parser work.
If there are large amount of headers `#[]` is pretty slow.

There is already `@charset` variable, but it doesn't speed up the `charset` method. This patch makes headers parsing faster by keeping `@charset` variable always up to date and speeding up the `charset` method .

Benchmark code:

``` ruby
Mail::Header.new("X-SubscriberID: 345\n" * 100)
```

Benchmark: https://gist.github.com/6b84d985c4e2b29dbb80

Result (with patch and without patch):

```
Running benchmark with current working tree
Checkout HEAD^
Running benchmark with HEAD^
Checkout to previous HEAD again

                    user     system      total        real
----------------------------------headers parsing when long
After patch:    0.100000   0.000000   0.100000 (  0.089926)
Before patch:   0.700000   0.000000   0.700000 (  0.697444)

----------------------------------headers parsing when tiny
After patch:    0.000000   0.000000   0.000000 (  0.009930)
Before patch:   0.020000   0.000000   0.020000 (  0.024283)

---------------------------------headers parsing when empty
After patch:    0.010000   0.000000   0.010000 (  0.002160)
Before patch:   0.000000   0.000000   0.000000 (  0.002354)
```
