### PR TITLE
Decode quoted-printable with bad line breaks

### DIFF
--- a/lib/mail/encodings/quoted_printable.rb
+++ b/lib/mail/encodings/quoted_printable.rb
@@ -12,9 +12,10 @@ module Mail
         EightBit.can_encode? str
       end
 
-      # Decode the string from Quoted-Printable
+      # Decode the string from Quoted-Printable. Cope with hard line breaks
+      # that were incorrectly encoded as hex instead of literal CRLF.
       def self.decode(str)
-        str.unpack("M*").first.to_lf
+        str.gsub(/(?:=0D=0A|=0D|=0A)\r\n/, "\r\n").unpack("M*").first.to_lf
       end
 
       def self.encode(str)

--- a/spec/mail/encodings/quoted_printable_spec.rb
+++ b/spec/mail/encodings/quoted_printable_spec.rb
@@ -31,5 +31,21 @@ describe Mail::Encodings::QuotedPrintable do
     result = "\000\000\000\000"
     Mail::Encodings::QuotedPrintable.decode("=00=00=00=00").should eq result
   end
+
+  %w(=0D =0A =0D=0A).each do |linebreak|
+    expected = "first line wraps\n\nsecond paragraph"
+    it "should cope with inappropriate #{linebreak} line break encoding" do
+      body = "first line=\r\n wraps#{linebreak}\r\n#{linebreak}\r\nsecond paragraph=\r\n"
+      Mail::Encodings::QuotedPrintable.decode(body).should eq expected
+    end
+  end
+
+  [["\r", "=0D"], ["\n", "=0A"], ["\r\n", "=0D=0A"]].each do |crlf, linebreak|
+    expected = "first line wraps\n\nsecond paragraph"
+    it "should allow encoded #{linebreak} line breaks with soft line feeds" do
+      body = "first line=\r\n wraps#{linebreak}=\r\n#{linebreak}=\r\nsecond paragraph=\r\n"
+      Mail::Encodings::QuotedPrintable.decode(body).should eq expected
+    end
+  end
   
 end


### PR DESCRIPTION
Many many clients hex-encode the \r, \n, or \r\n line break when they're supposed to use a literal CRLF (quoted-printable had the idea that they'd be line break agnostic). To make matters worse, they also include the CRLF after the encoded line break, so decoding it results in a double line break. If anything, they should use a soft line break.

"=0D\r\n" should decode as "\r\n" not "\r\r\n"
"=0A\r\n" should decode as "\r\n" not "\n\r\n"
"=0A=0D\r\n" should decode as "\r\n" not "\r\n\r\n"

Clients using hex-encoded line breaks along with quoted-printable soft line breaks still work as expected.
