### PR TITLE
Spec Cleanup: use correct syntax for address fields

### DIFF
--- a/spec/mail/fields/from_field_spec.rb
+++ b/spec/mail/fields/from_field_spec.rb
@@ -9,7 +9,7 @@ describe Mail::FromField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::FromField.new("From", "Mikel") }.should_not raise_error
+      doing { Mail::FromField.new("From: Mikel") }.should_not raise_error
     end
 
     it "should mix in the CommonAddress module" do

--- a/spec/mail/fields/reply_to_field_spec.rb
+++ b/spec/mail/fields/reply_to_field_spec.rb
@@ -9,7 +9,7 @@ describe Mail::ReplyToField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ReplyToField.new("ReplyTo", "Mikel") }.should_not raise_error
+      doing { Mail::ReplyToField.new("Reply-To: Mikel") }.should_not raise_error
     end
 
     it "should mix in the CommonAddress module" do

--- a/spec/mail/fields/resent_bcc_field_spec.rb
+++ b/spec/mail/fields/resent_bcc_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentBccField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentBccField.new("ResentBcc", "Mikel") }.should_not raise_error
+      doing { Mail::ResentBccField.new("Resent-Bcc: Mikel") }.should_not raise_error
     end
 
     it "should mix in the CommonAddress module" do

--- a/spec/mail/fields/resent_cc_field_spec.rb
+++ b/spec/mail/fields/resent_cc_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentCcField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentCcField.new("ResentCc", "Mikel") }.should_not raise_error
+      doing { Mail::ResentCcField.new("Resent-Cc: Mikel") }.should_not raise_error
     end
 
     it "should mix in the CommonAddress module" do

--- a/spec/mail/fields/resent_from_field_spec.rb
+++ b/spec/mail/fields/resent_from_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentFromField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentFromField.new("ResentFrom", "Mikel") }.should_not raise_error
+      doing { Mail::ResentFromField.new("Resent-From: Mikel") }.should_not raise_error
     end
 
     it "should mix in the CommonAddress module" do

--- a/spec/mail/fields/resent_sender_field_spec.rb
+++ b/spec/mail/fields/resent_sender_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentSenderField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentSenderField.new("ResentSender", "Mikel") }.should_not raise_error
+      doing { Mail::ResentSenderField.new("Resent-Sender: Mikel") }.should_not raise_error
     end
 
     it "should mix in the CommonAddress module" do

--- a/spec/mail/fields/resent_to_field_spec.rb
+++ b/spec/mail/fields/resent_to_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentToField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentToField.new("ResentTo", "Mikel") }.should_not raise_error
+      doing { Mail::ResentToField.new("Resent-To: Mikel") }.should_not raise_error
     end
 
     it "should mix in the CommonAddress module" do

--- a/spec/mail/fields/sender_field_spec.rb
+++ b/spec/mail/fields/sender_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::SenderField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::SenderField.new("Sender", "Mikel") }.should_not raise_error
+      doing { Mail::SenderField.new("Sender: Mikel") }.should_not raise_error
     end
 
     it "should mix in the CommonAddress module" do


### PR DESCRIPTION
Looks like the initializers for these address fields were updated to take a single argument but the specs weren't updated and still used the old syntax.
