### PR TITLE
Convert to string before calling encoding on it. 

### DIFF
--- a/lib/mail/fields/unstructured_field.rb
+++ b/lib/mail/fields/unstructured_field.rb
@@ -61,8 +61,8 @@ module Mail
     end
     
     def do_decode
-      result = value.blank? ? nil : Encodings.decode_encode(value, :decode)
-      result.encode!(value.encoding || "UTF-8") if RUBY_VERSION >= '1.9' && !result.blank?
+      result = value.blank? ? nil : Encodings.decode_encode(value, :decode).to_s
+      result.encode!(value.to_s.encoding || "UTF-8") if RUBY_VERSION >= '1.9' && !result.blank?
       result
     end
     

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -55,6 +55,16 @@ describe Mail::UnstructuredField do
       @field.encoded.should eq ''
     end
     
+    it "should handle array" do
+      @field.value = ['test']
+      @field.encoded.should eq "Subject: [\"test\"]\r\n"
+    end
+
+    it "should handle string" do
+      @field.value = 'test'
+      @field.encoded.should eq "Subject: test\r\n"
+    end    
+    
     it "should give an decoded value ready to insert into an email" do
       @field.decoded.should eq "Hello Frank"
     end


### PR DESCRIPTION
Addresses issue #299 where value would be converted to an array and calling enconding on Array causes it to blow up as such: 

```
vendor/bundle/ruby/1.9.1/gems/mail-2.3.3/lib/mail/fields/unstructured_field.rb:75:in `do_decode'
vendor/bundle/ruby/1.9.1/gems/mail-2.3.3/lib/mail/fields/unstructured_field.rb:56:in `decoded'
vendor/bundle/ruby/1.9.1/gems/mail-2.3.3/lib/mail/fields/unstructured_field.rb:60:in `default'
vendor/bundle/ruby/1.9.1/gems/mail-2.3.3/lib/mail/field.rb:123:in `method_missing'
vendor/bundle/ruby/1.9.1/gems/mail-2.3.3/lib/mail/message.rb:1107:in `default'
vendor/bundle/ruby/1.9.1/gems/mail-2.3.3/lib/mail/message.rb:517:in `cc'
vendor/bundle/ruby/1.9.1/gems/actionmailer-3.1.8/lib/action_mailer/base.rb:449:in `set_payload_for_mail'
vendor/bundle/ruby/1.9.1/gems/actionmailer-3.1.8/lib/action_mailer/base.rb:431:in `block in deliver_mail'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.8/lib/active_support/notifications.rb:53:in `block in instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.8/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.8/lib/active_support/notifications.rb:53:in `instrument'
vendor/bundle/ruby/1.9.1/gems/actionmailer-3.1.8/lib/action_mailer/base.rb:430:in `deliver_mail'
vendor/bundle/ruby/1.9.1/gems/mail-2.3.3/lib/mail/message.rb:230:in `deliver'
app/jobs/colleague_invitation_job.rb:46:in `notify_via_email'
app/jobs/colleague_invitation_job.rb:23:in `perform'
```

There may be a better solution to this problem which I am not aware of at the time of this writing. This patch does not break currently functionality when `value` is a string and if it is an array it simply calls `to_s` on it.
