### PR TITLE
don't raise an exception when processing emails with UTF-7

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -56,8 +56,8 @@ module Mail
         str = Ruby19.decode_base64(match[2])
         str.force_encoding(pick_encoding(charset))
       end
-      decoded = str.encode("utf-8", :invalid => :replace, :replace => "")
-      decoded.valid_encoding? ? decoded : decoded.encode("utf-16le", :invalid => :replace, :replace => "").encode("utf-8")
+      decoded = str.encode("utf-8", :invalid => :replace, :undef => :replace, :replace => "")
+      decoded.valid_encoding? ? decoded : decoded.encode("utf-16le", :invalid => :replace, :undef => :replace, :replace => "").encode("utf-8")
     rescue Encoding::ConverterNotFoundError => err
       return orig_str.force_encoding(Encoding::ASCII_8BIT)
     end

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -203,4 +203,13 @@ describe "mail encoding" do
     end
     m.subject.should eq "=?unicode-1-1-utf-7?B?K2tVMVA0WEsyWVV1UUduZmwtICAoK01LZ3c2VEQ4LSk=?="
   end
+
+  it "shouldn't fail with unconvertable chars" do
+    m = Mail.new
+    m['Subject'] = Mail::SubjectField.new("=?iso-2022-jp?B?GyRCOVY6Qi0iIVshISF6Nls1XjMrOkUheiFWQmdOLjlUGyhC?=")
+    if RUBY_VERSION > '1.9'
+      lambda { m.subject.should be_valid_encoding }.should_not raise_error
+    end
+    m.subject.should eq "講座】　★緊急開催★「大流行"
+  end
 end


### PR DESCRIPTION
When processing UTF-7 encoded emails (bounces from hotmail for instance), mail raises an exception.

This patch changes the behaviour to not raise an exception but simply keep the encoded string instead.
