### PR TITLE
Add search_charset option for Mail::IMAP#find

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -66,14 +66,14 @@ module Mail
     #   keys:   are passed as criteria to the SEARCH command.  They can either be a string holding the entire search string, 
     #           or a single-dimension array of search keywords and arguments.  Refer to  [IMAP] section 6.4.4 for a full list
     #           The default is 'ALL'
+    #   search_charset: charset for use search.
     #
     def find(options={}, &block)
       options = validate_options(options)
 
       start do |imap|
         options[:read_only] ? imap.examine(options[:mailbox]) : imap.select(options[:mailbox])
-
-        uids = imap.uid_search(options[:keys])
+        uids = imap.uid_search(options[:keys], options[:search_charset])
         uids.reverse! if options[:what].to_sym == :last
         uids = uids.first(options[:count]) if options[:count].is_a?(Integer)
         uids.reverse! if (options[:what].to_sym == :last && options[:order].to_sym == :asc) ||


### PR DESCRIPTION
Hi.
I want to use IMAP search with utf-8 charset.
But now It cannot.
So I added search_charset option into Mail::IMAP#find.
It works fine.

Thanks.
