### PR TITLE
Send diagnostic messages to STDERR not STDOUT

### DIFF
--- a/lib/load_parsers.rb
+++ b/lib/load_parsers.rb
@@ -8,7 +8,7 @@ module Mail # :doc:
 
   def self.compile_parser(parser)
     require 'treetop/compiler'
-    STDOUT.puts "Compiling parser #{parser} from treetop source"
+    STDERR.puts "Compiling parser #{parser} from treetop source"
     Treetop.load(File.join(File.dirname(__FILE__)) + "/mail/parsers/#{parser}")
   end
 
@@ -18,20 +18,20 @@ module Mail # :doc:
                 content_transfer_encoding content_location ]
 
   if defined?(MAIL_SPEC_SUITE_RUNNING)
-    STDOUT.puts "Compiling all parsers from treetop source"
+    STDERR.puts "Compiling all parsers from treetop source"
 
     parsers.each do |parser|
       compile_parser(parser)
     end
 
   else
-    STDOUT.puts "Loading precompiled parsers from ruby source"
+    STDERR.puts "Loading precompiled parsers from ruby source"
 
     parsers.each do |parser|
       begin
         require "mail/parsers/#{parser}"
       rescue LoadError
-        STDOUT.puts "Couldn't load parser #{parser} from ruby source"
+        STDERR.puts "Couldn't load parser #{parser} from ruby source"
         compile_parser(parser)
       end
     end


### PR DESCRIPTION
Sending diagnostic messages to stdout at load time is kind of anti-social...
