### PR TITLE
Fix forgot to replace at 702b306886bae732f2c6c15860320e20143b0059

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2006,7 +2006,7 @@ module Mail
 
     def set_envelope_header
       raw_string = raw_source.to_s
-      if match_data = raw_source.to_s.match(/\AFrom\s(#{TEXT}+)#{CRLF}/m)
+      if match_data = raw_string.match(/\AFrom\s(#{TEXT}+)#{CRLF}/m)
         set_envelope(match_data[1])
         self.raw_source = raw_string.sub(match_data[0], "") 
       end


### PR DESCRIPTION
This fixes the commit 702b306886bae732f2c6c15860320e20143b0059 to forget to replace a `raw_source.to_s` with `raw_string`.
