### PR TITLE
Mail::TestMailer clones messages when they're delivered

### DIFF
--- a/lib/mail/network/delivery_methods/test_mailer.rb
+++ b/lib/mail/network/delivery_methods/test_mailer.rb
@@ -33,7 +33,8 @@ module Mail
     attr_accessor :settings
 
     def deliver!(mail)
-      Mail::TestMailer.deliveries << mail
+      clone = Marshal.load(Marshal.dump(mail))
+      Mail::TestMailer.deliveries << clone
     end
     
   end

--- a/spec/mail/network/delivery_methods/test_mailer_spec.rb
+++ b/spec/mail/network/delivery_methods/test_mailer_spec.rb
@@ -54,4 +54,24 @@ describe "Mail::TestMailer" do
     Mail::TestMailer.deliveries.should be_empty
   end
 
+  it "should clone mail objects" do
+    Mail.defaults do
+      delivery_method :test
+    end
+
+    mail = Mail.new do
+      to 'foo@me.com'
+      from 'you@you.com'
+      subject 'testing'
+      body 'testing'
+    end
+    mail.deliver
+
+    # Modify the message and send again
+    mail.to = "bar@me.com"
+    mail.deliver
+    Mail::TestMailer.deliveries.first.to.should eq ["foo@me.com"]
+    Mail::TestMailer.deliveries.last.to.should eq ["bar@me.com"]
+  end
+
 end


### PR DESCRIPTION
This allows you to deliver a message, modify it, then deliver it again.

Modifying delivered messages is useful when sending the same message
body to many recipients.
