### PR TITLE
Ensure charset is maintained when serializing as YAML

### DIFF
--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -188,6 +188,16 @@ describe Mail::Message do
         deserialized.parts.each {|part| part.should be_a(Mail::Part)}
         deserialized.parts.map(&:body).should == ['body', '<b>body</b>']
       end
+
+      it 'should maintain the charset when the content type is set' do
+        @yaml_mail.content_type = 'text/plain'
+        @yaml_mail.charset = 'UTF-8'
+        @yaml_mail.from = %{"Bjørn" <me@somewhere.com>}
+        deserialized = Mail::Message.from_yaml(@yaml_mail.to_yaml)
+        deserialized.charset.should == 'UTF-8'
+        deserialized.header[:from].encoded.should == \
+          Mail::FromField.new(%{"Bjørn" <me@somewhere.com>}, 'UTF-8').encoded
+      end
     end
 
     describe "splitting" do


### PR DESCRIPTION
This issue stems from the following peculiarity:

``` ruby
mail = Mail.new
mail.charset # => "UTF-8"

mail.content_type = "text/plain"
mail.charset # => nil
```

I have modified the YAML serialization so that it sets the `charset` to its expected value after setting the content type header (similar to [how Rails seems to handle this](https://github.com/rails/rails/blob/master/actionmailer/lib/action_mailer/base.rb#L696)).
