### PR TITLE
Split strictly on MIME boundary lines [Fixes #379]

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -257,7 +257,7 @@ module Mail
     
     def split!(boundary)
       self.boundary = boundary
-      parts = raw_source.split("--#{boundary}")
+      parts = raw_source.split(/--#{Regexp.escape(boundary)}(?=(?:--)?\s*$)/)
       # Make the preamble equal to the preamble (if any)
       self.preamble = parts[0].to_s.strip
       # Make the epilogue equal to the epilogue (if any)

--- a/spec/fixtures/emails/mime_emails/email_with_similar_boundaries.eml
+++ b/spec/fixtures/emails/mime_emails/email_with_similar_boundaries.eml
@@ -1,0 +1,45 @@
+Received: from xxxx.xxxxxxx.xxx (127.0.0.1) by
+ xxxx.xxxxxxxx.xxx (127.0.01) with Microsoft SMTP Server id
+ 11.1.111.1; Thu, 5 Apr 2012 01:01:01 -0700
+Message-ID: <e4b473$b3jkq@xxxx.xxxx.xxxxxxxx.xxx>
+To: <xxxxxxx@xxxxxxxxxxx.xxx>
+Subject: Xxxxxx
+Date: Fri, 6 Apr 2012 01:01:01 +0000
+From: Xxxxx <xxxxxx@xxxxxxxx.xxx>
+X-Mailer: PHP/5.2.6
+Content-Type: multipart/mixed;
+	boundary="----=_NextPart_476c4fde88e507bb8028170e8cf47c73"
+MIME-Version: 1.0
+
+------=_NextPart_476c4fde88e507bb8028170e8cf47c73
+Content-Type: multipart/alternative;
+	boundary="----=_NextPart_476c4fde88e507bb8028170e8cf47c73_alt"
+
+------=_NextPart_476c4fde88e507bb8028170e8cf47c73_alt
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+Test
+
+------=_NextPart_476c4fde88e507bb8028170e8cf47c73_alt
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/1999/REC-html401-19991224/strict.dtd"><html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Test</title>
+<body>
+<p>Test</p>
+</body>
+
+------=_NextPart_476c4fde88e507bb8028170e8cf47c73_alt--
+
+------=_NextPart_476c4fde88e507bb8028170e8cf47c73
+Content-Type: application/octetstream
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="LOGO.png"
+Content-ID: <LOGO.png>
+
+SNIP
+
+------=_NextPart_476c4fde88e507bb8028170e8cf47c73--

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -100,6 +100,13 @@ describe "MIME Emails" do
         mail.should be_has_attachments
       end
 
+      it "should only split on exact boundary matches" do
+        mail = Mail.read(fixture('emails', 'mime_emails', 'email_with_similar_boundaries.eml'))
+        mail.parts.size.should == 2
+        mail.parts.first.parts.size.should == 2
+        mail.boundary.should == "----=_NextPart_476c4fde88e507bb8028170e8cf47c73"
+        mail.parts.first.boundary.should == "----=_NextPart_476c4fde88e507bb8028170e8cf47c73_alt"
+      end
     end
 
     describe "multipart emails" do


### PR DESCRIPTION
Tested on:
- jruby-1.6.7 [ amd64 ]
- ree-1.8.7-2011.12 [ x86_64 ]
- ruby-1.8.7-p352 [ x86_64 ]
- ruby-1.9.2-p290 [ x86_64 ]
- ruby-1.9.3-p125 [ x86_64 ]

Example problemative email: https://github.com/ConradIrwin/mail/blob/988f93eeb4d8a29347ba74a2394cc7fbe793b9d7/spec/fixtures/emails/mime_emails/email_with_similar_boundaries.eml

--8<--
Some mail generators ignore RFC 2046's "Boundary delimeters must not
appear within the encapsulated material" by using MIME boundaries for
inner parts that contain the MIME boundaries for outer parts.

To parse these emails as the author intended it is necessary to split
encapsulated content only on boundary delimeters that are on their own
line, instead of those that appear with suffixed content.
