### PR TITLE
Support dots in addresses

### DIFF
--- a/lib/mail/parsers/rfc2822.treetop
+++ b/lib/mail/parsers/rfc2822.treetop
@@ -110,7 +110,7 @@ module Mail
     end
     
     rule local_dot_atom_text
-      ("."* domain_text)+
+      ("."* domain_text "."*)+
     end
     
     rule domain_text

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -261,6 +261,21 @@ describe Mail::Address do
         end
       end
 
+      it "should handle trailing dots" do
+        1.upto(10) do |times|
+          dots    = "." * times
+          address = Mail::Address.new("hogetest#{dots}@docomo.ne.jp")
+          address.should break_down_to({
+                                           :display_name => nil,
+                                           :address      => "hogetest#{dots}@docomo.ne.jp",
+                                           :local        => "hogetest#{dots}",
+                                           :domain       => 'docomo.ne.jp',
+                                           :format       => "hogetest#{dots}@docomo.ne.jp",
+                                           :comments     => nil,
+                                           :raw          => "hogetest#{dots}@docomo.ne.jp"})
+        end
+      end
+
       it 'should handle |"Joe & J. Harvey" <ddd @Org>|' do
         address = Mail::Address.new('"Joe & J. Harvey" <ddd @Org>')
         address.should break_down_to({


### PR DESCRIPTION
This violates the RFC, but unfortunately email addresses with dots like this are used in the wild.
