### PR TITLE
Workaround for compilation failure under rbx-head

### DIFF
--- a/lib/load_parsers.rb
+++ b/lib/load_parsers.rb
@@ -28,8 +28,7 @@ module Mail # :doc:
       rescue LoadError
         compile_parser(parser)
       rescue => e
-        puts "Mail failed to compile: #{parser}"
-        puts e
+        puts "Mail failed to compile: #{parser} ... " + e.to_s
       end
     end
 


### PR DESCRIPTION
Workaround for mikel/mail#541
Temporary solution to rubinius/rubinius#2308
Still needs an actual fix, or diagnostic of why this happens.

At least for now the `mail` gem being required doesn't take down entire applications.
