### PR TITLE
Allow :ca_path or :ca_file to be passed in as settings, for SSL context

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,7 +95,7 @@ class MockSMTP
     end
   end
 
-  def enable_starttls_auto
+  def enable_starttls_auto(context = :dummy_ssl_context)
     true
   end
 


### PR DESCRIPTION
RE: Issue #345

Also refactored SSL context code in Mail::SMTP to use a shared private method: `#ssl_context`.
