### PR TITLE
Fix stack overflow (RegexpError) triggered by large emails with an envelope

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1917,7 +1917,7 @@ module Mail
       raw_string = raw_source.to_s
       if match_data = raw_source.to_s.match(/\AFrom\s(#{TEXT}+)#{CRLF}/m)
         set_envelope(match_data[1])
-        self.raw_source = raw_string.sub(match_data[1], "") 
+        self.raw_source = raw_string.sub(match_data[0], "") 
       end
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -225,6 +225,7 @@ describe Mail::Message do
       m.from.should eq ["News@InsideApple.Apple.com"]
       m.should be_multipart
     end
+
   end
 
   describe "accepting a plain text string email" do


### PR DESCRIPTION
We are seeing exceptions of this form when trying to parse large emails (>8MB) that include an envelope header:

```
/home/bpot/.rvm/gems/ree-1.8.7-2012.02/gems/mail-2.4.4/lib/mail/message.rb:1917:in `match': Stack overflow in regexp matcher: /\AFrom\s((?-mix:[\001-\010\016-\177])+)(?-mix:\r\n)(.*)/m (RegexpError)
    from /home/bpot/.rvm/gems/ree-1.8.7-2012.02/gems/mail-2.4.4/lib/mail/message.rb:1917:in `set_envelope_header'
    from /home/bpot/.rvm/gems/ree-1.8.7-2012.02/gems/mail-2.4.4/lib/mail/message.rb:2007:in `init_with_string'
    from /home/bpot/.rvm/gems/ree-1.8.7-2012.02/gems/mail-2.4.4/lib/mail/message.rb:125:in `initialize'
```

You can reproduce it with this script: https://gist.github.com/fabeff81c3a6780d1e23
