### PR TITLE
Use String#to_crlf instead of String#gsub

### DIFF
--- a/lib/mail/encodings/quoted_printable.rb
+++ b/lib/mail/encodings/quoted_printable.rb
@@ -18,7 +18,7 @@ module Mail
       end
 
       def self.encode(str)
-        [str].pack("M").gsub(/\n/, "\r\n")
+        [str].pack("M").to_crlf
       end
 
       def self.cost(str)


### PR DESCRIPTION
I wrote a patch use String#to_crlf instead of String#gsub to replace EOLs.
