### PR TITLE
define Object#blank? only if not defined yet

### DIFF
--- a/lib/mail/core_extensions/object.rb
+++ b/lib/mail/core_extensions/object.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
 
-# This is not loaded if ActiveSupport is already loaded
-
-class Object
-  def blank?
-    if respond_to?(:empty?)
-      empty?
-    else
-     !self
+unless Object.method_defined? :blank?
+  class Object
+    def blank?
+      if respond_to?(:empty?)
+        empty?
+      else
+       !self
+      end
     end
   end
 end


### PR DESCRIPTION
Similar to #353

I found comment here is telling a lie https://github.com/mikel/mail/blob/9c16d9d/lib/mail/core_extensions/object.rb#L3

```
% ruby -we "require 'active_support/all'; require 'mail'"
.../gems/mail-2.5.3/lib/mail/core_extensions/object.rb:6: warning: method redefined; discarding old blank?
.../gems/activesupport-3.2.9/lib/active_support/core_ext/object/blank.rb:15: warning: previous definition of blank? was here
```

Either way, I think it's better to let Ruby check the existence of the target method before monkey-patching.
