### PR TITLE
Parsing message_ids that have a comment.

### DIFF
--- a/lib/mail/parsers/message_ids_parser.rb
+++ b/lib/mail/parsers/message_ids_parser.rb
@@ -25,7 +25,8 @@ module Mail::Parsers
         when :domain_e, :domain_s, :local_dot_atom_e,
           :local_dot_atom_pre_comment_e,
           :local_dot_atom_pre_comment_s,
-          :local_dot_atom_s
+          :local_dot_atom_s,
+          :comment_s, :comment_e
 
           # ignored actions
 

--- a/spec/mail/parsers/message_ids_parser_spec.rb
+++ b/spec/mail/parsers/message_ids_parser_spec.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe "MessageIdsParser" do
+  it "should not fail to parse a message id with comments" do
+    text = '<8167EB1E991646B3@mx.smtp.test.de> (added by postmaster@test.com)'
+    expect {
+      Mail::Parsers::MessageIdsParser.new.parse(text)
+    }.to_not raise_error
+  end
+end


### PR DESCRIPTION
Some SMTP servers like to add comments after message ids.
like 8167EB1E991646B3@mx.smtp.test.de (added by postmaster@test.com)
