### PR TITLE
Don't try to add charset parameter for non-text types.

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2036,7 +2036,7 @@ module Mail
       add_required_message_fields
       add_multipart_mixed_header    if body.multipart?
       add_content_type              unless has_content_type?
-      add_charset                   unless has_charset?
+      add_charset                   if text? && !has_charset?
       add_content_transfer_encoding unless has_content_transfer_encoding?
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1131,6 +1131,14 @@ describe Mail::Message do
           mail.to_s =~ %r{Content-Type: text/plain;\r\n}
         end
 
+        it "should not set the charset if the content_type is not text" do
+          body = "This is NOT plain text ASCII　− かきくけこ"
+          mail = Mail.new
+          mail.body = body
+          mail.content_type = "image/png"
+          mail.to_s.should_not =~ %r{Content-Type: image/png;\s+charset=UTF-8}
+        end
+
         it "should raise a warning if there is no content type and there is non ascii chars and default to text/plain, UTF-8" do
           body = "This is NOT plain text ASCII　− かきくけこ"
           mail = Mail.new
@@ -1148,6 +1156,16 @@ describe Mail::Message do
           mail.content_transfer_encoding = "8bit"
           STDERR.should_receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
           mail.to_s =~ %r{Content-Type: text/plain; charset=UTF-8}
+        end
+
+        it "should not raise a warning if there is no charset parameter and the content-type is not text" do
+          body = "This is NOT plain text ASCII　− かきくけこ"
+          mail = Mail.new
+          mail.body = body
+          mail.content_type = "image/png"
+          mail.content_transfer_encoding = "8bit"
+          STDERR.should_not_receive(:puts)
+          mail.to_s
         end
 
         it "should not raise a warning if there is a charset defined and there is non ascii chars" do


### PR DESCRIPTION
Non-text/* types, such as multipart/\*, image/\*, and the like often contain non-text content or content containing data of multiple charsets.  Almost all those non-text/* types that can use a character set, such as application/xhtml+xml, can signal this data in-band without the need for an explicit header.

Additionally, the warning about adding a charset in this case is nonsensical for types such as multipart/mixed.  Omit the autogeneration of the charset parameter for non-text/* types.

This has been tested against Ruby 1.8, 1.9.3, and 2.0. In each case, the two new tests fail before the fix and all tests pass afterwards.

This also addresses issue #596.