### PR TITLE
Formerly, when converting a b_encoded string...

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -55,7 +55,7 @@ module Mail
         str = Ruby19.decode_base64(match[2])
         str.force_encoding(fix_encoding(encoding))
       end
-      decoded = str.encode("utf-8", :invalid => :replace, :replace => "")
+      decoded = str.encode("utf-8", :invalid => :replace, :undef => :replace, :replace => "")
       decoded.valid_encoding? ? decoded : decoded.encode("utf-16le", :invalid => :replace, :replace => "").encode("utf-8")
     end
 

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -757,6 +757,12 @@ describe Mail::Encodings do
       Mail::Encodings.address_encode(raw, 'utf-8').should eq encoded
     end
 
+    it "should not throw an error when converting a b encoded character in one encoding to another encoding that does not support that character" do
+      invalid_string_in_utf_8 = "\xFE\xD3".force_encoding('GB2312')
+      b_value_encoded = Mail::Encodings.b_value_encode(invalid_string_in_utf_8)
+      Mail::Encodings.value_decode(b_value_encoded).should eq ''
+    end
+
   end
   
 end


### PR DESCRIPTION
...from encoding like 'GB2312', 'BIG5', or 'ISO-8859-6' to 'UTF-8' an error would be thrown if a character did not exist in the 'UTF-8' encoding.  Now the character
will be replaced with an empty character instead of throwing the error.

Note that previously if a b_encoded character did not exist in the input encoding, it would be replaced
with an empty character in the output.  This change adds the same functionality if the character
does not exist in the output encoding.
