### PR TITLE
Do not require Net::IMAP or Net::POP if they're already loaded

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -36,7 +36,7 @@ module Mail
   #   #=> Returns the first 10 emails in ascending order
   #
   class IMAP < Retriever
-    require 'net/imap'
+    require 'net/imap' unless defined?(Net::IMAP)
     
     def initialize(values)
       self.settings = { :address              => "localhost",

--- a/lib/mail/network/retriever_methods/pop3.rb
+++ b/lib/mail/network/retriever_methods/pop3.rb
@@ -32,7 +32,7 @@ module Mail
   #   #=> Returns the first 10 emails in ascending order
   # 
   class POP3 < Retriever
-    require 'net/pop'
+    require 'net/pop' unless defined?(Net::POP)
 
     def initialize(values)
       self.settings = { :address              => "localhost",


### PR DESCRIPTION
We use a non-standard library version of Net::IMAP.  We have issues when the mail gem tries to load 'net/imap'.
