### PR TITLE
Save settings passed to TestMailer#new

### DIFF
--- a/lib/mail/network/delivery_methods/test_mailer.rb
+++ b/lib/mail/network/delivery_methods/test_mailer.rb
@@ -30,7 +30,7 @@ module Mail
     end
 
     def initialize(values)
-      @settings = {}
+      @settings = values.dup
     end
     
     attr_accessor :settings

--- a/spec/mail/network/delivery_methods/test_mailer_spec.rb
+++ b/spec/mail/network/delivery_methods/test_mailer_spec.rb
@@ -80,4 +80,7 @@ describe "Mail::TestMailer" do
     end.should raise_error('At least one recipient (To, Cc or Bcc) is required to send a message')
   end
 
+  it "should save settings passed to initialize" do
+    Mail::TestMailer.new(setting: true).settings.should include(setting: true)
+  end
 end


### PR DESCRIPTION
I came across this when using ActionMailer and testing that my `delivery_method` settings were being set correctly, specifically around https://github.com/rails/rails/blob/master/actionmailer/lib/action_mailer/delivery_methods.rb#L66 where `delivery_method` is `:test`. This hits https://github.com/mikel/mail/blob/master/lib/mail/message.rb#L254 which instantiates a new TestMailer with the passed settings. It seems weird to me that TestMailer provides `attr_accessor :settings` but ignores the `values` passed to `initialize`, especially since this lead to one method of changing settings, using Interceptors, which are set through the accessor, working but not the other, using Class attributes, which are set through an initialize.
