### PR TITLE
return header fields if Message#headers called without argument

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -424,8 +424,12 @@ module Mail
 
     # Provides a way to set custom headers, by passing in a hash
     def headers(hash = {})
-      hash.each_pair do |k,v|
-        header[k] = v
+      if hash.empty?
+        self.header_fields
+      else
+        hash.each_pair do |k,v|
+          header[k] = v
+        end
       end
     end
 
@@ -2008,7 +2012,7 @@ module Mail
       raw_string = raw_source.to_s
       if match_data = raw_source.to_s.match(/\AFrom\s(#{TEXT}+)#{CRLF}/m)
         set_envelope(match_data[1])
-        self.raw_source = raw_string.sub(match_data[0], "") 
+        self.raw_source = raw_string.sub(match_data[0], "")
       end
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -371,6 +371,10 @@ describe Mail::Message do
         @mail.header_fields.length.should eq 0
       end
 
+      it "should return header fields if headers is called with no argument" do
+        @mail.headers.should eq @mail.header_fields
+      end
+
     end
 
     describe "with :method=" do


### PR DESCRIPTION
Recently I had to parse specific headers from an incoming email and was "surprised" at the behavior of the `Message#headers` method.

This small change aligns the api of `headers` so that it behaves similarly to the `header` method: if no argument is passed to headers, return the header fields.
