### PR TITLE
Handle invalid date for robustness

### DIFF
--- a/lib/mail/elements/received_element.rb
+++ b/lib/mail/elements/received_element.rb
@@ -8,9 +8,14 @@ module Mail
     include Mail::Utilities
     attr_reader :date_time, :info
 
-    def initialize(string)
+    def initialize( string )
       received = Mail::Parsers::ReceivedParser.parse(string)
-      @date_time = ::DateTime.parse("#{received.date} #{received.time}")
+      begin
+        @date_time = ::DateTime.parse("#{received.date} #{received.time}")
+      rescue ArgumentError => e
+        raise e unless e.message == "invalid date"
+        @date_time = nil
+      end
       @info = received.info
     end
 

--- a/lib/mail/fields/common/common_date.rb
+++ b/lib/mail/fields/common/common_date.rb
@@ -5,6 +5,8 @@ module Mail
     # Returns a date time object of the parsed date
     def date_time
       ::DateTime.parse("#{element.date_string} #{element.time_string}")
+    rescue ArgumentError => e
+      raise e unless e.message == "invalid date"
     end
 
     def default

--- a/lib/mail/fields/date_field.rb
+++ b/lib/mail/fields/date_field.rb
@@ -39,11 +39,13 @@ module Mail
       else
         value = strip_field(FIELD_NAME, value)
         value.to_s.gsub!(/\(.*?\)/, '')
-        value = ::DateTime.parse(value.to_s.squeeze(" ")).strftime('%a, %d %b %Y %H:%M:%S %z')
+        begin
+          value = ::DateTime.parse(value.to_s.squeeze(" ")).strftime('%a, %d %b %Y %H:%M:%S %z')
+        rescue ArgumentError => e
+          raise e unless e.message == "invalid date"
+        end
       end
       super(CAPITALIZED_FIELD, value, charset)
-    rescue ArgumentError => e
-      raise e unless "invalid date"==e.message
     end
 
     def encoded

--- a/lib/mail/fields/received_field.rb
+++ b/lib/mail/fields/received_field.rb
@@ -45,7 +45,7 @@ module Mail
     end
     
     def date_time
-      @datetime ||= ::DateTime.parse("#{element.date_time}")
+      @datetime ||= element.date_time
     end
 
     def info

--- a/spec/mail/fields/date_field_spec.rb
+++ b/spec/mail/fields/date_field_spec.rb
@@ -74,7 +74,13 @@ describe Mail::DateField do
       expect(DateTime).to receive(:now).at_least(:once).and_return(now)
       expect(Mail::DateField.new.date_time).to eq ::DateTime.parse(now.to_s)
     end
-    
+
+    it "should handle invalid date" do
+      t = nil
+      doing { t = Mail::DateField.new("12 Aug 2009 30:00:02 GMT") }.should_not raise_error
+      t.date_time.should eq nil
+    end
+
   end
 
 end

--- a/spec/mail/fields/received_field_spec.rb
+++ b/spec/mail/fields/received_field_spec.rb
@@ -53,5 +53,13 @@ describe Mail::ReceivedField do
     expect(t.decoded).to eq ''
     expect(t.encoded).to eq "Received: \r\n"
   end
-  
+
+  it "should handle invalid date" do
+    t = Mail::ReceivedField.new("Received: mail.example.com (192.168.1.1) by mail.example.com with (esmtp) id (qid)  for <foo@example.com>; Mon, 29 Jul 2013 25:12:46 +0900")
+    t.name.should eq "Received"
+    t.value.should eq "mail.example.com (192.168.1.1) by mail.example.com with (esmtp) id (qid)  for <foo@example.com>; Mon, 29 Jul 2013 25:12:46 +0900"
+    t.info.should eq "mail.example.com (192.168.1.1) by mail.example.com with (esmtp) id (qid)  for <foo@example.com>"
+    t.date_time.should eq nil
+  end
+
 end


### PR DESCRIPTION
This PR can improve robustness for parsing mail that have invalid date in Date and Received header.

This PR can also fix #564.
