### PR TITLE
Issue #390: Fixed failed attachment parsing when file name in headers contains spaces and is not wrapped in quotes

### DIFF
--- a/lib/mail/fields/common/common_field.rb
+++ b/lib/mail/fields/common/common_field.rb
@@ -47,5 +47,11 @@ module Mail
       end
     end
 
+    def ensure_filename_quoted(value)
+      if !value.is_a?(Array) and /(.)*\s(filename|name)=[^"](.+\s)+[^"]/.match value
+        value.gsub!(/[^=]+$/, '"\\0"')
+      end
+    end
+
   end
 end

--- a/lib/mail/fields/content_disposition_field.rb
+++ b/lib/mail/fields/content_disposition_field.rb
@@ -9,6 +9,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
+      ensure_filename_quoted(value)
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
       self.parse
       self

--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -19,6 +19,7 @@ module Mail
         @parameters = nil
         value = strip_field(FIELD_NAME, value)
       end
+      ensure_filename_quoted(value)
       super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self

--- a/spec/fixtures/emails/attachment_emails/attachment_with_unquoted_name.eml
+++ b/spec/fixtures/emails/attachment_emails/attachment_with_unquoted_name.eml
@@ -1,0 +1,28 @@
+Mime-Version: 1.0 (Apple Message framework v730)
+Content-Type: multipart/mixed; boundary=Apple-Mail-13-196941151
+Message-Id: <9169D984-4E0B-45EF-82D4-8F5E53AD7012@example.com>
+From: foo@example.com
+Subject: testing
+Date: Mon, 6 Jun 2005 22:21:22 +0200
+To: blah@example.com
+
+
+--Apple-Mail-13-196941151
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+	charset=ISO-8859-1;
+	delsp=yes;
+	format=flowed
+
+This is the first part.
+
+--Apple-Mail-13-196941151
+Content-Type: text/plain; name=This is a test.txt
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment;
+	filename=This is a test.txt
+
+Hi there.
+
+--Apple-Mail-13-196941151--
+

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -240,6 +240,12 @@ describe "reading emails with attachments" do
       result.should eq expected
     end
 
+    it "should find an attachment that has a name not surrounded by quotes" do
+      mail = Mail.read(fixture(File.join('emails', 'attachment_emails', "attachment_with_unquoted_name.eml")))
+      mail.attachments.length.should eq 1
+      mail.attachments.first.filename.should eq "This is a test.txt"
+    end
+
     it "should find attachments inside parts with content-type message/rfc822" do
       mail = Mail.read(fixture(File.join("emails",
                                          "attachment_emails",

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -36,6 +36,17 @@ describe Mail::ContentDispositionField do
       c.encoded.should eq "Content-Disposition: inline\r\n"
     end
 
+    it "should wrap a filename in double quotation marks only if the filename contains spaces and does not already have double quotation marks" do
+      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=This is a bad filename.txt')
+      c.value.should eq 'attachment; filename="This is a bad filename.txt"'
+
+      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=some.jpg')
+      c.value.should eq 'attachment; filename=some.jpg'
+
+      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename="Bad filename but at least it is wrapped in quotes.txt"')
+      c.value.should eq 'attachment; filename="Bad filename but at least it is wrapped in quotes.txt"'
+    end
+
     it "should render decoded" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
       c.decoded.should eq 'attachment; filename=File'

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -122,6 +122,17 @@ describe Mail::ContentTypeField do
       c.main_type.should eq 'message'
       c.sub_type.should eq 'delivery-status'
     end
+
+    it "should wrap a filename in double quotation marks only if the filename contains spaces and does not already have double quotation marks" do
+      c = Mail::ContentTypeField.new('text/plain; name=This is a bad filename.txt')
+      c.value.should eq 'text/plain; name="This is a bad filename.txt"'
+
+      c = Mail::ContentTypeField.new('image/jpg; name=some.jpg')
+      c.value.should eq 'image/jpg; name=some.jpg'
+
+      c = Mail::ContentTypeField.new('text/plain; name="Bad filename but at least it is wrapped in quotes.txt"')
+      c.value.should eq 'text/plain; name="Bad filename but at least it is wrapped in quotes.txt"'
+    end
   end
 
   describe "instance methods" do


### PR DESCRIPTION
See issue #390 for more information.

Specs included. Tested on MRI Ruby 1.9.3 and 1.8.7, Rbx 2.0.0 (1.8.7), and JRuby 1.6.7 (1.8.7)
