### PR TITLE
Don't include separating semicolon in paramter value when sanitizing

### DIFF
--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -180,7 +180,7 @@ module Mail
         params = $2.to_s.split(/\s+/)
         params = params.map { |i| i.to_s.chomp.strip }
         params = params.map { |i| i.split(/\s*\=\s*/) }
-        params = params.map { |i| "#{i[0]}=#{dquote(i[1].to_s)}" }.join('; ')
+        params = params.map { |i| "#{i[0]}=#{dquote(i[1].to_s.gsub(/;$/,""))}" }.join('; ')
         "#{type}; #{params}"
       when val =~ /^\s*$/
         'text/plain'

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -755,6 +755,11 @@ describe Mail::ContentTypeField do
       c.string.should eq 'text/html'
     end
 
+    it "shouldn't include separating semicolon in parameter value when sanitizing" do
+      c = Mail::ContentTypeField.new(%Q{Multipart/Related;boundary=boundary123?WUT; type="application/xml";})
+      c.parameters['boundary'].should eq 'boundary123?WUT'
+    end
+
   end
 
 end


### PR DESCRIPTION
Came across this in the wild.

Initial parse fails because of the '?' in the boundary (not a valid character for a parameter unless it's in a quoted string), but then the sanitize method includes the separating semicolon when it turns it into a quoted string.

Fix is to remove any trailing semicolons before double quoting the value.
