### PR TITLE
clarify spec phrasing (typo fix)

### DIFF
--- a/spec/mail/elements/address_list_spec.rb
+++ b/spec/mail/elements/address_list_spec.rb
@@ -83,7 +83,7 @@ describe Mail::AddressList do
       list.address_nodes.length.should eq 2
     end
 
-    it "should have each nood a class of SyntaxNode" do
+    it "should make each node a class of SyntaxNode" do
       list = Mail::AddressList.new('mikel@me.com, bob@you.com')
       list.address_nodes.each { |n| n.class.should eq Treetop::Runtime::SyntaxNode }
     end


### PR DESCRIPTION
"nood" to "node", and clarifies spec's intent

1.8.7p370: 1351 examples, 0 failures, 13 pending
1.9.2-p320: 1351 examples, 0 failures, 8 pending
1.9.3-head: 1351 examples, 0 failures, 8 pending
