### PR TITLE
Set body's charset based on message

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1512,6 +1512,7 @@ module Mail
       @defaulted_charset = false
       @charset = value
       @header.charset = value
+      @body.charset = value
     end
 
     # Returns the main content type
@@ -2008,7 +2009,7 @@ module Mail
       raw_string = raw_source.to_s
       if match_data = raw_source.to_s.match(/\AFrom\s(#{TEXT}+)#{CRLF}/m)
         set_envelope(match_data[1])
-        self.raw_source = raw_string.sub(match_data[0], "") 
+        self.raw_source = raw_string.sub(match_data[0], "")
       end
     end
 
@@ -2017,6 +2018,7 @@ module Mail
     end
 
     def add_encoding_to_body
+      @body.charset = charset
       if has_content_transfer_encoding?
         @body.encoding = content_transfer_encoding
       end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1128,6 +1128,20 @@ describe Mail::Message do
           mail.to_s =~ %r{Content-Type: text/plain;\r\n}
         end
 
+        it "should set the body charset with the message charset" do
+          mail = Mail.new
+          mail.body = "This is plain text"
+          mail.charset = "iso-2022-jp"
+          mail.body.charset.should eq "iso-2022-jp"
+        end
+
+        it "should set the body charset with the message charset even if the body is not specified" do
+          mail = Mail.new
+          mail.body = nil
+          mail.charset = "iso-2022-jp"
+          mail.body.charset.should eq "iso-2022-jp"
+        end
+
         it "should raise a warning if there is no content type and there is non ascii chars and default to text/plain, UTF-8" do
           body = "This is NOT plain text ASCII　− かきくけこ"
           mail = Mail.new
@@ -1293,6 +1307,14 @@ describe Mail::Message do
 
       it 'should not strip the raw mail source in case the trailing \r\n is meaningful' do
         Mail.new("Content-Transfer-Encoding: quoted-printable;\r\n\r\nfoo=\r\nbar=\r\nbaz=\r\n").decoded.should eq 'foobarbaz'
+      end
+
+      it 'should change a body on encode if given a charset' do
+        mail = Mail.new
+        mail.charset = 'iso-2022-jp'
+        mail.body = "あいうえお\n"
+        expect = (RUBY_VERSION < '1.9') ? "あいうえお\r\n" : "\e$B$\"$$$&$($*\e(B\r\n"
+        mail.body.encoded.should eq expect
       end
 
     end


### PR DESCRIPTION
This adds the ability to set body's charset through message. Experienced this issue while using ActionMailer with custom charset: body is getting encoded in config's default charset, but decoded to a custom one and this results in unreadable email's body.
