### PR TITLE
Use nil for nil-date

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -589,7 +589,11 @@ module Mail
     end
 
     def date( val = nil )
-      default :date, val
+      if val
+        default :date, val
+      else
+        nil
+      end
     end
 
     def date=( val )


### PR DESCRIPTION
With a 'nil' for date value, date parsing fails and message loading stops.
