### PR TITLE
Do not collapse multiple quoted-printable lines if the line encodings are not the same.

### DIFF
--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -272,7 +272,15 @@ describe Mail::Encodings do
       unwrapped = Mail::Encodings.value_decode(wrapped)
       unwrapped.gsub("Subject: ", "").should eq original
     end
+  end
 
+  describe "mixed Q and B encodings" do
+    it "should decode an encoded string" do
+      string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= =?UTF-8?Q?_This_was_=E3=81=82_string?='
+      result = "This is あ string This was あ string"
+      result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
+      Mail::Encodings.value_decode(string).should eq result
+    end
   end
 
   describe "parameter MIME encodings" do


### PR DESCRIPTION
I came across an issue where I had a subject that was quoted-printable encoded into multiple lines. The encoding in all lines was not the same. In my case the first 3 were encoded B and the last was encoded Q. Decoding the subject line failed due to how multiple lines were being collapsed.

This change makes it so that only adjacent lines that have the same encoding are collapsed together. You can see the spec I added for a clearer example of what I am talking about.

I have tested this on the latest 1.8.7 and 1.9.3. The tests were failing on master, but I did ensure that the same tests failed after my changes.

Thanks,
Adam
