### PR TITLE
Treat GB2312 encodings as GB18030

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -132,6 +132,12 @@ module Mail
       when 'shift-jis'
         Encoding::Shift_JIS
 
+      # Many encoded fields which self identify as GB2312 are
+      # actually GB18030.  Just use GB18030 since it is a superset
+      # of GB2312.
+      when /gb2312/i
+        Encoding::GB18030
+
       else
         charset
       end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -165,6 +165,11 @@ describe Mail::Encodings do
         string = '=?shift-jis?Q?=93=FA=96{=8C=EA=?='.force_encoding('us-ascii')
         Mail::Encodings.value_decode(string).should == "日本語"
       end
+
+      it "should decode GB18030 encoded string misidentified as GB2312" do
+        string = '=?GB2312?B?6V8=?='.force_encoding('us-ascii')
+        Mail::Encodings.value_decode(string).should == "開"
+      end
     end
   end
 


### PR DESCRIPTION
```
GB 18030 character assignments are backwards compatible with the GB 2312-1980 standard and the GBK specification.
```

http://icu-project.org/docs/papers/gb18030.html
