### PR TITLE
Stop to join B-encoded lines

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -279,9 +279,9 @@ module Mail
     end
 
     # When the encoded string consists of multiple lines, lines with the same
-    # encoding (Q or B) can be joined together.
+    # Q encoding can be joined together.
     #
-    # String has to be of the format =?<encoding>?[QB]?<string>?=
+    # String has to be of the format =?<encoding>?Q?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
       lines = str.split(/(\?=)\s*(=\?)/).each_slice(2).map(&:join)
       results = []
@@ -292,7 +292,7 @@ module Mail
 
         if encoding == previous_encoding
           line = results.pop + line
-          line.gsub!(/\?\=\=\?.+?\?[QqBb]\?/m, '')
+          line.gsub!(/\?\=\=\?.+?\?Q\?/mi, '')
         end
 
         previous_encoding = encoding

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -137,6 +137,13 @@ describe Mail::Encodings do
       Mail::Encodings.value_decode(string).should eq result
     end
 
+    it "should decode a encoded string in multiple parts" do
+      string = '=?UTF-8?B?5LuK5pel44GvQQ==?= =?UTF-8?B?44GV44KI44GG44Gq44KJQg==?='
+      result = "今日はAさようならB"
+      result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
+      Mail::Encodings.value_decode(string).should eq result
+    end
+
     it "should decode UTF-16 encoded string" do
       string = "=?UTF-16?B?MEIwRDBGMEgwSg==?="
       result = "あいうえお"


### PR DESCRIPTION
Hello.
It looks to me as though 'mail' have a bug in its decoding argorithm for B-encodeed string.

Q-encoded strings can be able to concatenate before decode them.
Otherwise, B-encoded strings do not hold this property.

However, B-encoded strings were wrongly joined
in Mail::Encodings.collapse_adjacent_encodings.

If my notion is not wrong.
Could you merge my fix?

thanks.
