### PR TITLE
Allow string as delivery_method

### DIFF
--- a/lib/mail/configuration.rb
+++ b/lib/mail/configuration.rb
@@ -26,7 +26,7 @@ module Mail
     end
 
     def lookup_delivery_method(method)
-      case method
+      case method.is_a?(String) ? method.to_sym : method
       when nil
         Mail::SMTP
       when :smtp

--- a/spec/mail/configuration_spec.rb
+++ b/spec/mail/configuration_spec.rb
@@ -12,6 +12,11 @@ describe Mail::Configuration do
 
   describe "network configurations" do
 
+    it "defaults delivery_method to smtp" do
+      Mail.defaults { delivery_method nil, { :address => 'some.host' } }
+      Mail.delivery_method.settings[:address].should eq 'some.host'
+    end
+
     it "should be available from the Mail.defaults method" do
       Mail.defaults { delivery_method :smtp, { :address => 'some.host' } }
       Mail.delivery_method.settings[:address].should eq 'some.host'
@@ -19,6 +24,12 @@ describe Mail::Configuration do
 
     it "should configure sendmail" do
       Mail.defaults { delivery_method :sendmail, :location => "/usr/bin/sendmail" }
+      Mail.delivery_method.class.should eq Mail::Sendmail
+      Mail.delivery_method.settings[:location].should eq "/usr/bin/sendmail"
+    end
+
+    it "should configure sendmail using a string" do
+      Mail.defaults { delivery_method 'sendmail', :location => "/usr/bin/sendmail" }
       Mail.delivery_method.class.should eq Mail::Sendmail
       Mail.delivery_method.settings[:location].should eq "/usr/bin/sendmail"
     end


### PR DESCRIPTION
This PR contains the change from #457 as well as two tests: one for teting a nil delivery method, and the other for testing a string delivery method.
