### PR TITLE
Ignore undefined characters when decoding b_values

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -55,8 +55,8 @@ module Mail
         str = Ruby19.decode_base64(match[2])
         str.force_encoding(fix_encoding(encoding))
       end
-      decoded = str.encode("utf-8", :invalid => :replace, :replace => "")
-      decoded.valid_encoding? ? decoded : decoded.encode("utf-16le", :invalid => :replace, :replace => "").encode("utf-8")
+      decoded = str.encode("utf-8", :invalid => :replace, :undef => :replace, :replace => "")
+      decoded.valid_encoding? ? decoded : decoded.encode("utf-16le", :invalid => :replace, :undef => :replace, :replace => "").encode("utf-8")
     end
 
     def Ruby19.q_value_encode(str, encoding = nil)


### PR DESCRIPTION
Ran into this issue when parsing email where the `From` field included undefined sequences.
