### PR TITLE
Fix trailing equals signs mysteriously showing up on quoted-printable emails

### DIFF
--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -50,7 +50,7 @@ module Mail
     def initialize(header_text = nil, charset = nil)
       @errors = []
       @charset = charset
-      self.raw_source = header_text.to_crlf
+      self.raw_source = header_text.to_crlf.lstrip
       split_header if header_text
     end
     

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -122,7 +122,7 @@ module Mail
       if args.flatten.first.respond_to?(:each_pair)
         init_with_hash(args.flatten.first)
       else
-        init_with_string(args.flatten[0].to_s.strip)
+        init_with_string(args.flatten[0].to_s)
       end
 
       if block_given?
@@ -1875,7 +1875,7 @@ module Mail
     # Additionally, I allow for the case where someone might have put whitespace
     # on the "gap line"
     def parse_message
-      header_part, body_part = raw_source.split(/#{CRLF}#{WSP}*#{CRLF}(?!#{WSP})/m, 2)
+      header_part, body_part = raw_source.lstrip.split(/#{CRLF}#{WSP}*#{CRLF}(?!#{WSP})/m, 2)
       self.header = header_part
       self.body   = body_part
     end

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -254,7 +254,7 @@ describe "Test emails" do
       mail.from.should eq ["atsushi@example.com"]
       mail.subject.should eq "Re: TEST テストテスト"
       mail.message_id.should eq '0CC5E11ED2C1D@example.com'
-      mail.body.should eq "Hello"
+      mail.body.decoded.should eq "Hello\n"
     end
   end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -237,7 +237,7 @@ describe Mail::Message do
 
     it "should set a raw source instance variable to equal the passed in message" do
       mail = Mail::Message.new(basic_email)
-      mail.raw_source.should eq basic_email.strip
+      mail.raw_source.should eq basic_email
     end
 
     it "should set the raw source instance variable to '' if no message is passed in" do
@@ -259,7 +259,7 @@ describe Mail::Message do
 
     it "should give the body class the body to parse" do
       body = Mail::Body.new("email message")
-      Mail::Body.should_receive(:new).with("email message").and_return(body)
+      Mail::Body.should_receive(:new).with("email message\r\n").and_return(body)
       mail = Mail::Message.new(basic_email)
       mail.body #body calculates now lazy so need to ask for it
     end
@@ -290,8 +290,8 @@ describe Mail::Message do
 
     it "should allow for whitespace at the start of the email" do
       mail = Mail.new("\r\n\r\nFrom: mikel\r\n\r\nThis is the body")
-      mail.from.should eq ['mikel']
       mail.body.to_s.should eq 'This is the body'
+      mail.from.should eq ['mikel']
     end
 
     it "should read in an email message with the word 'From' in it multiple times and parse it" do
@@ -303,7 +303,7 @@ describe Mail::Message do
     it "should parse non-UTF8 sources" do
       mail = Mail::Message.new(File.read(fixture('emails', 'multi_charset', 'japanese_shiftjis.eml')))
       mail.to.should eq ["raasdnil@gmail.com"]
-      mail.decoded.should eq "すみません。"
+      mail.decoded.should eq "すみません。\n\n"
     end
   end
 
@@ -1252,6 +1252,10 @@ describe Mail::Message do
         end
         mail.body.decoded.should eq "The body"
         mail.body.encoded.should eq "VGhlIGJvZHk=\r\n"
+      end
+
+      it 'should not strip the raw mail source in case the trailing \r\n is meaningful' do
+        Mail.new("Content-Transfer-Encoding: quoted-printable;\r\n\r\nfoo=\r\nbar=\r\nbaz=\r\n").decoded.should eq 'foobarbaz'
       end
 
     end

--- a/spec/mail/round_tripping_spec.rb
+++ b/spec/mail/round_tripping_spec.rb
@@ -24,8 +24,8 @@ describe "Round Tripping" do
     parsed_mail.mime_type.should eq 'multipart/alternative'
     parsed_mail.boundary.should eq mail.boundary
     parsed_mail.parts.length.should eq 2
-    parsed_mail.parts[0].body.to_s.should eq "This is Text"
-    parsed_mail.parts[1].body.to_s.should eq "<b>This is HTML</b>"
+    parsed_mail.parts[0].body.to_s.should eq "This is Text\n\n"
+    parsed_mail.parts[1].body.to_s.should eq "<b>This is HTML</b>\n\n"
   end
 
   it "should round trip an email" do


### PR DESCRIPTION
Stripping the raw mail source can corrupt quoted-printable emails, resulting in trailing equals signs (=)

Fixes #440
