### PR TITLE
Access message parts via IMAP's part specifiers

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1955,6 +1955,24 @@ module Mail
       has_content_type? ? !!(main_type =~ /^text$/i) : false
     end
 
+    # Returns the part of the body as described by the IMAP part specifier in
+    # RFC 3501 section 6.4.5 (in the section about the BODY command). Only the
+    # numeric part specifiers are supported.
+    def body_section(part_specifier)
+      return self if parts.empty? && part_specifier == '1'
+
+      part = self
+      exploded_specifier = part_specifier.split('.')
+
+      exploded_specifier.each do |specifier|
+        break if part.nil?
+
+        part = part.parts[specifier.to_i - 1]
+      end
+
+      part
+    end
+
   private
 
     #  2.1. General Description

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1853,6 +1853,7 @@ describe Mail::Message do
 
       it "returns the appropriate part when given a valid part specifier" do
         nested_email.body_section('1.2').content_type.should eq 'text/html'
+        nested_email.body_section('1.2').body.should eq '<p>html</p>'
       end
 
       it "returns nil when given an out-of-bounds part specifier" do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1831,4 +1831,62 @@ describe Mail::Message do
     end
   end
 
+  describe 'body section' do
+    context 'with a nested message' do
+      let(:nested_email) do
+        Mail::Message.new do
+          add_part(
+            Mail::Part.new do
+              text_part do
+                body 'text'
+              end
+
+              html_part do
+                body '<p>html</p>'
+              end
+            end
+          )
+
+          add_file :filename => 'foo.png', :content => ''
+        end
+      end
+
+      it "returns the appropriate part when given a valid part specifier" do
+        nested_email.body_section('1.2').content_type.should eq 'text/html'
+      end
+
+      it "returns nil when given an out-of-bounds part specifier" do
+        nested_email.body_section('1.5').should be_nil
+      end
+
+      it "returns nil when given a part specification for a non-existent part" do
+        nested_email.body_section('1.5.1').should be_nil
+      end
+
+      it "returns nil when given a too-long part specification" do
+        nested_email.body_section('1.1.1.1.1.1').should be_nil
+      end
+    end
+
+    context 'with a flat message' do
+      let(:flat_email) do
+        Mail::Message.new do
+          content_type 'text/plain'
+          body 'text'
+        end
+      end
+
+      it "returns the message when given '1' as a part specifier" do
+        flat_email.body_section('1').should eq flat_email
+      end
+
+      it "returns nil for any other specifier" do
+        flat_email.body_section('5').should be_nil
+      end
+
+      it "returns nil when given a too-long part specification" do
+        flat_email.body_section('1.1.1.1.1.1').should be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
In RFC 3501, it talks about how you can request just a specific part of a message using numbers separated by dots. So '1.2.1' would get the first part of the second part of the first part. For messages that aren't multipart '1' means the message its self. I thought it would be handy to have a way to fetch message parts by the specifier, so I wrote a test and an implementation.

Is this something people are interested in? Does the code style and testing methodology look right in the larger context of the project? Should I be raising `ArgumentError` instead of returning `nil` in the places where I currently do so?
