### PR TITLE
Fixing exception on poorly encoded subject header

### DIFF
--- a/lib/mail/fields/unstructured_field.rb
+++ b/lib/mail/fields/unstructured_field.rb
@@ -146,7 +146,7 @@ module Mail
         line = ""
         while !words.empty?
           break unless word = words.first.dup
-          word.encode!(charset) if charset && word.respond_to?(:encode!)
+          word.encode!(charset, :invalid => :replace, :undef => :replace) if charset && word.respond_to?(:encode!)
           word = encode(word) if should_encode
           word = encode_crlf(word)
           # Skip to next line if we're going to go past the limit

--- a/lib/mail/version_specific/ruby_1_8.rb
+++ b/lib/mail/version_specific/ruby_1_8.rb
@@ -112,7 +112,14 @@ module Mail
       when 'UTF32', 'UTF-32'
         'UTF-32BE'
       else
-        encoding
+        # If no encoding matches, return plain string, but only if encoding is known to Iconv, 
+        # else fallback to ASCII
+        begin
+          Iconv.new('UTF-8', encoding)
+          encoding
+        rescue Iconv::InvalidEncoding => e
+          'ASCII'
+        end
       end
     end
   end

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -137,11 +137,13 @@ module Mail
         Encoding::GB18030
 
       else
+        # if nothing found return the plain string but only if Encoding can handle it.
+        # If not, fall back to ASCII.
         begin 
           Encoding.find(charset)
           charset
         rescue ArgumentError
-          Encoding::ASCII_8BIT
+          Encoding::ASCII
         end
       end
     end

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -137,7 +137,12 @@ module Mail
         Encoding::GB18030
 
       else
-        charset
+        begin 
+          Encoding.find(charset)
+          charset
+        rescue ArgumentError
+          Encoding::ASCII_8BIT
+        end
       end
     end
   end

--- a/spec/fixtures/emails/error_emails/bad_encoded_subject.eml
+++ b/spec/fixtures/emails/error_emails/bad_encoded_subject.eml
@@ -1,0 +1,3 @@
+Subject: =?NONE?B?VEVTVA=?=
+
+TEST

--- a/spec/fixtures/emails/error_emails/invalid_subject_characters.eml
+++ b/spec/fixtures/emails/error_emails/invalid_subject_characters.eml
@@ -1,0 +1,5 @@
+From: "=?Windows-1252?B?Rm9ybWHn428gRnJlbmV0aWtwb2xpcw==?=" <info@formacaofrenetik.info>
+To: martin@internet.ao, iris@internet.ao, support@maxnet.ao
+Subject: Formação FrenetikPolis: Mega Campanha Final Verão | Cursos de Setembro
+
+TEST

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -153,6 +153,12 @@ describe Mail::Encodings do
       string = "1+1=?"
       Mail::Encodings.value_decode(string).should == string
     end
+    
+    it "should decode a string, even with an invalid encoding name" do
+      string = "=?BAD-ENCODING?B?VEVTVA==?="
+      result = 'TEST'
+      Mail::Encodings.value_decode(string).should == result
+    end
 
     if '1.9'.respond_to?(:force_encoding)
       it "should decode 8bit encoded string" do

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -323,5 +323,12 @@ describe "Test emails" do
     end
 
   end
-
+  
+  describe "invalid encodings in subject" do
+    it "Mail::Message.encoded  should not raise anything on bad headers" do
+      mail = Mail.read(fixture('emails', 'error_emails', 'invalid_subject_characters.eml'))
+      x = mail.encoded rescue false
+    end
+  end      
+ 
 end

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -555,10 +555,10 @@ TRACEHEADER
     end
 
     if '1.9'.respond_to?(:force_encoding)
-      it "should blow up on encoding mismatches" do
+      it "should not blow up on encoding mismatches" do
         junk = "Subject: \xAF".force_encoding(Encoding::ASCII_8BIT)
         header = Mail::Header.new(junk, 'utf-8')
-        doing { header.encoded }.should raise_error
+        doing { header.encoded }.should_not raise_error
       end
     end
   end


### PR DESCRIPTION
This fixes the unknown encoding crash as described:
  https://github.com/mikel/mail/issues/544
