### PR TITLE
Expose & override the SMTP envelope

### DIFF
--- a/lib/mail/check_delivery_params.rb
+++ b/lib/mail/check_delivery_params.rb
@@ -1,22 +1,20 @@
 module Mail
   module CheckDeliveryParams
     def check_delivery_params(mail)
-      envelope_from = mail.return_path || mail.sender || mail.from_addrs.first
-      if envelope_from.blank?
-        raise ArgumentError.new('A sender (Return-Path, Sender or From) required to send a message')
+      if mail.smtp_envelope_from.blank?
+        raise ArgumentError.new('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
       end
 
-      destinations ||= mail.destinations if mail.respond_to?(:destinations) && mail.destinations
-      if destinations.blank?
-        raise ArgumentError.new('At least one recipient (To, Cc or Bcc) is required to send a message')
+      if mail.smtp_envelope_to.blank?
+        raise ArgumentError.new('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
       end
 
-      message ||= mail.encoded if mail.respond_to?(:encoded)
+      message = mail.encoded if mail.respond_to?(:encoded)
       if message.blank?
-        raise ArgumentError.new('A encoded content is required to send a message')
+        raise ArgumentError.new('An encoded message is required to send an email')
       end
 
-      [envelope_from, destinations, message]
+      [mail.smtp_envelope_from, mail.smtp_envelope_to, message]
     end
   end
 end

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -108,6 +108,9 @@ module Mail
       @charset = 'UTF-8'
       @defaulted_charset = true
 
+      @smtp_envelope_from = nil
+      @smtp_envelope_to = nil
+
       @perform_deliveries = true
       @raise_delivery_errors = true
 
@@ -1021,6 +1024,82 @@ module Mail
     #  mail.sender #=> 'mikel@test.lindsaar.net'
     def sender=( val )
       header[:sender] = val
+    end
+
+    # Returns the SMTP Envelope From value of the mail object, as a single
+    # string of an address spec.
+    #
+    # Defaults to Return-Path, Sender, or the first From address.
+    #
+    # Example:
+    #
+    #  mail.smtp_envelope_from = 'Mikel <mikel@test.lindsaar.net>'
+    #  mail.smtp_envelope_from #=> 'mikel@test.lindsaar.net'
+    #
+    # Also allows you to set the value by passing a value as a parameter
+    #
+    # Example:
+    #
+    #  mail.smtp_envelope_from 'Mikel <mikel@test.lindsaar.net>'
+    #  mail.smtp_envelope_from #=> 'mikel@test.lindsaar.net'
+    def smtp_envelope_from( val = nil )
+      if val
+        self.smtp_envelope_from = val
+      else
+        @smtp_envelope_from || return_path || sender || from_addrs.first
+      end
+    end
+
+    # Sets the From address on the SMTP Envelope.
+    #
+    # Example:
+    #
+    #  mail.smtp_envelope_from = 'Mikel <mikel@test.lindsaar.net>'
+    #  mail.smtp_envelope_from #=> 'mikel@test.lindsaar.net'
+    def smtp_envelope_from=( val )
+      @smtp_envelope_from = val
+    end
+
+    # Returns the SMTP Envelope To value of the mail object.
+    #
+    # Defaults to #destinations: To, Cc, and Bcc addresses.
+    #
+    # Example:
+    #
+    #  mail.smtp_envelope_to = 'Mikel <mikel@test.lindsaar.net>'
+    #  mail.smtp_envelope_to #=> 'mikel@test.lindsaar.net'
+    #
+    # Also allows you to set the value by passing a value as a parameter
+    #
+    # Example:
+    #
+    #  mail.smtp_envelope_to ['Mikel <mikel@test.lindsaar.net>', 'Lindsaar <lindsaar@test.lindsaar.net>']
+    #  mail.smtp_envelope_to #=> ['mikel@test.lindsaar.net', 'lindsaar@test.lindsaar.net']
+    def smtp_envelope_to( val = nil )
+      if val
+        self.smtp_envelope_to = val
+      else
+        @smtp_envelope_to || destinations
+      end
+    end
+
+    # Sets the To addresses on the SMTP Envelope.
+    #
+    # Example:
+    #
+    #  mail.smtp_envelope_to = 'Mikel <mikel@test.lindsaar.net>'
+    #  mail.smtp_envelope_to #=> 'mikel@test.lindsaar.net'
+    #
+    #  mail.smtp_envelope_to = ['Mikel <mikel@test.lindsaar.net>', 'Lindsaar <lindsaar@test.lindsaar.net>']
+    #  mail.smtp_envelope_to #=> ['mikel@test.lindsaar.net', 'lindsaar@test.lindsaar.net']
+    def smtp_envelope_to=( val )
+      @smtp_envelope_to =
+        case val
+        when Array, NilClass
+          val
+        else
+          [val]
+        end
     end
 
     # Returns the decoded value of the subject field, as a single string.

--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -89,13 +89,13 @@ module Mail
                         :tls                  => nil
                       }.merge!(values)
     end
-    
+
     attr_accessor :settings
-    
+
     # Send the message via SMTP.
     # The from and to attributes are optional. If not set, they are retrieve from the Message.
     def deliver!(mail)
-      envelope_from, destinations, message = check_delivery_params(mail)
+      smtp_from, smtp_to, message = check_delivery_params(mail)
 
       smtp = Net::SMTP.new(settings[:address], settings[:port])
       if settings[:tls] || settings[:ssl]
@@ -107,10 +107,10 @@ module Mail
           smtp.enable_starttls_auto(ssl_context)
         end
       end
-      
+
       response = nil
       smtp.start(settings[:domain], settings[:user_name], settings[:password], settings[:authentication]) do |smtp_obj|
-        response = smtp_obj.sendmail(message, envelope_from, destinations)
+        response = smtp_obj.sendmail(message, smtp_from, smtp_to)
       end
 
       if settings[:return_response]

--- a/lib/mail/network/delivery_methods/smtp_connection.rb
+++ b/lib/mail/network/delivery_methods/smtp_connection.rb
@@ -44,18 +44,18 @@ module Mail
       self.smtp = values[:connection]
       self.settings = values
     end
-    
+
     attr_accessor :smtp
     attr_accessor :settings
-    
+
     # Send the message via SMTP.
     # The from and to attributes are optional. If not set, they are retrieve from the Message.
     def deliver!(mail)
-      envelope_from, destinations, message = check_delivery_params(mail)
-      response = smtp.sendmail(message, envelope_from, destinations)
+      smtp_from, smtp_to, message = check_delivery_params(mail)
+      response = smtp.sendmail(message, smtp_from, smtp_to)
 
-      settings[:return_response] ? response : self 
+      settings[:return_response] ? response : self
     end
-        
+
   end
 end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1731,4 +1731,66 @@ describe Mail::Message do
 
   end
 
+  describe 'SMTP envelope From' do
+    it 'should respond' do
+      Mail::Message.new.should respond_to(:smtp_envelope_from)
+    end
+
+    it 'should default to return_path, sender, or first from address' do
+      message = Mail::Message.new do
+        return_path 'return'
+        sender 'sender'
+        from 'from'
+      end
+      message.smtp_envelope_from.should eq 'return'
+
+      message.return_path = nil
+      message.smtp_envelope_from.should eq 'sender'
+
+      message.sender = nil
+      message.smtp_envelope_from.should eq 'from'
+    end
+
+    it 'can be overridden' do
+      message = Mail::Message.new { return_path 'return' }
+
+      message.smtp_envelope_from = 'envelope_from'
+      message.smtp_envelope_from.should eq 'envelope_from'
+
+      message.smtp_envelope_from = 'declared_from'
+      message.smtp_envelope_from.should eq 'declared_from'
+
+      message.smtp_envelope_from = nil
+      message.smtp_envelope_from.should eq 'return'
+    end
+  end
+
+  describe 'SMTP envelope To' do
+    it 'should respond' do
+      Mail::Message.new.should respond_to(:smtp_envelope_to)
+    end
+
+    it 'should default to destinations' do
+      message = Mail::Message.new do
+        to 'to'
+        cc 'cc'
+        bcc 'bcc'
+      end
+      message.smtp_envelope_to.should eq message.destinations
+    end
+
+    it 'can be overridden' do
+      message = Mail::Message.new { to 'to' }
+
+      message.smtp_envelope_to = 'envelope_to'
+      message.smtp_envelope_to.should eq %w(envelope_to)
+
+      message.smtp_envelope_to = 'declared_to'
+      message.smtp_envelope_to.should eq %w(declared_to)
+
+      message.smtp_envelope_to = nil
+      message.smtp_envelope_to.should eq %w(to)
+    end
+  end
+
 end

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -30,7 +30,7 @@ describe "exim delivery agent" do
     Mail::Exim.should_receive(:call).with('/usr/sbin/exim', 
                                           '-i -t -f "roger@test.lindsaar.net" --', 
                                           '"marcel@test.lindsaar.net" "bob@test.lindsaar.net"', 
-                                          mail)
+                                          mail.encoded)
     mail.deliver!
   end
 
