### PR TITLE
Relax mime-types requirement to allow v2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "mime-types", "~> 1.16"
+gem "mime-types", ">= 1.16"
 gem "tlsmail" if RUBY_VERSION <= '1.8.6'
 
 gem 'jruby-openssl', :platform => :jruby

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "CONTRIBUTING.md", "CHANGELOG.rdoc", "TODO.rdoc"]
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 
-  s.add_dependency('mime-types', "~> 1.16")
+  s.add_dependency('mime-types', ">= 1.16")
   s.add_dependency('jruby-openssl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
   s.add_dependency('tlsmail', '~> 0.0.1') if RUBY_VERSION == '1.8.6'
 


### PR DESCRIPTION
This PR fixes #641.

I ran the specs on MRI 2.0.0 on Linux (Fedora 20 x86_64, if it matters) and the spec result is the same for mime-types >~ 1.16 and mime-types >= 1.16 (which resolves to 2.1 on my machine).

The main advantage of this approach, over straight-up moving to 2.0+, is that folks who need MRI 1.8 can still set the mime-types requirement in their Gemfile.

Thank you very much for the mail gem!
Please consider merging this so you can make life easier for folks who need / want mime-types 2!
