### PR TITLE
Requiring module emits "Loading precompiled parsers from ruby source"

### DIFF
--- a/lib/load_parsers.rb
+++ b/lib/load_parsers.rb
@@ -8,7 +8,6 @@ module Mail # :doc:
 
   def self.compile_parser(parser)
     require 'treetop/compiler'
-    STDOUT.puts "Compiling parser #{parser} from treetop source"
     Treetop.load(File.join(File.dirname(__FILE__)) + "/mail/parsers/#{parser}")
   end
 
@@ -18,20 +17,15 @@ module Mail # :doc:
                 content_transfer_encoding content_location ]
 
   if defined?(MAIL_SPEC_SUITE_RUNNING)
-    STDOUT.puts "Compiling all parsers from treetop source"
-
     parsers.each do |parser|
       compile_parser(parser)
     end
 
   else
-    STDOUT.puts "Loading precompiled parsers from ruby source"
-
     parsers.each do |parser|
       begin
         require "mail/parsers/#{parser}"
       rescue LoadError
-        STDOUT.puts "Couldn't load parser #{parser} from ruby source"
         compile_parser(parser)
       end
     end


### PR DESCRIPTION
As it's not really good form for a module to start spraying random diagnostic things to `STDOUT`, these `puts` calls should probably be removed or at least walled off unless some kind of debugging variable is engaged.

These seem to have ended up in the packaged release of the gem.
