### PR TITLE
Extract comments from an address when it is part of a group

### DIFF
--- a/lib/mail/parsers/rfc2822.treetop
+++ b/lib/mail/parsers/rfc2822.treetop
@@ -222,7 +222,22 @@ module Mail
     end
   
     rule mailbox
-      name_addr / addr_spec
+      (name_addr / addr_spec) {
+        def dig_comments(comments, elements)
+          elements.each { |elem|
+            if elem.respond_to?(:comment)
+              comments << elem.comment
+            end
+            dig_comments(comments, elem.elements) if elem.elements
+           }
+        end
+
+        def comments
+          comments = []
+          dig_comments(comments, elements)
+          comments
+        end
+      }
     end
 
     rule address
@@ -244,24 +259,7 @@ module Mail
         end
 
       } /
-      mailbox {
-
-      def dig_comments(comments, elements)
-        elements.each { |elem|
-          if elem.respond_to?(:comment)
-            comments << elem.comment
-          end
-          dig_comments(comments, elem.elements) if elem.elements
-         }
-      end
-
-      def comments
-        comments = []
-        dig_comments(comments, elements)
-        comments
-      end
-
-      }
+      mailbox
     end
   
     rule address_list

--- a/spec/mail/elements/address_list_spec.rb
+++ b/spec/mail/elements/address_list_spec.rb
@@ -75,6 +75,13 @@ describe Mail::AddressList do
       a.addresses.map {|addr| addr.to_s }.should eq result
     end
 
+    it "should extract comments in addreses which are part of a group" do
+      parse_text = "group: jimmy <jimmy@(comment)example.com>;";
+      result = ["comment"]
+      a = Mail::AddressList.new(parse_text)
+      a.addresses.first.comments.should eq result
+    end
+
   end
   
   describe "functionality" do

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -187,7 +187,7 @@ describe "Test emails" do
     it "should handle the rfc whitespace test email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example10.eml'))
       mail.from.should eq ["pete(his account)@silly.test"]
-      mail.to.should eq  ["c@(Chris's host.)public.example", "joe@example.org", "jdoe@one.test"]
+      mail.to.should eq  ["c@public.example", "joe@example.org", "jdoe@one.test"]
       mail[:cc].group_names.should eq ['(Empty list)(start)Undisclosed recipients ']
       mail.date.should eq ::DateTime.parse('Thu, 13 Feb 1969 23:32 -0330')
       mail.message_id.should eq 'testabcd.1234@silly.test'


### PR DESCRIPTION
The current code does not add the #comments method to addresses which are part of a group
