### PR TITLE
Allow String as delivery method

### DIFF
--- a/lib/mail/configuration.rb
+++ b/lib/mail/configuration.rb
@@ -26,7 +26,7 @@ module Mail
     end
 
     def lookup_delivery_method(method)
-      case method
+      case method.is_a?(String) ? method.to_sym : method
       when nil
         Mail::SMTP
       when :smtp


### PR DESCRIPTION
I have an issue refers to this limitation when my configuration yaml is generating by chef (JSON => Hash => YAML). JSON is not allowing to use symbols. 
