### PR TITLE
Correct line breaks in quoted-printable encoding

### DIFF
--- a/lib/mail/encodings/quoted_printable.rb
+++ b/lib/mail/encodings/quoted_printable.rb
@@ -14,11 +14,11 @@ module Mail
 
       # Decode the string from Quoted-Printable
       def self.decode(str)
-        str.unpack("M*").first
+        str.unpack("M*").first.to_lf
       end
 
       def self.encode(str)
-        [str].pack("M").to_crlf
+        [str.to_lf].pack("M").to_crlf
       end
 
       def self.cost(str)

--- a/spec/mail/encodings/quoted_printable_spec.rb
+++ b/spec/mail/encodings/quoted_printable_spec.rb
@@ -3,13 +3,23 @@ require 'spec_helper'
 describe Mail::Encodings::QuotedPrintable do
   
   it "should encode quoted printable from text" do
-    result = "This is a test=\r\n"
-    Mail::Encodings::QuotedPrintable.encode('This is a test').should eq result
+    result = "This is\r\na test=\r\n"
+    Mail::Encodings::QuotedPrintable.encode("This is\na test").should eq result
+  end
+
+  it "should encode quoted printable from crlf text" do
+    result = "This is\r\na test=\r\n"
+    Mail::Encodings::QuotedPrintable.encode("This is\r\na test").should eq result
+  end
+
+  it "should encode quoted printable from cr text" do
+    result = "This is\r\na test=\r\n"
+    Mail::Encodings::QuotedPrintable.encode("This is\ra test").should eq result
   end
   
   it "should decode quoted printable" do
-    result = "This is a test"
-    Mail::Encodings::QuotedPrintable.decode("This is a test").should eq result
+    result = "This is\na test"
+    Mail::Encodings::QuotedPrintable.decode("This is\r\na test").should eq result
   end
   
   it "should encode quoted printable from binary" do


### PR DESCRIPTION
Quoted-printable transfer encoding is intended to be "line break neutral." It uses CRLF to encode line breaks, whether you prefer carriage returns, line feeds, or both.

Ruby's builtin #pack and #unpack support quoted-printable encoding, but expect to see linefeeds (\n) only. So it's our responsibility to convert to LF before encoding and to CRLF afterward, and to convert CRLF to LF after decoding. Otherwise we get incorrectly hex-encoded CR as well as doubled-up CR:

Ruby treats \n as its line break, so it hex-encodes \r:

``` ruby
> ["\r\n"].pack('M')
=> "=0D\n"
```

And `Mail::Encodings::QuotedPrintable.decode` does an additional `to_crlf` which converts the \n to \r\n, resulting in an extra line break:

``` ruby
> ["\r\n"].pack('M').to_crlf
=> "=0D\r\n"
```

We should `to_lf` before using Ruby's quoted-printable packing. That gets the input text back into Ruby's line ending, which is faithfully encoded as quoted-printable CRLFs:

``` ruby
> ["\r\n".to_lf].pack('M').to_crlf
=> "\r\n"
```

Ruby also unpacks CRLF as CRLF—strangely, considering it only respects LF for packing! For consistency, one would expect Ruby to unpack CRLF as LF. In any case, we can `to_lf` the unpacked result for consistent behavior (and working round-tripping):

``` ruby
> "\r\n".unpack('M')
=> "\r\n"
> "\r\n".unpack('M').to_lf
=> "\n"
```
