### PR TITLE
Prefer content-disposition filename over the content-type filename or name.

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2016,10 +2016,10 @@ module Mail
       content_disp_name = header[:content_disposition].filename rescue nil
       content_loc_name  = header[:content_location].location rescue nil
       case
-      when content_type && content_type_name
-        filename = content_type_name
       when content_disposition && content_disp_name
         filename = content_disp_name
+      when content_type && content_type_name
+        filename = content_type_name
       when content_location && content_loc_name
         filename = content_loc_name
       else

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -218,9 +218,9 @@ describe "reading emails with attachments" do
       mail.attachments.length.should eq 1
     end
 
-    it "should use the content-type filename or name over the content-disposition filename" do
+    it "should use the content-disposition filename over the content-type filename or name" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_content_disposition.eml')))
-      mail.attachments[0].filename.should eq 'hello.rb'
+      mail.attachments[0].filename.should eq 'api.rb'
     end
 
     it "should decode an attachment" do

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -289,13 +289,13 @@ describe "MIME Emails" do
       it "should return an array of attachments" do
         mail = Mail.read(fixture('emails', 'attachment_emails', 'attachment_content_disposition.eml'))
         mail.attachments.length.should eq 1
-        mail.attachments.first.filename.should eq 'hello.rb'
+        mail.attachments.first.filename.should eq 'api.rb'
       end
 
       it "should return an array of attachments" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email_with_nested_attachment.eml'))
         mail.attachments.length.should eq 2
-        mail.attachments[0].filename.should eq 'byo-ror-cover.png'
+        mail.attachments[0].filename.should eq 'truncated.png'
         mail.attachments[1].filename.should eq 'smime.p7s'
       end
 


### PR DESCRIPTION
Currently mail prefers content-type filename or name over content-disposition filename. I think that's undesirable. I've got a few real-world cases where it's preferable to instead primarily prefer the content-disposition filename.

Please read the following discussions:
- http://en.wikipedia.org/wiki/MIME#Content-Disposition
- http://www.imc.org/ietf-smtp/mail-archive/msg05023.html

I.e. the Content-Disposition is there to _improve_ the flawed situation that exists with the Content-Type, and should therefor be preferred as the source from which to extract the filename.

From RFC2183 Content-Disposition Header Field:

```
2.3  The Filename Parameter

   The sender may want to suggest a filename to be used if the entity is
   detached and stored in a separate file. If the receiving MUA writes
   the entity to a file, the suggested filename should be used as a
   basis for the actual filename, where possible.
```
