### PR TITLE
Body#split! fixed to not raise error in case missing boundary

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -257,7 +257,7 @@ module Mail
     
     def split!(boundary)
       self.boundary = boundary
-      parts = raw_source.split(/(?:\A|\r\n)--#{Regexp.escape(boundary)}(?=(?:--)?\s*$)/)
+      parts = raw_source.split(/(?:\A|\r\n)--#{Regexp.escape(boundary || "")}(?=(?:--)?\s*$)/)
       # Make the preamble equal to the preamble (if any)
       self.preamble = parts[0].to_s.strip
       # Make the epilogue equal to the epilogue (if any)

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -118,7 +118,6 @@ describe Mail::Body do
   end
 
   describe "splitting up a multipart document" do
-
     it "should store the boundary passed in" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
@@ -199,6 +198,12 @@ describe Mail::Body do
       new_body.split!('------=_MIMEPART')
       new_body.parts.length.should eq 2
       new_body.preamble.should eq "this is some text"
+    end
+
+    it "should split if boundary is not set" do
+      multipart_body = "\n\n--\nDate: Thu, 01 Aug 2013 15:14:20 +0100\nMime-Version: 1.0\nContent-Type: text/plain\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment;\n filename=\"\"\nContent-ID: <51fa6d3cac796_d84e3fe5a58349e025683@local.mail>\n\n\n\n----"
+      body = Mail::Body.new(multipart_body)
+      doing { body.split!(nil) }.should_not raise_error
     end
 
   end


### PR DESCRIPTION
When multipart email has no boundary specified in Content-Type header Body#split! raises `TypeError`:

```
can't convert NilClass to String
```

This behavior was introduced in PR #380. Prior to this parts were split like this:

```
parts = raw_source.split("--#{boundary}")
```

In this case `nil` boundary is ok.
But after PR #380 it looks like this:

```
parts = raw_source.split(/--#{Regexp.escape(boundary)}(?=(?:--)?\s*$)/)
```

Which, in case `nil` boundary causes `TypeError`
