### PR TITLE
Adhere strictly to spec for header splitting

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1885,11 +1885,8 @@ module Mail
     #   this standard. The body is simply a sequence of characters that
     #   follows the header and is separated from the header by an empty line
     #   (i.e., a line with nothing preceding the CRLF).
-    #
-    # Additionally, I allow for the case where someone might have put whitespace
-    # on the "gap line"
     def parse_message
-      header_part, body_part = raw_source.lstrip.split(/#{CRLF}#{CRLF}|#{CRLF}#{WSP}*#{CRLF}(?!#{WSP})/m, 2)
+      header_part, body_part = raw_source.lstrip.split(/#{CRLF}#{CRLF}/, 2)
       self.header = header_part
       self.body   = body_part
     end

--- a/spec/fixtures/emails/mime_emails/sig_only_email.eml
+++ b/spec/fixtures/emails/mime_emails/sig_only_email.eml
@@ -6,24 +6,24 @@ Message-ID: <20070604150131.40d4fa1e@reforged>
 Mime-Version: 1.0
 Content-Type: multipart/signed; boundary=Sig_2GIY2xfzqSADMmu9sKGJqWm;
  protocol="application/pgp-signature"; micalg=PGP-SHA1
- 
+
 --Sig_2GIY2xfzqSADMmu9sKGJqWm
 Content-Type: text/plain; charset=US-ASCII
 Content-Transfer-Encoding: quoted-printable
- 
+
 This is random text, not what has been signed below, ie, this sig
 email is not signed correctly.
- 
+
 --Sig_2GIY2xfzqSADMmu9sKGJqWm
 Content-Type: application/pgp-signature; name=signature.asc
 Content-Disposition: attachment; filename=signature.asc
- 
+
 -----BEGIN PGP SIGNATURE-----
 Version: GnuPG v1.4.6 (GNU/Linux)
- 
+
 iD8DB1111Iu7dfRchrkBInkRArniAKCue17JOxXBiAZHwLy3uFacU+pmhwCgwzhf
 V5YSPv2xmYOA6mJ6oVaasseQ=
 =T7p9
 -----END PGP SIGNATURE-----
- 
+
 --Sig_2GIY2xfzqSADMmu9sKGJqWm--

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -221,9 +221,8 @@ describe Mail::Message do
         message.decoded.should == "Hello\n\nthere\n"
       end
 
-      # N.B. this is not in any RFCs
-      it "should split on a line with whitespace on it" do
-        message = Mail::Message.new("To: Example <example@cirw.in>\r\n \r\nHello there\r\n")
+      it "should allow headers that end in trailing whitespace" do
+        message = Mail::Message.new("To: Example <example@cirw.in>\r\nThread-Topic: -= MAINTENANCE =- Canasta - Wednesday 4/24/2013 8am - 10am\r\n                                         \r\n\r\nHello there\r\n")
         message.decoded.should == "Hello there\n"
       end
     end
@@ -314,15 +313,6 @@ describe Mail::Message do
       Mail::Header.should_receive(:new).with("To: mikel", 'UTF-8').and_return(header)
       Mail::Body.should_receive(:new).with("G'Day!").and_return(body)
       mail = Mail::Message.new("To: mikel\r\n\r\nG'Day!")
-      mail.body #body calculates now lazy so need to ask for it
-    end
-
-    it "should give allow for whitespace on the gap line between header and body" do
-      header = Mail::Header.new("To: mikel")
-      body = Mail::Body.new("G'Day!")
-      Mail::Header.should_receive(:new).with("To: mikel", 'UTF-8').and_return(header)
-      Mail::Body.should_receive(:new).with("G'Day!").and_return(body)
-      mail = Mail::Message.new("To: mikel\r\n   		  \r\nG'Day!")
       mail.body #body calculates now lazy so need to ask for it
     end
 


### PR DESCRIPTION
This is a backward incompatible change, but is necessary for the mail
gem to maintain compatibility with other mail parsing libraries (in
particular the one that powers Microsoft Exchange).

The header in the spec is one from an actual email I received (and the mail gem failed to parse). I can include it as a spec if necessary.
