### PR TITLE
fix header's charset getting reset to nil unintentionally

### DIFF
--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -175,7 +175,7 @@ module Mail
       if dasherize(fn) == "content-type"
         # Update charset if specified in Content-Type
         params = self[:content_type].parameters rescue nil
-        @charset = params && params[:charset]
+        @charset = params[:charset] if params && params[:charset]
       end
     end
     

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -52,6 +52,12 @@ describe Mail::Header do
       header['content-type'] = 'text/plain; charset=utf-8'
       header.charset.should eq 'utf-8'
     end
+
+    it "should not unset previously set charset if content-type is set without charset" do
+      header = Mail::Header.new(nil, 'utf-8')
+      header['content-type'] = 'text/plain'
+      header.charset.should eq 'utf-8'
+    end
     
     it "shouldn't die when queried for a charset and the content-type header is invalid" do
       header = Mail::Header.new


### PR DESCRIPTION
`m = Mail.new { text_part { body 'hi'}; from "你好 <y@q.com>" }`
results in a bad "From" address (when you do puts m.encoded)
but `m = Mail.new { from "你好 <y@q.com>"; text_part { body 'hi'} }` works fine

Discovered that `header["content-type"] = "text/plain"` will reset the header's charset even if it were previously set to utf-8.

This pull request fixes this issue.

Tested on
ruby-1.8.7-p352 [ i686 ]
ruby-1.9.2-p290 [ x86_64 ]
ruby-1.9.3-p432 [ x86_64 ]
