### PR TITLE
Fix an obvious bug in exim delivery_method

### DIFF
--- a/lib/mail/network/delivery_methods/exim.rb
+++ b/lib/mail/network/delivery_methods/exim.rb
@@ -42,7 +42,7 @@ module Mail
                         :arguments      => '-i -t' }.merge(values)
     end
 
-    def self.call(path, arguments, mail)
+    def self.call(path, arguments, destinations, mail)
       IO.popen("#{path} #{arguments}", "w+") do |io|
         io.puts mail.encoded.to_lf
         io.flush


### PR DESCRIPTION
I guess no one is using exim since this bug was introduced 6th March by the security fix and hasn't yet been rectified.
So here is my super simple fix.

I think that you may want to consider updating the exim_spec as the stubbing of the call method was hiding this bug.

Cheers,
