### PR TITLE
Fix failing encoding spec

### DIFF
--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -610,7 +610,7 @@ describe Mail::Encodings do
       end
 
       it "should unquote multiple strings in the middle of the text" do
-        a = "=?Shift_JIS?Q?=93=FA=96{=8C=EA=?= <a@example.com>, =?Shift_JIS?Q?=93=FA=96{=8C=EA=?= <b@example.com>"
+        a = "=?Shift_JIS?Q?=93=FA=96{=8C=EA?= <a@example.com>, =?Shift_JIS?Q?=93=FA=96{=8C=EA?= <b@example.com>"
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
         b.should eq "日本語 <a@example.com>, 日本語 <b@example.com>"
       end


### PR DESCRIPTION
Sorry for previous pull. My bad. I think it's just typo in spec. Am I right?

rspec output:

```
 expected: "日本語 <a@example.com>, 日本語 <b@example.com>"
            got: "日本語= <a@example.com>, 日本語= <b@example.com>"

```

Thanks,
Max