@@ -54,7 +54,7 @@ describe "exim delivery agent" do
       Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "return@test.lindsaar.net" --', 
                                                 '"to@test.lindsaar.net"', 
-                                                mail)
+                                                mail.encoded)
                                                 
       mail.deliver
 
@@ -77,7 +77,7 @@ describe "exim delivery agent" do
       Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "sender@test.lindsaar.net" --', 
                                                 '"to@test.lindsaar.net"', 
-                                                mail)
+                                                mail.encoded)
 
       mail.deliver
     end
@@ -98,7 +98,7 @@ describe "exim delivery agent" do
       Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "from@test.lindsaar.net" --', 
                                                 '"to@test.lindsaar.net"', 
-                                                mail)
+                                                mail.encoded)
       mail.deliver
     end
 
@@ -118,7 +118,7 @@ describe "exim delivery agent" do
       Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "\"from+suffix test\"@test.lindsaar.net" --',
                                                 '"to@test.lindsaar.net"',
-                                                mail)
+                                                mail.encoded)
       mail.deliver
     end
 
@@ -135,7 +135,7 @@ describe "exim delivery agent" do
       Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "from@test.lindsaar.net" --',
                                                 '"-hyphen@test.lindsaar.net"',
-                                                mail)
+                                                mail.encoded)
       mail.deliver
     end
   end
