### PR TITLE
Remove Gemfile.lock from gemspec

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency('tlsmail', '~> 0.0.1') if RUBY_VERSION == '1.8.6'
 
   s.require_path = 'lib'
-  s.files = %w(README.md CONTRIBUTING.md CHANGELOG.rdoc Dependencies.txt Gemfile Gemfile.lock Rakefile TODO.rdoc) + Dir.glob("lib/**/*")
+  s.files = %w(README.md CONTRIBUTING.md CHANGELOG.rdoc Dependencies.txt Gemfile Rakefile TODO.rdoc) + Dir.glob("lib/**/*")
 end


### PR DESCRIPTION
Removing Gemfile.lock from files list in gemspec since it's no longer in the repository.

This produces errors in bundler :

mail at /home/users/kartapracy/kartapracy24.pl/shared/bundle/ruby/1.9.1/bundler/gems/mail-f19ffd459955 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
["Gemfile.lock"] are not files
