### PR TITLE
CC fields with semicolon are now parsed right [fixes #228]

### DIFF
--- a/lib/mail/parsers/rfc2822.rb
+++ b/lib/mail/parsers/rfc2822.rb
@@ -1337,22 +1337,18 @@ module Mail
       s0, i0 = [], index
       loop do
         i1, s1 = index, []
-        s2, i2 = [], index
-        loop do
-          if has_terminal?(".", false, index)
-            r3 = instantiate_node(SyntaxNode,input, index...(index + 1))
-            @index += 1
-          else
-            terminal_parse_failure(".")
-            r3 = nil
-          end
-          if r3
-            s2 << r3
-          else
-            break
-          end
+        if has_terminal?(".", false, index)
+          r3 = instantiate_node(SyntaxNode,input, index...(index + 1))
+          @index += 1
+        else
+          terminal_parse_failure(".")
+          r3 = nil
         end
-        r2 = instantiate_node(SyntaxNode,input, i2...index, s2)
+        if r3
+          r2 = r3
+        else
+          r2 = instantiate_node(SyntaxNode,input, index...index)
+        end
         s1 << r2
         if r2
           r4 = _nt_domain_text
@@ -2714,11 +2710,11 @@ module Mail
         s3, i3 = [], index
         loop do
           i4, s4 = index, []
-          if has_terminal?(",", false, index)
+          if has_terminal?(";", false, index)
             r5 = instantiate_node(SyntaxNode,input, index...(index + 1))
             @index += 1
           else
-            terminal_parse_failure(",")
+            terminal_parse_failure(";")
             r5 = nil
           end
           s4 << r5
@@ -2915,11 +2911,11 @@ module Mail
           r5 = instantiate_node(SyntaxNode,input, i5...index, s5)
           s4 << r5
           if r5
-            if has_terminal?(",", false, index)
+            if has_terminal?(";", false, index)
               r7 = instantiate_node(SyntaxNode,input, index...(index + 1))
               @index += 1
             else
-              terminal_parse_failure(",")
+              terminal_parse_failure(";")
               r7 = nil
             end
             s4 << r7

--- a/lib/mail/parsers/rfc2822.treetop
+++ b/lib/mail/parsers/rfc2822.treetop
@@ -218,7 +218,7 @@ module Mail
     end
     
     rule mailbox_list
-      (first_addr:mailbox other_addr:("," addr_value:mailbox)*) / obs_mbox_list
+      (first_addr:mailbox other_addr:(("," / ";") addr_value:mailbox)*) / obs_mbox_list
     end
   
     rule mailbox
@@ -265,7 +265,7 @@ module Mail
     end
   
     rule address_list
-      first_addr:address? other_addr:(FWS* "," FWS* addr_value:address?)*
+      first_addr:address? other_addr:(FWS* ("," / ";") FWS* addr_value:address?)*
     end
     
     rule date_time

--- a/spec/mail/parsers/address_lists_parser_spec.rb
+++ b/spec/mail/parsers/address_lists_parser_spec.rb
@@ -12,4 +12,9 @@ describe "AddressListsParser" do
     a = Mail::AddressListsParser.new
     a.parse(text).should_not be_nil
   end
+  it "should parse an address list separated by semicolons" do
+    text = 'Mikel Lindsaar <test@lindsaar.net>; Friends: test2@lindsaar.net; Ada <test3@lindsaar.net>;'
+    a = Mail::AddressListsParser.new
+    a.parse(text).should_not be_nil
+  end
 end


### PR DESCRIPTION
cf. https://github.com/mikel/mail/issues/228
