### PR TITLE
check mail params for every delivery method

### DIFF
--- a/lib/mail/check_delivery_params.rb
+++ b/lib/mail/check_delivery_params.rb
@@ -1,0 +1,30 @@
+module Mail
+
+  module CheckDeliveryParams
+
+    def self.included(klass)
+      klass.class_eval do
+
+        def check_params(mail)
+          envelope_from = mail.return_path || mail.sender || mail.from_addrs.first
+          if envelope_from.blank?
+            raise ArgumentError.new('A sender (Return-Path, Sender or From) required to send a message')
+          end
+
+          destinations ||= mail.destinations if mail.respond_to?(:destinations) && mail.destinations
+          if destinations.blank?
+            raise ArgumentError.new('At least one recipient (To, Cc or Bcc) is required to send a message')
+          end
+
+          message ||= mail.encoded if mail.respond_to?(:encoded)
+          if message.blank?
+            raise ArgumentError.new('A encoded content is required to send a message')
+          end
+
+          [envelope_from, destinations, message]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/mail/network/delivery_methods/exim.rb
+++ b/lib/mail/network/delivery_methods/exim.rb
@@ -1,3 +1,5 @@
+require 'mail/check_delivery_params'
+
 module Mail
 
   # A delivery method implementation which sends via exim.
@@ -36,6 +38,7 @@ module Mail
   #
   #   mail.deliver!
   class Exim < Sendmail
+    include Mail::CheckDeliveryParams
 
     def initialize(values)
       self.settings = { :location       => '/usr/sbin/exim',
@@ -43,6 +46,8 @@ module Mail
     end
 
     def self.call(path, arguments, mail)
+      check_params(mail)
+
       IO.popen("#{path} #{arguments}", "w+") do |io|
         io.puts mail.encoded.to_lf
         io.flush

--- a/lib/mail/network/delivery_methods/file_delivery.rb
+++ b/lib/mail/network/delivery_methods/file_delivery.rb
@@ -1,3 +1,5 @@
+require 'mail/check_delivery_params'
+
 module Mail
   
   # FileDelivery class delivers emails into multiple files based on the destination
@@ -11,6 +13,7 @@ module Mail
   # Make sure the path you specify with :location is writable by the Ruby process
   # running Mail.
   class FileDelivery
+    include Mail::CheckDeliveryParams
 
     if RUBY_VERSION >= '1.9.1'
       require 'fileutils'
@@ -25,6 +28,8 @@ module Mail
     attr_accessor :settings
     
     def deliver!(mail)
+      check_params(mail)
+
       if ::File.respond_to?(:makedirs)
         ::File.makedirs settings[:location]
       else

--- a/lib/mail/network/delivery_methods/sendmail.rb
+++ b/lib/mail/network/delivery_methods/sendmail.rb
@@ -1,3 +1,5 @@
+require 'mail/check_delivery_params'
+
 module Mail
   # A delivery method implementation which sends via sendmail.
   #
@@ -35,6 +37,7 @@ module Mail
   #
   #   mail.deliver!
   class Sendmail
+    include Mail::CheckDeliveryParams
 
     def initialize(values)
       self.settings = { :location       => '/usr/sbin/sendmail',
@@ -44,6 +47,8 @@ module Mail
     attr_accessor :settings
 
     def deliver!(mail)
+      check_params(mail)
+
       envelope_from = mail.return_path || mail.sender || mail.from_addrs.first
       return_path = "-f " + '"' + envelope_from.escape_for_shell + '"' if envelope_from
 

--- a/lib/mail/network/delivery_methods/test_mailer.rb
+++ b/lib/mail/network/delivery_methods/test_mailer.rb
@@ -1,3 +1,5 @@
+require 'mail/check_delivery_params'
+
 module Mail
   # The TestMailer is a bare bones mailer that does nothing.  It is useful
   # when you are testing.
@@ -5,6 +7,7 @@ module Mail
   # It also provides a template of the minimum methods you require to implement
   # if you want to make a custom mailer for Mail
   class TestMailer
+    include Mail::CheckDeliveryParams
 
     # Provides a store of all the emails sent with the TestMailer so you can check them.
     def TestMailer.deliveries
@@ -33,6 +36,7 @@ module Mail
     attr_accessor :settings
 
     def deliver!(mail)
+      check_params(mail)
       Mail::TestMailer.deliveries << mail
     end
     

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1466,7 +1466,7 @@ describe Mail::Message do
     end
 
     it "should inform observers that the mail was sent" do
-      mail = Mail.new
+      mail = Mail.new(:from => 'bob@example.com', :to => 'bobette@example.com')
       mail.delivery_method :test
       Mail.register_observer(ObserverAgent)
       ObserverAgent.should_receive(:delivered_email).with(mail)
@@ -1494,7 +1494,7 @@ describe Mail::Message do
     end
 
     it "should pass to the interceptor the email just before it gets sent" do
-      mail = Mail.new
+      mail = Mail.new(:from => 'bob@example.com', :to => 'bobette@example.com')
       mail.delivery_method :test
       Mail.register_interceptor(InterceptorAgent)
       InterceptorAgent.should_receive(:delivering_email).with(mail)
@@ -1504,7 +1504,7 @@ describe Mail::Message do
     end
 
     it "should let the interceptor that the mail was sent" do
-      mail = Mail.new
+      mail = Mail.new(:from => 'bob@example.com', :to => 'bobette@example.com')
       mail.to = 'fred@example.com'
       mail.delivery_method :test
       Mail.register_interceptor(InterceptorAgent)

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -158,4 +158,30 @@ describe "exim delivery agent" do
                                               mail)
     mail.deliver!
   end
+
+  it "should raise an error if no sender is defined" do
+    Mail.defaults do
+      delivery_method :test
+    end
+    lambda do
+      Mail.deliver do
+        to "to@somemail.com"
+        subject "Email with no sender"
+        body "body"
+      end
+    end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+  end
+
+  it "should raise an error if no recipient if defined" do
+    Mail.defaults do
+      delivery_method :test
+    end
+    lambda do
+      Mail.deliver do
+        from "from@somemail.com"
+        subject "Email with no recipient"
+        body "body"
+      end
+    end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+  end
 end

--- a/spec/mail/network/delivery_methods/file_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/file_delivery_spec.rb
@@ -89,6 +89,34 @@ describe "SMTP Delivery Method" do
       File.exists?(delivery).should be_true
     end
 
+    it "should raise an error if no sender is defined" do
+      Mail.defaults do
+        delivery_method :file, :location => tmpdir
+      end
+
+      lambda do
+        Mail.deliver do
+          to "to@somemail.com"
+          subject "Email with no sender"
+          body "body"
+        end
+       end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+    end
+
+    it "should raise an error if no recipient if defined" do
+      Mail.defaults do
+        delivery_method :file, :location => tmpdir
+      end
+
+      lambda do
+        Mail.deliver do
+          from "from@somemail.com"
+          subject "Email with no recipient"
+          body "body"
+        end
+       end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+    end
+
   end
   
 end

--- a/spec/mail/network/delivery_methods/sendmail_spec.rb
+++ b/spec/mail/network/delivery_methods/sendmail_spec.rb
@@ -158,4 +158,30 @@ describe "sendmail delivery agent" do
                                               mail)
     mail.deliver!
   end
