### PR TITLE
Improve handling of backslashes in quoted strings. [Fixes #450]

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -41,28 +41,36 @@ module Mail
       token_safe?( str ) ? str : dquote(str)
     end
 
-    # Wraps supplied string in double quotes unless it is already wrapped.
-    # 
-    # Additionally will escape any double quotation marks in the string with a single
-    # backslash in front of the '"' character.
-    def dquote( str )
-      match = str.match(/^"(.*)?"$/)
-      str = match[1] if match
-      # First remove all escaped double quotes:
-      str = str.gsub(/\\"/, '"')
-      # Then wrap and re-escape all double quotes
-      '"' + str.gsub(/["]/n) {|s| '\\' + s } + '"'
-    end
-    
-    # Unwraps supplied string from inside double quotes.
-    # 
+    # Wraps supplied string in double quotes and applies \-escaping as necessary,
+    # unless it is already wrapped.
+    #
     # Example:
-    # 
+    #
+    #  string = 'This is a string'
+    #  dquote(string) #=> '"This is a string"'
+    #
+    #  string = 'This is "a string"'
+    #  dquote(string #=> '"This is \"a string\"'
+    def dquote( str )
+      '"' + unquote(str).gsub(/[\\"]/n) {|s| '\\' + s } + '"'
+    end
+
+    # Unwraps supplied string from inside double quotes and
+    # removes any \-escaping.
+    #
+    # Example:
+    #
     #  string = '"This is a string"'
     #  unquote(string) #=> 'This is a string'
+    #
+    #  string = '"This is \"a string\""'
+    #  unqoute(string) #=> 'This is "a string"'
     def unquote( str )
-      match = str.match(/^"(.*?)"$/)
-      match ? match[1] : str
+      if str =~ /^"(.*?)"$/
+        $1.gsub(/\\(.)/, '\1')
+      else
+        str
+      end
     end
     
     # Wraps a string in parenthesis and escapes any that are in the string itself.

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -516,7 +516,7 @@ describe Mail::Address do
                                          :comments     => ['foo@bar.com (foobar), ned@foo.com (nedfoo) '],
                                          :domain       => 'goess.org',
                                          :local        => 'kevin',
-                                         :format       => '"(foo@bar.com \\(foobar\\), ned@foo.com \(nedfoo\) )" <kevin@goess.org> (foo@bar.com \(foobar\), ned@foo.com \(nedfoo\) )',
+                                         :format       => '"(foo@bar.com \\\\(foobar\\\\), ned@foo.com \\\\(nedfoo\\\\) )" <kevin@goess.org> (foo@bar.com \(foobar\), ned@foo.com \(nedfoo\) )',
                                          :raw          => '(foo@bar.com (foobar), ned@foo.com (nedfoo) ) <kevin@goess.org>'})
       end
 

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -175,14 +175,40 @@ describe "Utilities Module" do
     
     it "should quote correctly a phrase with an escaped quote in it" do
       test = 'this needs \"quoting'
-      result = '"this needs \"quoting"'
+      result = '"this needs \\\\\\"quoting"'
       dquote(test).should eq result
     end
     
     it "should quote correctly a phrase with an escaped backslash followed by an escaped quote in it" do
       test = 'this needs \\\"quoting'
-      result = '"this needs \\\"quoting"'
+      result = '"this needs \\\\\\\\\\"quoting"'
       dquote(test).should eq result
+    end
+  end
+
+  describe "unquoting phrases" do
+    it "should remove quotes from the edge" do
+      unquote('"This is quoted"').should eq 'This is quoted'
+    end
+
+    it "should remove backslash escaping from quotes" do
+      unquote('"This is \\"quoted\\""').should eq 'This is "quoted"'
+    end
+
+    it "should remove backslash escaping from any char" do
+      unquote('"This is \\quoted"').should eq 'This is quoted'
+    end
+
+    it "should be able to handle unquoted strings" do
+      unquote('This is not quoted').should eq 'This is not quoted'
+    end
+
+    it "should preserve backslashes in unquoted strings" do
+      unquote('This is not \"quoted').should eq 'This is not \"quoted'
+    end
+
+    it "should be able to handle unquoted quotes" do
+      unquote('"This is "quoted"').should eq 'This is "quoted'
     end
   end
   


### PR DESCRIPTION
The relevant part of RFC-822 says that '\' '"' and "\r" should be
escaped in quoted strings.

I have added escaping for '\', but not for '\r' as we already use
quoted-printable form for those (and if we allow raw newlines in headers
we have to be much more careful to avoid header-injection).

I've also fixed unquote() to remove backslash-escaping from the string
as RFC-822 suggests.
