### PR TITLE
Since there was a bug fix that does not specify a mailbox at delete_all

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -111,6 +111,7 @@ module Mail
       mailbox = Net::IMAP.encode_utf7(mailbox)
 
       start do |imap|
+        imap.select(mailbox)
         imap.uid_search(['ALL']).each do |message_id|
           imap.uid_store(message_id, "+FLAGS", [Net::IMAP::DELETED])
         end


### PR DESCRIPTION
I was using the delete_all but errors are out "(Error in IMAP command received by server.) Net :: IMAP :: NoResponseError", was added because there was no process to select the mailbox.
