### PR TITLE
Relax mime-types requirement to allow v2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "treetop", "~> 1.4.10"
-gem "mime-types", "~> 1.16"
+gem "mime-types", ">= 1.16"
 gem "tlsmail" if RUBY_VERSION <= '1.8.6'
 
 gem 'jruby-openssl', :platform => :jruby

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.md", "CONTRIBUTING.md", "CHANGELOG.rdoc", "TODO.rdoc"]
 
-  s.add_dependency('mime-types', "~> 1.16")
+  s.add_dependency('mime-types', ">= 1.16")
   s.add_dependency('treetop', '~> 1.4.8')
   s.add_dependency('jruby-openssl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
   s.add_dependency('tlsmail', '~> 0.0.1') if RUBY_VERSION == '1.8.6'


### PR DESCRIPTION
This PR fixes #641 for the 2-5-stable.

This has the same reasoning as #661, but it can be used together with Rails, which locks mail to `~> 2.5.4`

Thank you very much for your work on mail!
