### PR TITLE
Clarify parser behavior for funky angle bracket addresses

### DIFF
--- a/lib/mail/elements/address.rb
+++ b/lib/mail/elements/address.rb
@@ -296,6 +296,12 @@ module Mail
         tree.angle_addr.addr_spec.local_part.text_value
       when tree.respond_to?(:addr_spec) && tree.addr_spec.respond_to?(:local_part)
         tree.addr_spec.local_part.text_value
+      when tree.respond_to?(:angle_addr) && tree.angle_addr.respond_to?(:addr_spec) && tree.angle_addr.addr_spec.respond_to?(:local_dot_atom_text)
+        # Ignore local dot atom text when in angle brackets
+        nil
+      when tree.respond_to?(:addr_spec) && tree.addr_spec.respond_to?(:local_dot_atom_text)
+        # Ignore local dot atom text when in angle brackets
+        nil
       else
         tree && tree.respond_to?(:local_part) ? tree.local_part.text_value : nil
       end

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -38,7 +38,7 @@ describe Mail::Address do
     end
 
     ['"-Earnings...Notification-" <vodacom.co.rs>', '<56253817>'].each do |spammy_address|
-      it "should allow for funky spammy address #{spammy_address}" do
+      it "should ignore funky local-only spammy addresses in angle brackets #{spammy_address}" do
         Mail::Address.new(spammy_address).address.should eq nil
       end
     end


### PR DESCRIPTION
This PR doesn't change any behavior.  It only makes the code more explicit for addresses of the form `blah <blah.co.jp>`.  Currently Mail::Address#address will return nil for these type of addresses.

It's not 100% clear to me that this is intended behavior. If this is a bug I'm more than happy to make another PR that allows us to recognize these types of addresses instead of ignoring them.