@@ -152,9 +152,9 @@ describe "exim delivery agent" do
     end
     
     Mail::Exim.should_receive(:call).with('/usr/sbin/exim', 
-                                              '-f "from@test.lindsaar.net" --', 
+                                              ' -f "from@test.lindsaar.net" --',
                                               '"marcel@test.lindsaar.net" "bob@test.lindsaar.net"', 
-                                              mail)
+                                              mail.encoded)
     mail.deliver!
   end
 
@@ -170,9 +170,9 @@ describe "exim delivery agent" do
     end
     
     Mail::Exim.should_receive(:call).with('/usr/sbin/exim', 
-                                              "-f \"\\\"foo\\\\\\\"\\;touch /tmp/PWNED\\;\\\\\\\"\\\"@blah.com\" --", 
+                                              " -f \"\\\"foo\\\\\\\"\\;touch /tmp/PWNED\\;\\\\\\\"\\\"@blah.com\" --",
                                               '"marcel@test.lindsaar.net"', 
-                                              mail)
+                                              mail.encoded)
     mail.deliver!
   end
 
@@ -186,7 +186,7 @@ describe "exim delivery agent" do
         subject "Email with no sender"
         body "body"
       end
-    end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+    end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
   end
 
   it "should raise an error if no recipient if defined" do
@@ -199,6 +199,6 @@ describe "exim delivery agent" do
         subject "Email with no recipient"
         body "body"
       end
-    end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+    end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
   end
 end

--- a/spec/mail/network/delivery_methods/file_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/file_delivery_spec.rb
@@ -100,7 +100,7 @@ describe "SMTP Delivery Method" do
           subject "Email with no sender"
           body "body"
         end
-      end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+      end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
     end
 
     it "should raise an error if no recipient if defined" do
@@ -114,7 +114,7 @@ describe "SMTP Delivery Method" do
           subject "Email with no recipient"
           body "body"
         end
-      end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+      end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
     end
 
   end

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -19,11 +19,14 @@ describe "SMTP Delivery Method" do
       from    'roger@test.lindsaar.net'
       to      'marcel@test.lindsaar.net, bob@test.lindsaar.net'
       subject 'invalid RFC2822'
+
+      smtp_envelope_from 'smtp_from'
+      smtp_envelope_to 'smtp_to'
     end
 
     MockSMTP.deliveries[0][0].should eq mail.encoded
-    MockSMTP.deliveries[0][1].should eq mail.from[0]
-    MockSMTP.deliveries[0][2].should eq mail.destinations    
+    MockSMTP.deliveries[0][1].should eq 'smtp_from'
+    MockSMTP.deliveries[0][2].should eq %w(smtp_to)
   end
 
   it "should be able to return actual SMTP protocol response" do
@@ -56,7 +59,7 @@ describe "SMTP Delivery Method" do
         subject "Email with no sender"
         body "body"
       end
-    end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+    end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
   end
 
   it "should raise an error if no recipient if defined" do
@@ -71,6 +74,6 @@ describe "SMTP Delivery Method" do
         subject "Email with no recipient"
         body "body"
       end
-    end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+    end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
   end
 end

--- a/spec/mail/network/delivery_methods/test_mailer_spec.rb
+++ b/spec/mail/network/delivery_methods/test_mailer_spec.rb
@@ -64,7 +64,7 @@ describe "Mail::TestMailer" do
         subject "Email with no sender"
         body "body"
       end
-    end.should raise_error('A sender (Return-Path, Sender or From) required to send a message')
+    end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
   end
 
   it "should raise an error if no recipient if defined" do
@@ -77,7 +77,7 @@ describe "Mail::TestMailer" do
         subject "Email with no recipient"
         body "body"
       end
-    end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
+    end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
   end
 
 end


### PR DESCRIPTION
The envelope From address defaults to `return_path || sender || from_addrs.first`.
The envelope To address defaults to `destinations` (to + cc + bcc).

Set them yourself using `smtp_envelope_from` and `smtp_envelope_to`.

The sendmail, smtp, and smtp_connection delivery methods no longer worry about return_path vs sender vs from; they just use the `message.smtp_envelope_from` address.

References #421 and rails/rails#5985
