### PR TITLE
Do not attempt to collapse broken encodings in fields

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -290,7 +290,7 @@ module Mail
       lines.each do |line|
         encoding = split_value_encoding_from_string(line)
 
-        if encoding == previous_encoding
+        if encoding && encoding == previous_encoding
           line = results.pop + line
         end
 

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -160,6 +160,11 @@ describe Mail::Encodings do
       Mail::Encodings.value_decode(string).should == result
     end
 
+    it "should not collapse encoded pieces with broken encodings" do
+      string = "=?utf-8?iB?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?=\n =?utf-8?B?0LXQtdCy?="
+      Mail::Encodings.value_decode(string).should == "=?utf-8?iB?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?=еев"
+    end
+
     it "should parse adjacent words with no space" do
       string = "=?utf-8?B?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?==?utf-8?B?0LXQtdCy?="
       result = "новый сотрудник — дорофеев"


### PR DESCRIPTION
Without this strings with broken encodings will raise an exception in `Encodings.collapse_adjacent_encodings:` `NoMethodError: undefined method`+' for nil:NilClass`