+
+  it "should raise an error if no sender is defined" do
+    Mail.defaults do
+      delivery_method :test
+    end
+    lambda do
+      Mail.deliver do
+        to "to@somemail.com"
+        subject "Email with no sender"
+        body "body"
+      end
+    end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+  end
+
+  it "should raise an error if no recipient if defined" do
+    Mail.defaults do
+      delivery_method :test
+    end
+    lambda do
+      Mail.deliver do
+        from "from@somemail.com"
+        subject "Email with no recipient"
+        body "body"
+      end
+    end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+  end
 end

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -9,7 +9,7 @@ describe "SMTP Delivery Method" do
       delivery_method :smtp_connection, :connection => smtp
     end
   end
-  
+
   after(:each) do
     Mail.delivery_method.smtp.finish
   end
@@ -25,23 +25,52 @@ describe "SMTP Delivery Method" do
     MockSMTP.deliveries[0][1].should eq mail.from[0]
     MockSMTP.deliveries[0][2].should eq mail.destinations    
   end
-  
+
   it "should be able to return actual SMTP protocol response" do
     Mail.defaults do
       smtp = Net::SMTP.start('127.0.0.1', 25)
       delivery_method :smtp_connection, :connection => smtp, :port => 587, :return_response => true
     end
-    
+
     mail = Mail.deliver do
       from    'roger@moore.com'
       to      'marcel@amont.com'
       subject 'invalid RFC2822'
     end
-    
+
     response = mail.deliver!
     response.should eq 'OK'
-    
+
   end
-  
-  
+
+
+  it "should raise an error if no sender is defined" do
+    Mail.defaults do
+      smtp = Net::SMTP.start('127.0.0.1', 25)
+      delivery_method :smtp_connection, :connection => smtp, :port => 587, :return_response => true
+    end
+
+    lambda do
+      Mail.deliver do
+        to "to@somemail.com"
+        subject "Email with no sender"
+        body "body"
+      end
+    end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+  end
+
+  it "should raise an error if no recipient if defined" do
+    Mail.defaults do
+      smtp = Net::SMTP.start('127.0.0.1', 25)
+      delivery_method :smtp_connection, :connection => smtp, :port => 587, :return_response => true
+    end
+
+    lambda do
+      Mail.deliver do
+        from "from@somemail.com"
+        subject "Email with no recipient"
+        body "body"
+      end
+    end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+  end
 end

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -187,7 +187,26 @@ describe "SMTP Delivery Method" do
       end
       MockSMTP.deliveries[0][1].should eq "from@someemail.com"
     end
-    
+
+    it "should raise an error if no sender is defined" do
+      lambda do
+        Mail.deliver do
+          to "to@somemail.com"
+          subject "Email with no sender"
+          body "body"
+        end
+       end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+    end
+
+    it "should raise an error if no recipient if defined" do
+      lambda do
+        Mail.deliver do
+          from "from@somemail.com"
+          subject "Email with no recipient"
+          body "body"
+        end
+       end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+    end
   end
   
 end

--- a/spec/mail/network/delivery_methods/test_mailer_spec.rb
+++ b/spec/mail/network/delivery_methods/test_mailer_spec.rb
@@ -54,4 +54,30 @@ describe "Mail::TestMailer" do
     Mail::TestMailer.deliveries.should be_empty
   end
 
+  it "should raise an error if no sender is defined" do
+    Mail.defaults do
+      delivery_method :test
+    end
+    lambda do
+      Mail.deliver do
+        to "to@somemail.com"
+        subject "Email with no sender"
+        body "body"
+      end
+    end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+  end
+
+  it "should raise an error if no recipient if defined" do
+    Mail.defaults do
+      delivery_method :test
+    end
+    lambda do
+      Mail.deliver do
+        from "from@somemail.com"
+        subject "Email with no recipient"
+        body "body"
+      end
+    end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+  end
+
 end


### PR DESCRIPTION
Currently, when sending an email via SMTP without a sender or recipient, an exception is raised.
This occurs only in SMTP though, when it should happen for every delivery method.

For example, if I don't specify a sender or recipient with the test delivery method, no error will be raised.
But when going to staging/production, there will be.
