### PR TITLE
Only wrap attachment filenames in double quotes not other params

### DIFF
--- a/lib/mail/fields/common/common_field.rb
+++ b/lib/mail/fields/common/common_field.rb
@@ -47,11 +47,16 @@ module Mail
       end
     end
 
+    WORD_CHAR_WITHOUT_QUOTE = '[\w[^"]]'
+    WORD_WITHOUT_QUOTE = "#{WORD_CHAR_WITHOUT_QUOTE}+?"
+    WORD_WITHOUT_QUOTE_FOLLOWED_BY_WSP = "#{WORD_WITHOUT_QUOTE}\\s+?"
+    PARAM_ENDING = '(\r|\z)'
+    FILENAME_RE = /\s((filename|name)=((#{WORD_WITHOUT_QUOTE_FOLLOWED_BY_WSP})+?(#{WORD_CHAR_WITHOUT_QUOTE})*?))#{PARAM_ENDING}/
+
     def ensure_filename_quoted(value)
-      if !value.is_a?(Array) and /(.)*\s(filename|name)=[^"](.+\s)+[^"]/.match value
-        value.gsub!(/[^=]+$/, '"\\0"')
+      if value && !value.is_a?(Array) && matches = value.match(FILENAME_RE)
+        value.sub!(matches[1], "#{matches[2]}=\"#{matches[3]}\"")
       end
     end
-
   end
 end

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -133,6 +133,11 @@ describe Mail::ContentTypeField do
       c = Mail::ContentTypeField.new('text/plain; name="Bad filename but at least it is wrapped in quotes.txt"')
       c.value.should eq 'text/plain; name="Bad filename but at least it is wrapped in quotes.txt"'
     end
+
+    it "should only wrap filenames in double quotation marks" do
+      c = Mail::ContentTypeField.new("image/jpg;\r\n\sname=some .jpg\r\n\ssize=100")
+      c.value.should eq %Q{image/jpg;\r\n\sname="some .jpg"\r\n\ssize=100}
+    end
   end
 
   describe "instance methods" do


### PR DESCRIPTION
The current implementation is sticking quotes in odd places:

```
1.9.3p194 :018 > Mail::ContentTypeField.new.send(:ensure_filename_quoted, "audio/x-midi;\r\n\sname=Part .exe")
 => "\"audio/x-midi;\r\"\n name=\"Part .exe\""
```

After the fix:

```
1.9.3p194 :002 > Mail::ContentTypeField.new.send(:ensure_filename_quoted, "audio/x-midi;\r\n\sname=Part .exe")
 => "audio/x-midi;\r\n name=\"Part .exe\"" 
```

Not super thrilled with the nasty regexp, open to other ways of solving this problem.
