### PR TITLE
Fix code example for Message#resent_sender=

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -938,8 +938,8 @@ module Mail
     #
     # Example:
     #
-    #  mail.sender = 'Mikel <mikel@test.lindsaar.net>'
-    #  mail.sender #=> 'mikel@test.lindsaar.net'
+    #  mail.resent_sender = 'Mikel <mikel@test.lindsaar.net>'
+    #  mail.resent_sender #=> 'mikel@test.lindsaar.net'
     def resent_sender=( val )
       header[:resent_sender] = val
     end


### PR DESCRIPTION
The code example for Message#resent_sender= contains the wrong method name.
