### PR TITLE
Fix NoMethodError in Part#inline? when Content-Dispostion header can't be parsed.

### DIFF
--- a/lib/mail/part.rb
+++ b/lib/mail/part.rb
@@ -34,7 +34,7 @@ module Mail
     end
     
     def inline?
-      header[:content_disposition].disposition_type == 'inline' if header[:content_disposition]
+      header[:content_disposition].disposition_type == 'inline' if header[:content_disposition] rescue false
     end
     
     def add_required_fields

--- a/spec/mail/part_spec.rb
+++ b/spec/mail/part_spec.rb
@@ -168,4 +168,8 @@ ENDPART
     part.to_s.should match(/^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/)
   end
 
+  it "should not fail on invalid byte sequence in content-disposition header" do
+    part = Mail::Part.new("Content-Disposition: inline; filename=a\xB8z\r\n\r\nThis is the body text.")
+    doing { part.inline? }.should_not raise_error
+  end
 end


### PR DESCRIPTION
Invalid byte sequence in Content-Disposition field make it parse as UnstructuredField.  Later, then someone calls Part.inline? (like Message#ready_to_send! does via Part#add_required_fiels) it can fail with NoMethodError on call to `disposition_type.'
