### PR TITLE
Handle invalid date in Received header

### DIFF
--- a/lib/mail/elements/received_element.rb
+++ b/lib/mail/elements/received_element.rb
@@ -7,7 +7,12 @@ module Mail
     def initialize( string )
       parser = Mail::ReceivedParser.new
       if tree = parser.parse(string)
-        @date_time = ::DateTime.parse("#{tree.date_time.date.text_value} #{tree.date_time.time.text_value}")
+        begin
+          @date_time = ::DateTime.parse("#{tree.date_time.date.text_value} #{tree.date_time.time.text_value}")
+        rescue ArgumentError => ex
+          @date_time = nil
+          raise ex unless ex.message == "invalid date"
+        end
         @info = tree.name_val_list.text_value
       else
         raise Mail::Field::ParseError.new(ReceivedElement, string, parser.failure_reason)

--- a/lib/mail/fields/received_field.rb
+++ b/lib/mail/fields/received_field.rb
@@ -44,7 +44,7 @@ module Mail
     end
     
     def date_time
-      @datetime ||= ::DateTime.parse("#{element.date_time}")
+      @datetime ||= element.date_time
     end
 
     def info

--- a/spec/mail/fields/received_field_spec.rb
+++ b/spec/mail/fields/received_field_spec.rb
@@ -52,5 +52,13 @@ describe Mail::ReceivedField do
     t.decoded.should eq ''
     t.encoded.should eq "Received: \r\n"
   end
-  
+
+  it "should handle invalid date" do
+    t = Mail::ReceivedField.new('Received: from mail.example.com (192.168.1.1) by mail.example.com with (esmtp) id (qid) for <foo@example.com>; Mon, 29 Jul 2013 25:12:46 +0900')
+    t.name.should eq 'Received'
+    t.value.should eq 'from mail.example.com (192.168.1.1) by mail.example.com with (esmtp) id (qid) for <foo@example.com>; Mon, 29 Jul 2013 25:12:46 +0900'
+    t.info.should eq 'from mail.example.com (192.168.1.1) by mail.example.com with (esmtp) id (qid) for <foo@example.com>'
+    t.date_time.should eq nil
+  end
+
 end


### PR DESCRIPTION
Raise ArgumentError If invalid date in Received header.
On the other hand, nothing raised if invalid date in Date header.
So I think mail library should not raise ArgumentError if invalid date in Received header.

This patch can improve robustness.
I created this patch for 2-5-stable branch but it may be applied for master.
(I have not checked for master yet.)

Thanks!

Related issues: #564, #216
