### PR TITLE
Fix for UnstructuredField which responds to Content-Field

### DIFF
--- a/lib/mail/parts_list.rb
+++ b/lib/mail/parts_list.rb
@@ -44,7 +44,7 @@ module Mail
   private
 
     def get_order_value(part, order)
-      if part.respond_to?(:content_type)
+      if part.respond_to?(:content_type) && part[:content_type].field.is_a?(Mail::ContentTypeField)
         order.index(part[:content_type].string.downcase) || 10000
       else
         10000

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -17,4 +17,13 @@ describe "PartsList" do
     p << 'text/html'
     p.sort!(order)
   end
+
+  it "should not raise an error when the part is content_type and Mail::UnstructuredField" do
+    part = Mail::Part.new do
+      content_type 'unknown/unknown; name="image.gif"'
+    end
+
+    Mail::PartsList.new.send(:get_order_value, part, [])
+  end
+
 end


### PR DESCRIPTION
Recently received an e-mail which had the following content-type for an attachment:

```
Content-Type: unknown/unknown;
    charset=iso-8859-1;
    name=IMSTP19.gif
```

After receiving the e-mail I perform a to string on the Mail object to generate a unique hash. Something like the following:

``` ruby
Mail::POP3.new(settings).find_and_delete(count: 25) do |msg| 
  receive(msg)
  process_email_key(Digest::SHA1.hexdigest(msg.to_s))
end
```

When I received the e-mail with the content-type I noticed above I got the following error

```
undefined method `string' for unknown/unknown; name="image.gif":Mail::UnstructuredField
```

The private method `get_order_value()` in `lib/mail/parts_list.rb` assumes that the Field is a `Mail::ContentTypeField` when the part responds_to content-type. But with the content-type used in this e-mail the field is a `Mail::UnstructuredField`.

The `part[:content_type].string` raises an error because there's no string method for an UnstructuredField.
