### PR TITLE
Fix build on Ruby18. We should specify endian for UTF16/32.

### DIFF
--- a/lib/mail/version_specific/ruby_1_8.rb
+++ b/lib/mail/version_specific/ruby_1_8.rb
@@ -107,6 +107,10 @@ module Mail
       case encoding.upcase
       when 'UTF8'
         'UTF-8'
+      when 'UTF16', 'UTF-16'
+        'UTF-16BE'
+      when 'UTF32', 'UTF-32'
+        'UTF-32BE'
       else
         encoding
       end


### PR DESCRIPTION
I found build error the following url.

https://travis-ci.org/mikel/mail/jobs/3381626

I think we should specify endian for UTF16/32.
