### PR TITLE
Stable sort method for parts list

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -127,9 +127,9 @@ module Mail
     def sort_parts!
       @parts.each do |p|
         p.body.set_sort_order(@part_sort_order)
-        @parts.sort!(@part_sort_order)
         p.body.sort_parts!
       end
+      @parts.sort!(@part_sort_order)
     end
     
     # Returns the raw source that the body was initialized with, without

--- a/lib/mail/parts_list.rb
+++ b/lib/mail/parts_list.rb
@@ -31,11 +31,13 @@ module Mail
     end
 
     def sort!(order)
-      sorted = self.sort do |a, b|
+      # stable sort should be used to maintain the relative order as the parts are added
+      i = 0;
+      sorted = self.sort_by do |a|
         # OK, 10000 is arbitrary... if anyone actually wants to explicitly sort 10000 parts of a
         # single email message... please show me a use case and I'll put more work into this method,
         # in the meantime, it works :)
-        get_order_value(a, order) <=> get_order_value(b, order)
+        [get_order_value(a, order), i += 1]
       end
       self.clear
       sorted.each { |p| self << p }

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -336,6 +336,28 @@ describe Mail::Body do
       body.parts[0].parts[2].content_type.should eq "text/html"
     end
 
+    it "should maintain the relative order of the parts with the same content-type as they are added" do
+      body = Mail::Body.new('');
+      body << Mail::Part.new("content-type: text/html\r\nsubject: HTML_1")
+      body << Mail::Part.new("content-type: image/jpeg\r\nsubject: JPGEG_1\r\n\r\nsdkjskjdksjdkjsd")
+      body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text_1")
+      body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched_1")
+      body << Mail::Part.new("content-type: text/html\r\nsubject: HTML_2")
+      body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text_2")
+      body << Mail::Part.new("content-type: image/jpeg\r\nsubject: JPGEG_2\r\n\r\nsdkjskjdksjdkjsd")
+      body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched_2")
+      body.parts.length.should eq 8
+      body.should be_multipart
+      body.sort_parts!
+      body.parts[0].subject.should eq "Plain Text_1"
+      body.parts[1].subject.should eq "Plain Text_2"
+      body.parts[2].subject.should eq "Enriched_1"
+      body.parts[3].subject.should eq "Enriched_2"
+      body.parts[4].subject.should eq "HTML_1"
+      body.parts[5].subject.should eq "HTML_2"
+      body.parts[6].subject.should eq "JPGEG_1"
+      body.parts[7].subject.should eq "JPGEG_2"
+    end
   end
 
   describe "matching" do


### PR DESCRIPTION
Stable sort should be used to maintain the relative order as the parts are added.
And I'm not sure but the following codes seemed a programming mistake to me...

``` ruby
def sort_parts!
  @parts.each do |p|
    p.body.set_sort_order(@part_sort_order)
    @parts.sort!(@part_sort_order)
    p.body.sort_parts!
  end
end
```

Tested against 1.8.7, 1.9.2 and 1.9.3.
Hoping for comments.
