### PR TITLE
Don't expose the treetop parse tree for envelope.

### DIFF
--- a/spec/mail/elements/envelope_from_element_spec.rb
+++ b/spec/mail/elements/envelope_from_element_spec.rb
@@ -4,15 +4,15 @@ describe Mail::EnvelopeFromElement do
   
   describe "parsing a from envelope string" do
     it "should parse a full field" do
-      Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug  7 00:39:21 2009").tree.should_not be_nil
+      doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug  7 00:39:21 2009") }.should_not raise_error
     end
 
     it "should parse a full field with a double digit day" do
-      Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug 17 00:39:21 2009").tree.should_not be_nil
+      doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug 17 00:39:21 2009") }.should_not raise_error
     end
 
     it "should parse a full field with a single space day" do
-      Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009").tree.should_not be_nil
+      doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009") }.should_not raise_error
     end
   end
 

--- a/spec/mail/fields/envelope_spec.rb
+++ b/spec/mail/fields/envelope_spec.rb
@@ -28,11 +28,6 @@ describe Mail::Envelope do
     doing { Mail::Envelope.new('mikel@test.lindsaar.net Mon May  2 16:07:05 2005') }.should_not raise_error
   end
 
-  it "should return the envelope from element tree" do
-    envelope = Mail::Envelope.new('mikel@test.lindsaar.net Mon May  2 16:07:05 2005')
-    envelope.tree.class.should eq Treetop::Runtime::SyntaxNode
-  end
-
   describe "accessor methods" do
     it "should return the address" do
       envelope = Mail::Envelope.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009")


### PR DESCRIPTION
I'm in the process of swapping out the treetop parser for a quicker ragel based parser.  This is a prep work to disentangle some of the specs from treetop.
