### PR TITLE
Fix missing .should calls in tests.

### DIFF
--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1117,18 +1117,20 @@ describe Mail::Message do
         end
 
         it "should set the content type to text/plain; charset=us-ascii" do
+          pending
           body = "This is plain text US-ASCII"
           mail = Mail.new
           mail.body = body
-          mail.to_s =~ %r{Content-Type: text/plain; charset=US-ASCII}
+          mail.to_s.should =~ %r{Content-Type: text/plain;\s+charset=US-ASCII}
         end
 
         it "should not set the charset if the file is an attachment" do
+          pending
           body = "This is plain text US-ASCII"
           mail = Mail.new
           mail.body = body
           mail.content_disposition = 'attachment; filename="foo.jpg"'
-          mail.to_s =~ %r{Content-Type: text/plain;\r\n}
+          mail.to_s.should =~ %r{Content-Type: text/plain\r\n}
         end
 
         it "should raise a warning if there is no content type and there is non ascii chars and default to text/plain, UTF-8" do
@@ -1137,7 +1139,7 @@ describe Mail::Message do
           mail.body = body
           mail.content_transfer_encoding = "8bit"
           STDERR.should_receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
-          mail.to_s =~ %r{Content-Type: text/plain; charset=UTF-8}
+          mail.to_s.should =~ %r{Content-Type: text/plain;\s+charset=UTF-8}
         end
 
         it "should raise a warning if there is no charset parameter and there is non ascii chars and default to text/plain, UTF-8" do
@@ -1147,7 +1149,7 @@ describe Mail::Message do
           mail.content_type = "text/plain"
           mail.content_transfer_encoding = "8bit"
           STDERR.should_receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
-          mail.to_s =~ %r{Content-Type: text/plain; charset=UTF-8}
+          mail.to_s.should =~ %r{Content-Type: text/plain;\s+charset=UTF-8}
         end
 
         it "should not raise a warning if there is a charset defined and there is non ascii chars" do


### PR DESCRIPTION
Several of the message tests were missing their .should invocations, resulting in those tests not testing what they should (no pun intended).  Modify these tests to use the proper syntax, fix the regular expressions to match appropriately, and mark the two failing tests as pending.

I adjusted the regular expressions after testing sample fixups for each of the two tests I marked pending. The charset=US-ASCII test fails because the output actually has charset=UTF-8, and the attachment test fails because a charset _is_ generated for attachments. I left them pending because it wasn't clear to me what the correct behavior should be.
