### PR TITLE
Upgrade test suite to RSpec's current

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /.idea
 /.rbenv-vars
 /.ruby-version
+/vendor

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('bundler', '>= 1.0.3')
   s.add_development_dependency('rake', '> 0.8.7')
-  s.add_development_dependency('rspec', '~> 2.12.0')
+  s.add_development_dependency('rspec', '~> 2.14.0')
   s.add_development_dependency('rdoc')
 
   s.require_path = 'lib'

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -7,10 +7,10 @@ end
 
 def check_decoded(actual, expected)
   if RUBY_VERSION >= '1.9'
-    actual.encoding.should eq Encoding::BINARY
-    actual.should eq expected.force_encoding(Encoding::BINARY)
+    expect(actual.encoding).to eq Encoding::BINARY
+    expect(actual).to eq expected.force_encoding(Encoding::BINARY)
   else
-    actual.should eq expected
+    expect(actual).to eq expected
   end
 end
 
@@ -24,51 +24,51 @@ describe "Attachments" do
   describe "from direct content" do
     it "should work" do
       @mail.attachments['test.png'] = @test_png
-      @mail.attachments['test.png'].filename.should eq 'test.png'
+      expect(@mail.attachments['test.png'].filename).to eq 'test.png'
       check_decoded(@mail.attachments[0].decoded, @test_png)
     end
 
     it "should work out magically the mime_type" do
       @mail.attachments['test.png'] = @test_png
-      @mail.attachments[0].mime_type.should eq 'image/png'
+      expect(@mail.attachments[0].mime_type).to eq 'image/png'
     end
 
     it "should assign the filename" do
       @mail.attachments['test.png'] = @test_png
-      @mail.attachments[0].filename.should eq 'test.png'
+      expect(@mail.attachments[0].filename).to eq 'test.png'
     end
 
     it "should assign mime-encoded multibyte filename" do
       @mail.attachments['てすと.txt'] = File.open(fixture('attachments', 'てすと.txt'), 'rb', &:read)
-      @mail.attachments.should_not be_blank
-      Mail::Encodings.decode_encode(@mail.attachments[0].filename, :decode).should eq 'てすと.txt'
+      expect(@mail.attachments).not_to be_blank
+      expect(Mail::Encodings.decode_encode(@mail.attachments[0].filename, :decode)).to eq 'てすと.txt'
     end
   end
 
   describe "from a supplied Hash" do
     it "should work" do
       @mail.attachments['test.png'] = { :content => @test_png }
-      @mail.attachments[0].filename.should eq 'test.png'
+      expect(@mail.attachments[0].filename).to eq 'test.png'
       check_decoded(@mail.attachments[0].decoded, @test_png)
     end
 
     it "should allow you to override the content_type" do
       @mail.attachments['test.png'] = { :content => @test_png,
                                         :content_type => "application/x-gzip" }
-      @mail.attachments[0].content_type.should eq 'application/x-gzip'
+      expect(@mail.attachments[0].content_type).to eq 'application/x-gzip'
     end
 
     it "should allow you to override the mime_type" do
       @mail.attachments['test.png'] = { :content => @test_png,
                                         :mime_type => "application/x-gzip" }
-      @mail.attachments[0].mime_type.should eq 'application/x-gzip'
+      expect(@mail.attachments[0].mime_type).to eq 'application/x-gzip'
     end
 
     it "should allow you to override the mime_type" do
       @mail.attachments['invoice.jpg'] = { :data => "you smiling",
                                            :mime_type => "image/x-jpg",
                                            :transfer_encoding => "base64" }
-      @mail.attachments[0].mime_type.should eq 'image/x-jpg'
+      expect(@mail.attachments[0].mime_type).to eq 'image/x-jpg'
     end
 
   end
@@ -78,13 +78,13 @@ describe "Attachments" do
     it "should set its content_transfer_encoding" do
       @mail.attachments['test.png'] = { :content => @test_png }
       @mail.ready_to_send!
-      @mail.attachments[0].content_transfer_encoding.should eq 'base64'
+      expect(@mail.attachments[0].content_transfer_encoding).to eq 'base64'
     end
 
     it "should encode its body to base64" do
       @mail.attachments['test.png'] = { :content => @test_png }
       @mail.ready_to_send!
-      @mail.attachments[0].encoded.should include(encode_base64(@test_png))
+      expect(@mail.attachments[0].encoded).to include(encode_base64(@test_png))
     end
 
     it "should allow you to pass in an encoded attachment with an encoding" do
@@ -97,14 +97,14 @@ describe "Attachments" do
     it "should allow you set a mime type and encoding without overriding the encoding" do
       encoded = encode_base64('<foo/>')
       @mail.attachments['test.png'] = { :mime_type => 'text/xml', :content => encoded, :encoding => 'base64' }
-      @mail.attachments[0].content_transfer_encoding.should eq 'base64'
+      expect(@mail.attachments[0].content_transfer_encoding).to eq 'base64'
       check_decoded(@mail.attachments[0].decoded, '<foo/>')
     end
 
     it "should not allow you to pass in an encoded attachment with an unknown encoding" do
       base64_encoded_data = encode_base64(@test_png)
-      doing {@mail.attachments['test.png'] = { :content => base64_encoded_data,
-                                               :encoding => 'weird_encoding' }}.should raise_error
+      expect(doing {@mail.attachments['test.png'] = { :content => base64_encoded_data,
+                                               :encoding => 'weird_encoding' }}).to raise_error
     end
 
    it "should be able to call read on the attachment to return the decoded data" do
@@ -114,7 +114,7 @@ describe "Attachments" do
       else
         expected = @mail.attachments[0].read
       end
-      expected.should eq @test_png
+      expect(expected).to eq @test_png
     end
 
     it "should only add one newline between attachment body and boundary" do
@@ -122,7 +122,7 @@ describe "Attachments" do
       @mail.attachments['text.txt'] = { :content => contents}
       encoded = @mail.encoded
       regex = /\r\n#{Regexp.escape(contents.gsub(/\n/, "\r\n"))}\r\n--#{@mail.boundary}--\r\n\Z/
-      encoded.should match regex
+      expect(encoded).to match regex
     end
 
   end
@@ -135,10 +135,10 @@ describe "Attachments" do
       mail.attachments['test.gif'] = File.open(fixture('attachments', 'test.gif'), 'rb', &:read)
       mail.attachments['test.jpg'] = File.open(fixture('attachments', 'test.jpg'), 'rb', &:read)
       mail.attachments['test.zip'] = File.open(fixture('attachments', 'test.zip'), 'rb', &:read)
-      mail.attachments[0].filename.should eq 'test.pdf'
-      mail.attachments[1].filename.should eq 'test.gif'
-      mail.attachments[2].filename.should eq 'test.jpg'
-      mail.attachments[3].filename.should eq 'test.zip'
+      expect(mail.attachments[0].filename).to eq 'test.pdf'
+      expect(mail.attachments[1].filename).to eq 'test.gif'
+      expect(mail.attachments[2].filename).to eq 'test.jpg'
+      expect(mail.attachments[3].filename).to eq 'test.zip'
     end
 
   end
@@ -148,21 +148,21 @@ describe "Attachments" do
     it "should set the content_disposition to inline or attachment as appropriate" do
       mail = Mail.new
       mail.attachments['test.pdf'] = File.open(fixture('attachments', 'test.pdf'), 'rb', &:read)
-      mail.attachments['test.pdf'].content_disposition.should eq 'attachment; filename=test.pdf'
+      expect(mail.attachments['test.pdf'].content_disposition).to eq 'attachment; filename=test.pdf'
       mail.attachments.inline['test.png'] = File.open(fixture('attachments', 'test.png'), 'rb', &:read)
-      mail.attachments.inline['test.png'].content_disposition.should eq 'inline; filename=test.png'
+      expect(mail.attachments.inline['test.png'].content_disposition).to eq 'inline; filename=test.png'
     end
 
     it "should return a cid" do
       mail = Mail.new
       mail.attachments.inline['test.png'] = @test_png
-      mail.attachments['test.png'].url.should eq "cid:#{mail.attachments['test.png'].cid}"
+      expect(mail.attachments['test.png'].url).to eq "cid:#{mail.attachments['test.png'].cid}"
     end
 
     it "should respond true to inline?" do
       mail = Mail.new
       mail.attachments.inline['test.png'] = @test_png
-      mail.attachments['test.png'].should be_inline
+      expect(mail.attachments['test.png']).to be_inline
     end
   end
 
@@ -174,17 +174,17 @@ describe "Attachments" do
     end
 
     it "should return a content-id for the attachment on creation if passed inline => true" do
-      @cid.should_not be_nil
+      expect(@cid).not_to be_nil
     end
 
     it "should return a valid content-id on inline attachments" do
-      Mail::ContentIdField.new(@cid).errors.should be_empty
+      expect(Mail::ContentIdField.new(@cid).errors).to be_empty
     end
 
     it "should provide a URL escaped content_id (without brackets) for use inside an email" do
       @inline = @mail.attachments['test.gif'].cid
       uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
-      @inline.should eq uri_parser.escape(@cid.gsub(/^</, '').gsub(/>$/, ''))
+      expect(@inline).to eq uri_parser.escape(@cid.gsub(/^</, '').gsub(/>$/, ''))
     end
   end
 
@@ -193,7 +193,7 @@ describe "Attachments" do
       mail = Mail.new
       mail.attachments['test.pdf'] = File.open(fixture('attachments', 'test.pdf'), 'rb', &:read)
       mail.encoded
-      mail.mime_type.should eq 'multipart/mixed'
+      expect(mail.mime_type).to eq 'multipart/mixed'
     end
 
     it "allows you to set the attachment before the content type" do
@@ -210,12 +210,12 @@ describe "Attachments" do
     it "should not raise an exception with a filename that contains a non-7bit-character" do
       filename = "f\u00f6\u00f6.b\u00e4r"
       if RUBY_VERSION >= '1.9'
-        filename.encoding.should eq Encoding::UTF_8
+        expect(filename.encoding).to eq Encoding::UTF_8
       end
       mail = Mail.new
-      doing {
+      expect(doing {
         mail.attachments[filename] = File.open(fixture('attachments', 'test.pdf'), 'rb', &:read)
-      }.should_not raise_error
+      }).not_to raise_error
     end
   end
 
@@ -226,48 +226,48 @@ describe "reading emails with attachments" do
 
     it "should find the attachment using content location" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_content_location.eml')))
-      mail.attachments.length.should eq 1
+      expect(mail.attachments.length).to eq 1
     end
 
     it "should find an attachment defined with 'name' and Content-Disposition: attachment" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_content_disposition.eml')))
-      mail.attachments.length.should eq 1
+      expect(mail.attachments.length).to eq 1
     end
 
     it "should use the content-type filename or name over the content-disposition filename" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_content_disposition.eml')))
-      mail.attachments[0].filename.should eq 'hello.rb'
+      expect(mail.attachments[0].filename).to eq 'hello.rb'
     end
 
     it "should decode an attachment" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_pdf.eml')))
-      mail.attachments[0].decoded.length.should eq 1026
+      expect(mail.attachments[0].decoded.length).to eq 1026
     end
 
     it "should find an attachment that has an encoded name value" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_with_encoded_name.eml')))
-      mail.attachments.length.should eq 1
+      expect(mail.attachments.length).to eq 1
       result = mail.attachments[0].filename
       if RUBY_VERSION >= '1.9'
         expected = "01 Quien Te Dij\212at. Pitbull.mp3".force_encoding(result.encoding)
       else
         expected = "01 Quien Te Dij\212at. Pitbull.mp3"
       end
-      result.should eq expected
+      expect(result).to eq expected
     end
 
     it "should find an attachment that has a name not surrounded by quotes" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', "attachment_with_unquoted_name.eml")))
-      mail.attachments.length.should eq 1
-      mail.attachments.first.filename.should eq "This is a test.txt"
+      expect(mail.attachments.length).to eq 1
+      expect(mail.attachments.first.filename).to eq "This is a test.txt"
     end
 
     it "should find attachments inside parts with content-type message/rfc822" do
       mail = Mail.read(fixture(File.join("emails",
                                          "attachment_emails",
                                          "attachment_message_rfc822.eml")))
-      mail.attachments.length.should eq 1
-      mail.attachments[0].decoded.length.should eq 1026
+      expect(mail.attachments.length).to eq 1
+      expect(mail.attachments[0].decoded.length).to eq 1026
     end
 
     it "attach filename decoding (issue 83)" do
@@ -302,7 +302,7 @@ YWFhCg==
 limitMAIL
       mail = Mail.new(data)
       #~ puts Mail::Encodings.decode_encode(mail.attachments[0].filename, :decode)
-      mail.attachments[0].filename.should eq "Foto0009.jpg"
+      expect(mail.attachments[0].filename).to eq "Foto0009.jpg"
     end
 
   end
@@ -325,16 +325,16 @@ describe "attachment order" do
     mail.attachments['test.pdf'] = File.open(fixture('attachments', 'test.pdf'), 'rb', &:read)
     mail.attachments['test.gif'] = File.open(fixture('attachments', 'test.gif'), 'rb', &:read)
     mail.attachments['test.jpg'] = File.open(fixture('attachments', 'test.jpg'), 'rb', &:read)
-    mail.attachments[0].filename.should eq 'test.zip'
-    mail.attachments[1].filename.should eq 'test.pdf'
-    mail.attachments[2].filename.should eq 'test.gif'
-    mail.attachments[3].filename.should eq 'test.jpg'
+    expect(mail.attachments[0].filename).to eq 'test.zip'
+    expect(mail.attachments[1].filename).to eq 'test.pdf'
+    expect(mail.attachments[2].filename).to eq 'test.gif'
+    expect(mail.attachments[3].filename).to eq 'test.jpg'
 
 
     mail2 = Mail.new(mail.encoded)
-    mail2.attachments[0].filename.should eq 'test.zip'
-    mail2.attachments[1].filename.should eq 'test.pdf'
-    mail2.attachments[2].filename.should eq 'test.gif'
-    mail2.attachments[3].filename.should eq 'test.jpg'
+    expect(mail2.attachments[0].filename).to eq 'test.zip'
+    expect(mail2.attachments[1].filename).to eq 'test.pdf'
+    expect(mail2.attachments[2].filename).to eq 'test.gif'
+    expect(mail2.attachments[3].filename).to eq 'test.jpg'
   end
 end

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -26,30 +26,30 @@ describe Mail::Body do
   describe "initialization" do
 
     it "should be instantiated" do
-      doing { Mail::Body.new }.should_not raise_error
+      expect(doing { Mail::Body.new }).not_to raise_error
     end
 
     it "should initialize on a nil value" do
-      doing { Mail::Body.new(nil) }.should_not raise_error
+      expect(doing { Mail::Body.new(nil) }).not_to raise_error
     end
 
     it "should accept text as raw source data" do
       body = Mail::Body.new('this is some text')
-      body.to_s.should eq 'this is some text'
+      expect(body.to_s).to eq 'this is some text'
     end
 
     it "should accept nil as a value and return an empty body" do
       body = Mail::Body.new
-      body.to_s.should eq ''
+      expect(body.to_s).to eq ''
     end
 
     it "should accept an array as the body and join it" do
-      doing { Mail::Body.new(["line one\n", "line two\n"]) }.should_not raise_error
+      expect(doing { Mail::Body.new(["line one\n", "line two\n"]) }).not_to raise_error
     end
 
     it "should accept an array as the body and join it" do
       body = Mail::Body.new(["line one\n", "line two\n"])
-      body.encoded.should eq "line one\r\nline two\r\n"
+      expect(body.encoded).to eq "line one\r\nline two\r\n"
     end
 
   end
@@ -58,29 +58,29 @@ describe Mail::Body do
 
     it "should accept text as raw source data" do
       body = Mail::Body.new('this is some text')
-      body.encoded.should eq 'this is some text'
+      expect(body.encoded).to eq 'this is some text'
     end
 
     it "should set its own encoding to us_ascii if it is ascii only body" do
       body = Mail::Body.new('This is some text')
-      body.charset.should eq 'US-ASCII'
+      expect(body.charset).to eq 'US-ASCII'
     end
 
     it "should allow you to set its encoding" do
       body = Mail::Body.new('')
       body.charset = 'UTF-8'
-      body.charset.should eq 'UTF-8'
+      expect(body.charset).to eq 'UTF-8'
     end
 
     it "should allow you to specify an encoding" do
       body = Mail::Body.new('')
       body.encoding = 'base64'
-      body.encoding.should eq 'base64'
+      expect(body.encoding).to eq 'base64'
     end
 
     it "should convert all new lines to crlf" do
       body = Mail::Body.new("This has \n various \r new \r\n lines")
-      body.encoded.should eq "This has \r\n various \r\n new \r\n lines"
+      expect(body.encoded).to eq "This has \r\n various \r\n new \r\n lines"
     end
 
   end
@@ -89,30 +89,30 @@ describe Mail::Body do
 
     it "should convert all new lines to crlf" do
       body = Mail::Body.new("This has \n various \r new \r\n lines")
-      body.decoded.should eq "This has \n various \n new \n lines"
+      expect(body.decoded).to eq "This has \n various \n new \n lines"
     end
 
     it "should not change a body on decode if not given an encoding type to decode" do
       body = Mail::Body.new("The=3Dbody")
-      body.decoded.should eq "The=3Dbody"
+      expect(body.decoded).to eq "The=3Dbody"
     end
 
     it "should change return the raw text if it does not recognise the encoding" do
       body = Mail::Body.new("The=3Dbody")
       body.encoding = '7bit'
-      body.decoded.should eq "The=3Dbody"
+      expect(body.decoded).to eq "The=3Dbody"
     end
 
     it "should change a body on decode if given an encoding type to decode" do
       body = Mail::Body.new("The=3Dbody")
       body.encoding = 'quoted-printable'
-      body.decoded.should eq "The=body"
+      expect(body.decoded).to eq "The=body"
     end
 
     it "should change a body on decode if given an encoding type to decode" do
       body = Mail::Body.new("VGhlIGJvZHk=\n")
       body.encoding = 'base64'
-      body.decoded.should eq "The body"
+      expect(body.decoded).to eq "The body"
     end
 
   end
@@ -122,56 +122,56 @@ describe Mail::Body do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.boundary.should eq '----=_Part_2192_32400445'
+      expect(body.boundary).to eq '----=_Part_2192_32400445'
     end
 
     it "should split at the boundry string given returning two message bodies" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
-      body.split!('----=_Part_2192_32400445').parts.length.should eq 2
+      expect(body.split!('----=_Part_2192_32400445').parts.length).to eq 2
     end
 
     it "should keep the preamble text as its own preamble" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.preamble.should eq "this is some text"
+      expect(body.preamble).to eq "this is some text"
     end
 
     it "should return the parts as their own messages" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.parts[0].class.should eq Mail::Part
-      body.parts[1].class.should eq Mail::Part
+      expect(body.parts[0].class).to eq Mail::Part
+      expect(body.parts[1].class).to eq Mail::Part
     end
 
     it "should return the first part as its own message" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.parts[0].content_type.should eq "text/plain; charset=ISO-8859-1"
+      expect(body.parts[0].content_type).to eq "text/plain; charset=ISO-8859-1"
     end
 
     it "should return the first part as its own message" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.parts[1].content_type.should eq "text/html"
+      expect(body.parts[1].content_type).to eq "text/html"
     end
 
     it "should separate out its parts" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.should be_multipart
+      expect(body).to be_multipart
     end
 
     it "should keep track of its parts" do
       multipart_body = "this is some text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/plain; charset=ISO-8859-1\r\n\r\nThis is a plain text\r\n\r\n------=_Part_2192_32400445\r\nContent-Type: text/html\r\n\r\n<p>This is HTML</p>\r\n------=_Part_2192_32400445--\r\n"
       body = Mail::Body.new(multipart_body)
       body.split!('----=_Part_2192_32400445')
-      body.parts.length.should eq 2
+      expect(body.parts.length).to eq 2
     end
 
     it "should round trip its parts" do
@@ -182,11 +182,11 @@ describe Mail::Body do
       body.epilogue = "And this is the end"
       new_body = Mail::Body.new(body.encoded)
       new_body.split!('----=_Part_2192_32400445')
-      new_body.parts.length.should eq 2
-      new_body.parts[0].decoded.should eq "This is a plain text\n"
-      new_body.parts[1].decoded.should eq "<p>This is HTML</p>"
-      new_body.preamble.should eq "Really! this is some text"
-      new_body.epilogue.should eq "And this is the end"
+      expect(new_body.parts.length).to eq 2
+      expect(new_body.parts[0].decoded).to eq "This is a plain text\n"
+      expect(new_body.parts[1].decoded).to eq "<p>This is HTML</p>"
+      expect(new_body.preamble).to eq "Really! this is some text"
+      expect(new_body.epilogue).to eq "And this is the end"
     end
 
     it "should allow you to change the boundary" do
@@ -196,14 +196,14 @@ describe Mail::Body do
       body.boundary = '------=_MIMEPART'
       new_body = Mail::Body.new(body.encoded)
       new_body.split!('------=_MIMEPART')
-      new_body.parts.length.should eq 2
-      new_body.preamble.should eq "this is some text"
+      expect(new_body.parts.length).to eq 2
+      expect(new_body.preamble).to eq "this is some text"
     end
 
     it "should split if boundary is not set" do
       multipart_body = "\n\n--\nDate: Thu, 01 Aug 2013 15:14:20 +0100\nMime-Version: 1.0\nContent-Type: text/plain\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment;\n filename=\"\"\nContent-ID: <51fa6d3cac796_d84e3fe5a58349e025683@local.mail>\n\n\n\n----"
       body = Mail::Body.new(multipart_body)
-      doing { body.split!(nil) }.should_not raise_error
+      expect(doing { body.split!(nil) }).not_to raise_error
     end
 
   end
@@ -211,17 +211,17 @@ describe Mail::Body do
   describe "detecting non ascii" do
     it "should say an empty string is all ascii" do
       body = Mail::Body.new
-      body.should be_only_us_ascii
+      expect(body).to be_only_us_ascii
     end
 
     it "should say if a body is ascii" do
       body = Mail::Body.new('This is ASCII')
-      body.should be_only_us_ascii
+      expect(body).to be_only_us_ascii
     end
 
     it "should say if a body is not ascii" do
       body = Mail::Body.new("This is NOT plain text ASCII　− かきくけこ")
-      body.should_not be_only_us_ascii
+      expect(body).not_to be_only_us_ascii
     end
   end
 
@@ -229,8 +229,8 @@ describe Mail::Body do
     it "should allow you to add a part" do
       body = Mail::Body.new('')
       body << Mail::Part.new('')
-      body.parts.length.should eq 1
-      body.should be_multipart
+      expect(body.parts.length).to eq 1
+      expect(body).to be_multipart
     end
 
     it "should allow you to sort the parts" do
@@ -238,12 +238,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/html\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched")
-      body.parts.length.should eq 3
-      body.should be_multipart
+      expect(body.parts.length).to eq 3
+      expect(body).to be_multipart
       body.sort_parts!
-      body.parts[0].content_type.should eq "text/plain"
-      body.parts[1].content_type.should eq "text/enriched"
-      body.parts[2].content_type.should eq "text/html"
+      expect(body.parts[0].content_type).to eq "text/plain"
+      expect(body.parts[1].content_type).to eq "text/enriched"
+      expect(body.parts[2].content_type).to eq "text/html"
     end
 
     it "should allow you to sort the parts with an arbitrary sort order" do
@@ -252,12 +252,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/html\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched")
-      body.parts.length.should eq 3
-      body.should be_multipart
+      expect(body.parts.length).to eq 3
+      expect(body).to be_multipart
       body.sort_parts!
-      body.parts[0].content_type.should eq "text/plain"
-      body.parts[1].content_type.should eq "text/html"
-      body.parts[2].content_type.should eq "text/enriched"
+      expect(body.parts[0].content_type).to eq "text/plain"
+      expect(body.parts[1].content_type).to eq "text/html"
+      expect(body.parts[2].content_type).to eq "text/enriched"
     end
 
     it "should allow you to sort the parts with an arbitrary sort order" do
@@ -266,12 +266,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/plain\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/html\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: application/x-yaml\r\nsubject: Enriched")
-      body.parts.length.should eq 3
-      body.should be_multipart
+      expect(body.parts.length).to eq 3
+      expect(body).to be_multipart
       body.sort_parts!
-      body.parts[0].content_type.should eq "application/x-yaml"
-      body.parts[1].content_type.should eq "text/plain"
-      body.parts[2].content_type.should eq "text/html"
+      expect(body.parts[0].content_type).to eq "application/x-yaml"
+      expect(body.parts[1].content_type).to eq "text/plain"
+      expect(body.parts[2].content_type).to eq "text/html"
     end
 
     it "should sort the parts on encode" do
@@ -279,12 +279,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/html\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched")
-      body.parts.length.should eq 3
-      body.should be_multipart
+      expect(body.parts.length).to eq 3
+      expect(body).to be_multipart
       body.encoded
-      body.parts[0].content_type.should eq "text/plain"
-      body.parts[1].content_type.should eq "text/enriched"
-      body.parts[2].content_type.should eq "text/html"
+      expect(body.parts[0].content_type).to eq "text/plain"
+      expect(body.parts[1].content_type).to eq "text/enriched"
+      expect(body.parts[2].content_type).to eq "text/html"
     end
 
     it "should put the part types it doesn't know about at the end" do
@@ -292,12 +292,12 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/html\r\nsubject: HTML")
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text")
       body << Mail::Part.new("content-type: image/jpeg\r\n")
-      body.parts.length.should eq 3
-      body.should be_multipart
+      expect(body.parts.length).to eq 3
+      expect(body).to be_multipart
       body.encoded
-      body.parts[0].content_type.should eq "text/plain"
-      body.parts[1].content_type.should eq "text/html"
-      body.parts[2].content_type.should eq "image/jpeg"
+      expect(body.parts[0].content_type).to eq "text/plain"
+      expect(body.parts[1].content_type).to eq "text/html"
+      expect(body.parts[2].content_type).to eq "image/jpeg"
     end
 
     it "should allow you to sort the parts recursively" do
@@ -308,14 +308,14 @@ describe Mail::Body do
       body = Mail::Body.new('')
       body << part
       body << Mail::Part.new("content-type: image/jpeg\r\nsubject: JPGEG\r\n\r\nsdkjskjdksjdkjsd")
-      body.parts.length.should eq 2
-      body.should be_multipart
+      expect(body.parts.length).to eq 2
+      expect(body).to be_multipart
       body.sort_parts!
-      body.parts[0].content_type.should match %r{\Amultipart/alternate(;|\Z)}
-      body.parts[1].content_type.should eq "image/jpeg"
-      body.parts[0].parts[0].content_type.should eq "text/plain"
-      body.parts[0].parts[1].content_type.should eq "text/enriched"
-      body.parts[0].parts[2].content_type.should eq "text/html"
+      expect(body.parts[0].content_type).to match %r{\Amultipart/alternate(;|\Z)}
+      expect(body.parts[1].content_type).to eq "image/jpeg"
+      expect(body.parts[0].parts[0].content_type).to eq "text/plain"
+      expect(body.parts[0].parts[1].content_type).to eq "text/enriched"
+      expect(body.parts[0].parts[2].content_type).to eq "text/html"
     end
 
     it "should allow you to sort the parts recursively" do
@@ -326,14 +326,14 @@ describe Mail::Body do
       body = Mail::Body.new('')
       body << part
       body << Mail::Part.new("content-type: image/jpeg\r\nsubject: JPGEG\r\n\r\nsdkjskjdksjdkjsd")
-      body.parts.length.should eq 2
-      body.should be_multipart
+      expect(body.parts.length).to eq 2
+      expect(body).to be_multipart
       body.sort_parts!
-      body.parts[0].content_type.should match %r{\Amultipart/alternate(;|\Z)}
-      body.parts[1].content_type.should eq "image/jpeg"
-      body.parts[0].parts[0].content_type.should eq "text/plain"
-      body.parts[0].parts[1].content_type.should eq "text/enriched"
-      body.parts[0].parts[2].content_type.should eq "text/html"
+      expect(body.parts[0].content_type).to match %r{\Amultipart/alternate(;|\Z)}
+      expect(body.parts[1].content_type).to eq "image/jpeg"
+      expect(body.parts[0].parts[0].content_type).to eq "text/plain"
+      expect(body.parts[0].parts[1].content_type).to eq "text/enriched"
+      expect(body.parts[0].parts[2].content_type).to eq "text/html"
     end
 
     it "should maintain the relative order of the parts with the same content-type as they are added" do
@@ -346,17 +346,17 @@ describe Mail::Body do
       body << Mail::Part.new("content-type: text/plain\r\nsubject: Plain Text_2")
       body << Mail::Part.new("content-type: image/jpeg\r\nsubject: JPGEG_2\r\n\r\nsdkjskjdksjdkjsd")
       body << Mail::Part.new("content-type: text/enriched\r\nsubject: Enriched_2")
-      body.parts.length.should eq 8
-      body.should be_multipart
+      expect(body.parts.length).to eq 8
+      expect(body).to be_multipart
       body.sort_parts!
-      body.parts[0].subject.should eq "Plain Text_1"
-      body.parts[1].subject.should eq "Plain Text_2"
-      body.parts[2].subject.should eq "Enriched_1"
-      body.parts[3].subject.should eq "Enriched_2"
-      body.parts[4].subject.should eq "HTML_1"
-      body.parts[5].subject.should eq "HTML_2"
-      body.parts[6].subject.should eq "JPGEG_1"
-      body.parts[7].subject.should eq "JPGEG_2"
+      expect(body.parts[0].subject).to eq "Plain Text_1"
+      expect(body.parts[1].subject).to eq "Plain Text_2"
+      expect(body.parts[2].subject).to eq "Enriched_1"
+      expect(body.parts[3].subject).to eq "Enriched_2"
+      expect(body.parts[4].subject).to eq "HTML_1"
+      expect(body.parts[5].subject).to eq "HTML_2"
+      expect(body.parts[6].subject).to eq "JPGEG_1"
+      expect(body.parts[7].subject).to eq "JPGEG_2"
     end
   end
 
@@ -364,51 +364,51 @@ describe Mail::Body do
 
     it "should still equal itself" do
       body = Mail::Body.new('The body')
-      body.should eq body
+      expect(body).to eq body
     end
 
     it "should match on the body part decoded if given a string to ==" do
       body = Mail::Body.new('The body')
-      (body == 'The body').should be_true
+      expect(body == 'The body').to be_true
     end
 
     it "should match on the body part decoded if given a string to ==" do
       body = Mail::Body.new("VGhlIGJvZHk=\n")
       body.encoding = 'base64'
-      (body == "The body").should be_true
+      expect(body == "The body").to be_true
     end
 
     it "should match on the body part decoded if given a string to =~" do
       body = Mail::Body.new('The body')
-      (body =~ /The/).should eq 0
+      expect(body =~ /The/).to eq 0
     end
 
     it "should match on the body part decoded if given a string to ==" do
       body = Mail::Body.new("VGhlIGJvZHk=\n")
       body.encoding = 'base64'
-      (body =~ /The/).should eq 0
+      expect(body =~ /The/).to eq 0
     end
 
     it "should match on the body part decoded if given a string to match" do
       body = Mail::Body.new('The body')
-      (body.match(/The/))[0].should eq 'The'
+      expect((body.match(/The/))[0]).to eq 'The'
     end
 
     it "should match on the body part decoded if given a string to match" do
       body = Mail::Body.new("VGhlIGJvZHk=\n")
       body.encoding = 'base64'
-      (body.match(/The/))[0].should eq 'The'
+      expect((body.match(/The/))[0]).to eq 'The'
     end
 
     it "should match on the body part decoded if given a string to include?" do
       body = Mail::Body.new('The Body')
-      body.should include('The')
+      expect(body).to include('The')
     end
 
     it "should match on the body part decoded if given a string to include?" do
       body = Mail::Body.new("VGhlIGJvZHk=\n")
       body.encoding = 'base64'
-      body.should include('The')
+      expect(body).to include('The')
     end
   end
 
@@ -417,7 +417,7 @@ describe Mail::Body do
       body = Mail::Body.new("あいうえお\n")
       body.charset = 'iso-2022-jp'
       expect = (RUBY_VERSION < '1.9') ? "あいうえお\r\n" : "\e$B$\"$$$&$($*\e(B\r\n"
-      body.encoded.should eq expect
+      expect(body.encoded).to eq expect
     end
   end
 end

--- a/spec/mail/configuration_spec.rb
+++ b/spec/mail/configuration_spec.rb
@@ -17,44 +17,44 @@ describe Mail::Configuration do
       # will not clear it.
       Mail::Configuration.instance.send(:initialize)
       Mail.defaults { delivery_method nil, { :address => 'some.host' } }
-      Mail.delivery_method.settings[:address].should eq 'some.host'
+      expect(Mail.delivery_method.settings[:address]).to eq 'some.host'
     end
 
     it "should be available from the Mail.defaults method" do
       Mail.defaults { delivery_method :smtp, { :address => 'some.host' } }
-      Mail.delivery_method.settings[:address].should eq 'some.host'
+      expect(Mail.delivery_method.settings[:address]).to eq 'some.host'
     end
 
     it "should configure sendmail" do
       Mail.defaults { delivery_method :sendmail, :location => "/usr/bin/sendmail" }
-      Mail.delivery_method.class.should eq Mail::Sendmail
-      Mail.delivery_method.settings[:location].should eq "/usr/bin/sendmail"
+      expect(Mail.delivery_method.class).to eq Mail::Sendmail
+      expect(Mail.delivery_method.settings[:location]).to eq "/usr/bin/sendmail"
     end
 
     it "should configure sendmail using a string" do
       Mail.defaults { delivery_method 'sendmail', :location => "/usr/bin/sendmail" }
-      Mail.delivery_method.class.should eq Mail::Sendmail
-      Mail.delivery_method.settings[:location].should eq "/usr/bin/sendmail"
+      expect(Mail.delivery_method.class).to eq Mail::Sendmail
+      expect(Mail.delivery_method.settings[:location]).to eq "/usr/bin/sendmail"
     end
 
     it "should configure exim" do
       Mail.defaults { delivery_method :exim, :location => "/usr/bin/exim" }
-      Mail.delivery_method.class.should eq Mail::Exim
-      Mail.delivery_method.settings[:location].should eq "/usr/bin/exim"
+      expect(Mail.delivery_method.class).to eq Mail::Exim
+      expect(Mail.delivery_method.settings[:location]).to eq "/usr/bin/exim"
     end
 
     it "should configure an open SMTP connection" do
       smtp = Net::SMTP.start('127.0.0.1', 25)
       Mail.defaults { delivery_method :smtp_connection, {:connection => smtp} }
-      Mail.delivery_method.class.should eq Mail::SMTPConnection
-      Mail.delivery_method.smtp.should eq smtp
+      expect(Mail.delivery_method.class).to eq Mail::SMTPConnection
+      expect(Mail.delivery_method.smtp).to eq smtp
     end
 
     it "should accept a plug-in delivery method" do
       Mail.defaults { delivery_method MyTestDeliveryMethod, { :option1 => "one", :option2 => "two" }}
-      Mail.delivery_method.class.should eq MyTestDeliveryMethod
-      Mail.delivery_method.settings[:option1].should eq "one"
-      Mail.delivery_method.settings[:option2].should eq "two"
+      expect(Mail.delivery_method.class).to eq MyTestDeliveryMethod
+      expect(Mail.delivery_method.settings[:option1]).to eq "one"
+      expect(Mail.delivery_method.settings[:option2]).to eq "two"
     end
 
   end

--- a/spec/mail/core_extensions/string_spec.rb
+++ b/spec/mail/core_extensions/string_spec.rb
@@ -6,63 +6,63 @@ describe 'core_extensions/string' do
   describe "to_crlf" do
 
     it "should change a single LF to CRLF" do
-      "\n".to_crlf.should eq "\r\n"
+      expect("\n".to_crlf).to eq "\r\n"
     end
 
     it "should change multiple LF to CRLF" do
-      "\n\n".to_crlf.should eq "\r\n\r\n"
+      expect("\n\n".to_crlf).to eq "\r\n\r\n"
     end
 
     it "should change a single CR to CRLF" do
-      "\r".to_crlf.should eq "\r\n"
+      expect("\r".to_crlf).to eq "\r\n"
     end
 
     it "should not change CRLF" do
-      "\r\n".to_crlf.should eq "\r\n"
+      expect("\r\n".to_crlf).to eq "\r\n"
     end
 
     it "should not change multiple CRLF" do
-      "\r\n\r\n".to_crlf.should eq "\r\n\r\n"
+      expect("\r\n\r\n".to_crlf).to eq "\r\n\r\n"
     end
 
     it "should handle a mix" do
-      "\r \n\r\n".to_crlf.should eq "\r\n \r\n\r\n"
+      expect("\r \n\r\n".to_crlf).to eq "\r\n \r\n\r\n"
     end
   end
 
   describe "to_lf" do
     it "should change a single CR to LF" do
-      "\r".to_lf.should eq "\n"
+      expect("\r".to_lf).to eq "\n"
     end
 
     it "should change multiple LF to CRLF" do
-      "\r\r".to_lf.should eq "\n\n"
+      expect("\r\r".to_lf).to eq "\n\n"
     end
 
     it "should change a single CRLF to LF" do
-      "\r\n".to_lf.should eq "\n"
+      expect("\r\n".to_lf).to eq "\n"
     end
 
     it "should change multiple CR to LF" do
-      "\r\n\r\n".to_lf.should eq "\n\n"
+      expect("\r\n\r\n".to_lf).to eq "\n\n"
     end
 
     it "should not change LF" do
-      "\n".to_lf.should eq "\n"
+      expect("\n".to_lf).to eq "\n"
     end
 
     it "should not change multiple CRLF" do
-      "\n\n".to_lf.should eq "\n\n"
+      expect("\n\n".to_lf).to eq "\n\n"
     end
 
     it "should handle a mix" do
-      "\r \n\r\n".to_lf.should eq "\n \n\n"
+      expect("\r \n\r\n".to_lf).to eq "\n \n\n"
     end
   end
 
   describe 'constantize' do
     it 'should converts string to constant' do
-      "Kernel".constantize.should eq Kernel
+      expect("Kernel".constantize).to eq Kernel
     end
   end
 

--- a/spec/mail/core_extensions_spec.rb
+++ b/spec/mail/core_extensions_spec.rb
@@ -5,94 +5,94 @@ describe Object do
 
   describe "blank method" do
     it "should say nil is blank" do
-      nil.should be_blank
+      expect(nil).to be_blank
     end
 
     it "should say false is blank" do
-      false.should be_blank
+      expect(false).to be_blank
     end
 
     it "should say true is not blank" do
-      true.should_not be_blank
+      expect(true).not_to be_blank
     end
 
     it "should say an empty array is blank" do
-      [].should be_blank
+      expect([]).to be_blank
     end
 
     it "should say an empty hash is blank" do
-      {}.should be_blank
+      expect({}).to be_blank
     end
 
     it "should say an empty string is blank" do
-      ''.should be_blank
-      " ".should be_blank
+      expect('').to be_blank
+      expect(" ").to be_blank
       a = ''; 1000.times { a << ' ' }
-      a.should be_blank
-      "\t \n\n".should be_blank
+      expect(a).to be_blank
+      expect("\t \n\n").to be_blank
     end
   end
 
   describe "not blank method" do
     it "should say a number is not blank" do
-      1.should_not be_blank
+      expect(1).not_to be_blank
     end
     
     it "should say a valueless hash is not blank" do
-      {:one => nil, :two => nil}.should_not be_blank
+      expect({:one => nil, :two => nil}).not_to be_blank
     end
     
     it "should say a hash containing an empty hash is not blank" do
-      {:key => {}}.should_not be_blank
+      expect({:key => {}}).not_to be_blank
     end
   end
 
   describe "to_lf method on String" do
     it "should leave lf as lf" do
-      "\n".to_lf.should eq "\n"
+      expect("\n".to_lf).to eq "\n"
     end
 
     it "should clean just cr to lf" do
-      "\r".to_lf.should eq "\n"
+      expect("\r".to_lf).to eq "\n"
     end
 
     it "should leave crlf as lf" do
-      "\r\n".to_lf.should eq "\n"
+      expect("\r\n".to_lf).to eq "\n"
     end
     
     it "should handle japanese characters" do
       string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
-      string.to_lf.should eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\n\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\n\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\n\n"
+      expect(string.to_lf).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\n\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\n\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\n\n"
     end
   end
 
   describe "to_crlf method on String" do
     it "should clean just lf to crlf" do
-      "\n".to_crlf.should eq "\r\n"
+      expect("\n".to_crlf).to eq "\r\n"
     end
 
     it "should clean just cr to crlf" do
-      "\r".to_crlf.should eq "\r\n"
+      expect("\r".to_crlf).to eq "\r\n"
     end
 
     it "should leave crlf as crlf" do
-      "\r\n".to_crlf.should eq "\r\n"
+      expect("\r\n".to_crlf).to eq "\r\n"
     end
 
     it "should handle japanese characters" do
       string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
-      string.to_crlf.should eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
+      expect(string.to_crlf).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
     end
     
   end
 
   describe "methods on NilClass" do
     it "should return empty string on to_crlf" do
-      nil.to_crlf.should eq ''
+      expect(nil.to_crlf).to eq ''
     end
 
     it "should return empty string on to_lf" do
-      nil.to_lf.should eq ''
+      expect(nil.to_lf).to eq ''
     end
   end
 

--- a/spec/mail/elements/address_list_spec.rb
+++ b/spec/mail/elements/address_list_spec.rb
@@ -6,65 +6,65 @@ describe Mail::AddressList do
   describe "parsing" do
     it "should parse an address list" do
       parse_text  = 'test@lindsaar.net'
-      doing { Mail::AddressList.new(parse_text) }.should_not raise_error
+      expect(doing { Mail::AddressList.new(parse_text) }).not_to raise_error
     end
 
     it "should raise an error if the input is useless" do
       parse_text = '@@@@@@'
-      doing { Mail::AddressList.new(parse_text) }.should raise_error
+      expect(doing { Mail::AddressList.new(parse_text) }).to raise_error
     end
     
     it "should not raise an error if the input is just blank" do
       parse_text = nil
-      doing { Mail::AddressList.new(parse_text) }.should_not raise_error
+      expect(doing { Mail::AddressList.new(parse_text) }).not_to raise_error
     end
 
     it "should raise an error if the input is useless" do
       parse_text = "This ( is an invalid address!"
-      doing { Mail::AddressList.new(parse_text) }.should raise_error
+      expect(doing { Mail::AddressList.new(parse_text) }).to raise_error
     end
 
     it "should give the address passed in" do
       parse_text  = 'test@lindsaar.net'
       result      = 'test@lindsaar.net'
       a = Mail::AddressList.new(parse_text)
-      a.addresses.first.to_s.should eq result
+      expect(a.addresses.first.to_s).to eq result
     end
 
     it "should give the addresses passed in" do
       parse_text  = 'test@lindsaar.net, test2@lindsaar.net'
       result      = ['test@lindsaar.net', 'test2@lindsaar.net']
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should eq result
+      expect(a.addresses.map {|addr| addr.to_s }).to eq result
     end
 
     it "should preserve the display name" do
       parse_text  = '"Mikel Lindsaar" <mikel@test.lindsaar.net>'
       result      = 'Mikel Lindsaar <mikel@test.lindsaar.net>'
       a = Mail::AddressList.new(parse_text)
-      a.addresses.first.format.should eq result
-      a.addresses.first.display_name.should eq 'Mikel Lindsaar'
+      expect(a.addresses.first.format).to eq result
+      expect(a.addresses.first.display_name).to eq 'Mikel Lindsaar'
     end
 
     it "should handle and ignore nil addresses" do
       parse_text  = ' , user-example@aol.com, e-s-a-s-2200@app.ar.com'
       result      = ['user-example@aol.com', 'e-s-a-s-2200@app.ar.com']
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should eq result
+      expect(a.addresses.map {|addr| addr.to_s }).to eq result
     end
 
     it "should handle truly horrific combinations of commas, spaces, and addresses" do
       parse_text = '  ,, foo@example.com,  ,    ,,, bar@example.com  ,,'
       result = ['foo@example.com', 'bar@example.com']
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should eq result
+      expect(a.addresses.map {|addr| addr.to_s }).to eq result
     end
 
     it "should handle folding whitespace" do
       parse_text = "foo@example.com,\r\n\tbar@example.com"
       result = ['foo@example.com', 'bar@example.com']
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should eq result
+      expect(a.addresses.map {|addr| addr.to_s }).to eq result
     end
 
     it "should handle malformed folding whitespace" do
@@ -72,14 +72,14 @@ describe Mail::AddressList do
       parse_text = "leads@sg.dc.com,\n\t sag@leads.gs.ry.com,\n\t sn@example-hotmail.com,\n\t e-s-a-g-8718@app.ar.com,\n\t jp@t-exmaple.com,\n\t\n\t cc@c-l-example.com"
       result = %w(leads@sg.dc.com sag@leads.gs.ry.com sn@example-hotmail.com e-s-a-g-8718@app.ar.com jp@t-exmaple.com cc@c-l-example.com)
       a = Mail::AddressList.new(parse_text)
-      a.addresses.map {|addr| addr.to_s }.should eq result
+      expect(a.addresses.map {|addr| addr.to_s }).to eq result
     end
 
     it "should extract comments in addreses which are part of a group" do
       parse_text = "group: jimmy <jimmy@(comment)example.com>;";
       result = ["comment"]
       a = Mail::AddressList.new(parse_text)
-      a.addresses.first.comments.should eq result
+      expect(a.addresses.first.comments).to eq result
     end
 
   end
@@ -87,37 +87,37 @@ describe Mail::AddressList do
   describe "functionality" do
     it "should give all the groups when asked" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.addresses_grouped_by_group.length.should eq 1
+      expect(list.addresses_grouped_by_group.length).to eq 1
     end
 
     it "should ask the group for all its addresses" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.addresses_grouped_by_group.values.first.length.should eq 2
+      expect(list.addresses_grouped_by_group.values.first.length).to eq 2
     end
 
     it "should give all the addresses when asked" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.addresses.length.should eq 3
+      expect(list.addresses.length).to eq 3
     end
     
     it "should handle a really nasty obsolete address list" do
       pending
       psycho_obsolete = "Mary Smith <@machine.tld:mary@example.net>, , jdoe@test   . example"
       list = Mail::AddressList.new(psycho_obsolete)
-      list.addresses.length.should eq 2
+      expect(list.addresses.length).to eq 2
     end
     
 
     it "should create an address instance for each address returned" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       list.addresses.each do |address|
-        address.class.should eq Mail::Address
+        expect(address.class).to eq Mail::Address
       end
     end
 
     it "should provide a list of group names" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      list.group_names.should eq ["my_group"]
+      expect(list.group_names).to eq ["my_group"]
     end
     
   end

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -6,40 +6,40 @@ describe Mail::Address do
   describe "functionality" do
 
     it "should allow us to instantiate an empty address object and call inspect" do
-      doing {
+      expect(doing {
         Mail::Address.new.inspect
-      }.should_not raise_error
+      }).not_to raise_error
     end
 
     it "should allow us to instantiate an empty address object and call to_s" do
-      Mail::Address.new.to_s.should eq ''
+      expect(Mail::Address.new.to_s).to eq ''
     end
 
     it "should allow us to instantiate an empty address object and call format" do
-      Mail::Address.new.format.should eq ''
+      expect(Mail::Address.new.format).to eq ''
     end
 
     it "should allow us to instantiate an empty address object and call address" do
       [nil, '', ' '].each do |input|
-        Mail::Address.new(input).address.should eq nil
+        expect(Mail::Address.new(input).address).to eq nil
       end
     end
 
     it "should allow us to instantiate an empty address object and call local" do
       [nil, '', ' '].each do |input|
-        Mail::Address.new(input).local.should eq nil
+        expect(Mail::Address.new(input).local).to eq nil
       end
     end
 
     it "should allow us to instantiate an empty address object and call domain" do
       [nil, '', ' '].each do |input|
-        Mail::Address.new(input).domain.should eq nil
+        expect(Mail::Address.new(input).domain).to eq nil
       end
     end
 
     ['"-Earnings...Notification-" <vodacom.co.rs>', '<56253817>'].each do |spammy_address|
       it "should ignore funky local-only spammy addresses in angle brackets #{spammy_address}" do
-        Mail::Address.new(spammy_address).address.should eq nil
+        expect(Mail::Address.new(spammy_address).address).to eq nil
       end
     end
 
@@ -47,100 +47,100 @@ describe Mail::Address do
     it "should give its address back on :to_s if there is no display name" do
       parse_text = 'test@lindsaar.net'
       result     = 'test@lindsaar.net'
-      Mail::Address.new(parse_text).to_s.should eq result
+      expect(Mail::Address.new(parse_text).to_s).to eq result
     end
 
     it "should give its format back on :to_s if there is a display name" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'Mikel Lindsaar <test@lindsaar.net>'
-      Mail::Address.new(parse_text).to_s.should eq result
+      expect(Mail::Address.new(parse_text).to_s).to eq result
     end
 
     it "should give back the display name" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'Mikel Lindsaar'
       a          = Mail::Address.new(parse_text)
-      a.display_name.should eq result
+      expect(a.display_name).to eq result
     end
 
     it "should preserve the display name passed in" do
       parse_text = '"Mikel Lindsaar" <mikel@test.lindsaar.net>'
       result     = 'Mikel Lindsaar'
       a          = Mail::Address.new(parse_text)
-      a.display_name.should eq result
+      expect(a.display_name).to eq result
     end
 
     it "should preserve the display name passed in with token unsafe chars" do
       parse_text = '"Mikel@@@Lindsaar" <mikel@test.lindsaar.net>'
       result     = 'Mikel@@@Lindsaar'
       a          = Mail::Address.new(parse_text)
-      a.display_name.should eq result
+      expect(a.display_name).to eq result
     end
 
     it "should decode the display name without calling #decoded first" do
       encoded = '=?ISO-8859-1?Q?Jan_Kr=FCtisch?= <jan@krutisch.de>'
-      Mail::Address.new(encoded).display_name.should eq 'Jan Krütisch'
+      expect(Mail::Address.new(encoded).display_name).to eq 'Jan Krütisch'
     end
 
     it "should give back the local part" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'test'
       a          = Mail::Address.new(parse_text)
-      a.local.should eq result
+      expect(a.local).to eq result
     end
 
     it "should give back the domain" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'lindsaar.net'
       a          = Mail::Address.new(parse_text)
-      a.domain.should eq result
+      expect(a.domain).to eq result
     end
 
     it "should give back the formated address" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'Mikel Lindsaar <test@lindsaar.net>'
       a          = Mail::Address.new(parse_text)
-      a.format.should eq result
+      expect(a.format).to eq result
     end
 
     it "should handle an address without a domain" do
       parse_text = 'test'
       result     = 'test'
       a          = Mail::Address.new(parse_text)
-      a.address.should eq result
+      expect(a.address).to eq result
     end
 
     it "should handle comments" do
       parse_text = "Mikel Lindsaar (author) <test@lindsaar.net>"
       result     = ['author']
       a          = Mail::Address.new(parse_text)
-      a.comments.should eq result
+      expect(a.comments).to eq result
     end
 
     it "should handle multiple comments" do
       parse_text = "Mikel (first name) Lindsaar (author) <test@lindsaar.net>"
       result     = ['first name', 'author']
       a          = Mail::Address.new(parse_text)
-      a.comments.should eq result
+      expect(a.comments).to eq result
     end
 
     it "should handle nested comments" do
       parse_text  = "bob@example.com (hello   (nested) yeah)"
       result      = ["hello \(nested\) yeah"]
       a           = Mail::Address.new(parse_text)
-      a.comments.should eq result
+      expect(a.comments).to eq result
     end
 
     it "should give back the raw value" do
       parse_text = "Mikel (first name) Lindsaar (author) <test@lindsaar.net>"
       result     = "Mikel (first name) Lindsaar (author) <test@lindsaar.net>"
       a          = Mail::Address.new(parse_text)
-      a.raw.should eq result
+      expect(a.raw).to eq result
     end
 
     it "should format junk addresses as raw text" do
       junk = '<"somename@gmail.com">'
-      Mail::Address.new(junk).format.should eq junk
+      expect(Mail::Address.new(junk).format).to eq junk
     end
 
   end
@@ -149,27 +149,27 @@ describe Mail::Address do
     it "should allow you to assign an address" do
       a         = Mail::Address.new
       a.address = 'mikel@test.lindsaar.net'
-      a.address.should eq 'mikel@test.lindsaar.net'
-      a.format.should eq 'mikel@test.lindsaar.net'
+      expect(a.address).to eq 'mikel@test.lindsaar.net'
+      expect(a.format).to eq 'mikel@test.lindsaar.net'
     end
 
     it "should allow you to assign a display name" do
       a              = Mail::Address.new
       a.display_name = 'Mikel Lindsaar'
-      a.display_name.should eq 'Mikel Lindsaar'
+      expect(a.display_name).to eq 'Mikel Lindsaar'
     end
 
     it "should return an empty format a display name and no address defined" do
       a              = Mail::Address.new
       a.display_name = 'Mikel Lindsaar'
-      a.format.should eq ''
+      expect(a.format).to eq ''
     end
 
     it "should allow you to assign an address and a display name" do
       a              = Mail::Address.new
       a.address      = 'mikel@test.lindsaar.net'
       a.display_name = 'Mikel Lindsaar'
-      a.format.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(a.format).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
   end
 
@@ -184,7 +184,7 @@ describe Mail::Address do
 
         ].each do |(words, ok)|
           a = Mail::Address.new(words)
-          a.local.should eq ok
+          expect(a.local).to eq ok
         end
       end
 
@@ -197,7 +197,7 @@ describe Mail::Address do
 
         ].each do |(words, ok)|
           a = Mail::Address.new(%Q|me@#{words}|)
-          a.domain.should eq ok
+          expect(a.domain).to eq ok
         end
       end
     end
@@ -205,7 +205,7 @@ describe Mail::Address do
     describe "email addresses from the wild" do
       it "should handle |aamine@loveruby.net|" do
         address = Mail::Address.new('aamine@loveruby.net')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :display_name => nil,
                                          :address      => 'aamine@loveruby.net',
                                          :local        => 'aamine',
@@ -217,7 +217,7 @@ describe Mail::Address do
 
       it "should handle |Minero Aoki <aamine@loveruby.net>|" do
         address = Mail::Address.new('Minero Aoki <aamine@loveruby.net>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :display_name => 'Minero Aoki',
                                          :address      => 'aamine@loveruby.net',
                                          :local        => 'aamine',
@@ -229,7 +229,7 @@ describe Mail::Address do
 
       it "should handle |Minero Aoki<aamine@loveruby.net>|" do
         address = Mail::Address.new('Minero Aoki<aamine@loveruby.net>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :display_name => 'Minero Aoki',
                                          :address      => 'aamine@loveruby.net',
                                          :local        => 'aamine',
@@ -241,7 +241,7 @@ describe Mail::Address do
 
       it 'should handle |"Minero Aoki" <aamine@loveruby.net>|' do
         address = Mail::Address.new('"Minero Aoki" <aamine@loveruby.net>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :display_name => 'Minero Aoki',
                                          :address      => 'aamine@loveruby.net',
                                          :local        => 'aamine',
@@ -253,7 +253,7 @@ describe Mail::Address do
 
       it "should handle |Minero Aoki<aamine@0246.loveruby.net>|" do
         address = Mail::Address.new('Minero Aoki<aamine@0246.loveruby.net>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :display_name => 'Minero Aoki',
                                          :address      => 'aamine@0246.loveruby.net',
                                          :local        => 'aamine',
@@ -267,7 +267,7 @@ describe Mail::Address do
         1.upto(10) do |times|
           dots    = "." * times
           address = Mail::Address.new("hoge#{dots}test@docomo.ne.jp")
-          address.should break_down_to({
+          expect(address).to break_down_to({
                                            :display_name => nil,
                                            :address      => "hoge#{dots}test@docomo.ne.jp",
                                            :local        => "hoge#{dots}test",
@@ -282,7 +282,7 @@ describe Mail::Address do
         1.upto(10) do |times|
           dots    = "." * times
           address = Mail::Address.new("hogetest#{dots}@docomo.ne.jp")
-          address.should break_down_to({
+          expect(address).to break_down_to({
                                            :display_name => nil,
                                            :address      => "hogetest#{dots}@docomo.ne.jp",
                                            :local        => "hogetest#{dots}",
@@ -295,7 +295,7 @@ describe Mail::Address do
 
       it 'should handle |"Joe & J. Harvey" <ddd @Org>|' do
         address = Mail::Address.new('"Joe & J. Harvey" <ddd @Org>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'Joe & J. Harvey',
                                          :display_name => 'Joe & J. Harvey',
                                          :address      => 'ddd@Org',
@@ -308,7 +308,7 @@ describe Mail::Address do
 
       it 'should handle |"spickett@tiac.net" <Sean.Pickett@zork.tiac.net>|' do
         address = Mail::Address.new('"spickett@tiac.net" <Sean.Pickett@zork.tiac.net>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'spickett@tiac.net',
                                          :display_name => 'spickett@tiac.net',
                                          :address      => 'Sean.Pickett@zork.tiac.net',
@@ -321,7 +321,7 @@ describe Mail::Address do
 
       it "should handle |rls@intgp8.ih.att.com (-Schieve,R.L.)|" do
         address = Mail::Address.new('rls@intgp8.ih.att.com (-Schieve,R.L.)')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => '-Schieve,R.L.',
                                          :display_name => nil,
                                          :address      => 'rls@intgp8.ih.att.com',
@@ -334,7 +334,7 @@ describe Mail::Address do
 
       it "should handle |jrh%cup.portal.com@portal.unix.portal.com|" do
         address = Mail::Address.new('jrh%cup.portal.com@portal.unix.portal.com')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => nil,
                                          :display_name => nil,
                                          :address      => 'jrh%cup.portal.com@portal.unix.portal.com',
@@ -347,7 +347,7 @@ describe Mail::Address do
 
       it "should handle |astrachan@austlcm.sps.mot.com ('paul astrachan/xvt3')|" do
         address = Mail::Address.new("astrachan@austlcm.sps.mot.com ('paul astrachan/xvt3')")
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => "'paul astrachan/xvt3'",
                                          :display_name => nil,
                                          :address      => 'astrachan@austlcm.sps.mot.com',
@@ -360,7 +360,7 @@ describe Mail::Address do
 
       it "should handle 'TWINE57%SDELVB.decnet@SNYBUF.CS.SNYBUF.EDU (JAMES R. TWINE - THE NERD)'" do
         address = Mail::Address.new('TWINE57%SDELVB.decnet@SNYBUF.CS.SNYBUF.EDU (JAMES R. TWINE - THE NERD)')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'JAMES R. TWINE - THE NERD',
                                          :display_name => nil,
                                          :address      => 'TWINE57%SDELVB.decnet@SNYBUF.CS.SNYBUF.EDU',
@@ -373,7 +373,7 @@ describe Mail::Address do
 
       it "should be able to handle 'David Apfelbaum <da0g+@andrew.cmu.edu>'" do
         address = Mail::Address.new('David Apfelbaum <da0g+@andrew.cmu.edu>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'David Apfelbaum',
                                          :display_name => 'David Apfelbaum',
                                          :address      => 'da0g+@andrew.cmu.edu',
@@ -386,7 +386,7 @@ describe Mail::Address do
 
       it 'should handle |"JAMES R. TWINE - THE NERD" <TWINE57%SDELVB%SNYDELVA.bitnet@CUNYVM.CUNY.EDU>|' do
         address = Mail::Address.new('"JAMES R. TWINE - THE NERD" <TWINE57%SDELVB%SNYDELVA.bitnet@CUNYVM.CUNY.EDU>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'JAMES R. TWINE - THE NERD',
                                          :display_name => 'JAMES R. TWINE - THE NERD',
                                          :address      => 'TWINE57%SDELVB%SNYDELVA.bitnet@CUNYVM.CUNY.EDU',
@@ -399,7 +399,7 @@ describe Mail::Address do
 
       it "should handle '/G=Owen/S=Smith/O=SJ-Research/ADMD=INTERSPAN/C=GB/@mhs-relay.ac.uk'" do
         address = Mail::Address.new('/G=Owen/S=Smith/O=SJ-Research/ADMD=INTERSPAN/C=GB/@mhs-relay.ac.uk')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => nil,
                                          :display_name => nil,
                                          :address      => '/G=Owen/S=Smith/O=SJ-Research/ADMD=INTERSPAN/C=GB/@mhs-relay.ac.uk',
@@ -412,7 +412,7 @@ describe Mail::Address do
 
       it 'should handle |"Stephen Burke, Liverpool" <BURKE@vxdsya.desy.de>|' do
         address = Mail::Address.new('"Stephen Burke, Liverpool" <BURKE@vxdsya.desy.de>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'Stephen Burke, Liverpool',
                                          :display_name => 'Stephen Burke, Liverpool',
                                          :address      => 'BURKE@vxdsya.desy.de',
@@ -425,7 +425,7 @@ describe Mail::Address do
 
       it "should handle 'The Newcastle Info-Server <info-admin@newcastle.ac.uk>'" do
         address = Mail::Address.new('The Newcastle Info-Server <info-admin@newcastle.ac.uk>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'The Newcastle Info-Server',
                                          :display_name => 'The Newcastle Info-Server',
                                          :address      => 'info-admin@newcastle.ac.uk',
@@ -438,7 +438,7 @@ describe Mail::Address do
 
       it "should handle 'Suba.Peddada@eng.sun.com (Suba Peddada [CONTRACTOR])'" do
         address = Mail::Address.new('Suba.Peddada@eng.sun.com (Suba Peddada [CONTRACTOR])')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'Suba Peddada [CONTRACTOR]',
                                          :display_name => nil,
                                          :address      => 'Suba.Peddada@eng.sun.com',
@@ -451,7 +451,7 @@ describe Mail::Address do
 
       it "should handle 'Paul Manser (0032 memo) <a906187@tiuk.ti.com>'" do
         address = Mail::Address.new('Paul Manser (0032 memo) <a906187@tiuk.ti.com>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'Paul Manser',
                                          :display_name => 'Paul Manser',
                                          :address      => 'a906187@tiuk.ti.com',
@@ -464,7 +464,7 @@ describe Mail::Address do
 
       it 'should handle |"gregg (g.) woodcock" <woodcock@bnr.ca>|' do
         address = Mail::Address.new('"gregg (g.) woodcock" <woodcock@bnr.ca>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'gregg (g.) woodcock',
                                          :display_name => 'gregg (g.) woodcock',
                                          :address      => 'woodcock@bnr.ca',
@@ -477,7 +477,7 @@ describe Mail::Address do
 
       it 'should handle |Graham.Barr@tiuk.ti.com|' do
         address = Mail::Address.new('Graham.Barr@tiuk.ti.com')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => nil,
                                          :display_name => nil,
                                          :address      => 'Graham.Barr@tiuk.ti.com',
@@ -490,7 +490,7 @@ describe Mail::Address do
 
       it "should handle |a909937 (Graham Barr          (0004 bodg))|" do
         address = Mail::Address.new('a909937 (Graham Barr          (0004 bodg))')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'Graham Barr (0004 bodg)',
                                          :display_name => nil,
                                          :address      => 'a909937',
@@ -503,7 +503,7 @@ describe Mail::Address do
 
       it "should handle |david d `zoo' zuhn <zoo@aggregate.com>|" do
         address = Mail::Address.new("david d `zoo' zuhn <zoo@aggregate.com>")
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => "david d `zoo' zuhn",
                                          :display_name => "david d `zoo' zuhn",
                                          :address      => 'zoo@aggregate.com',
@@ -516,7 +516,7 @@ describe Mail::Address do
 
       it "should handle |(foo@bar.com (foobar), ned@foo.com (nedfoo) ) <kevin@goess.org>|" do
         address = Mail::Address.new('(foo@bar.com (foobar), ned@foo.com (nedfoo) ) <kevin@goess.org>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'foo@bar.com \(foobar\), ned@foo.com \(nedfoo\) ',
                                          :display_name => '(foo@bar.com \(foobar\), ned@foo.com \(nedfoo\) )',
                                          :address      => 'kevin@goess.org',
@@ -529,7 +529,7 @@ describe Mail::Address do
 
       it "should handle |Pete(A wonderful ) chap) <pete(his account)@silly.test(his host)>|" do
         address = Mail::Address.new('Pete(A wonderful \) chap) <pete(his account)@silly.test(his host)>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'Pete',
                                          :display_name => 'Pete',
                                          :address      => 'pete(his account)@silly.test',
@@ -542,7 +542,7 @@ describe Mail::Address do
 
       it "should handle |Joe Q. Public <john.q.public@example.com>|" do
         address = Mail::Address.new('Joe Q. Public <john.q.public@example.com>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'Joe Q. Public',
                                          :display_name => 'Joe Q. Public',
                                          :address      => 'john.q.public@example.com',
@@ -555,7 +555,7 @@ describe Mail::Address do
 
       it "should handle |Mary Smith <@machine.tld:mary@example.net>|" do
         address = Mail::Address.new('Mary Smith <@machine.tld:mary@example.net>')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'Mary Smith',
                                          :display_name => 'Mary Smith',
                                          :address      => '@machine.tld:mary@example.net',
@@ -569,7 +569,7 @@ describe Mail::Address do
       it "should handle |jdoe@test   . example|" do
         pending
         address = Mail::Address.new('jdoe@test   . example')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => 'jdoe@test.example',
                                          :display_name => 'jdoe@test.example',
                                          :address      => 'jdoe@test.example',
@@ -582,7 +582,7 @@ describe Mail::Address do
 
       it "should handle |groupname+domain.com@example.com|" do
         address = Mail::Address.new('groupname+domain.com@example.com')
-        address.should break_down_to({
+        expect(address).to break_down_to({
                                          :name         => nil,
                                          :display_name => nil,
                                          :address      => 'groupname+domain.com@example.com',
@@ -603,13 +603,13 @@ describe Mail::Address do
       it "should add an address" do
         address         = Mail::Address.new
         address.address = "mikel@test.lindsaar.net"
-        address.should break_down_to({:address => 'mikel@test.lindsaar.net'})
+        expect(address).to break_down_to({:address => 'mikel@test.lindsaar.net'})
       end
 
       it "should add a display name" do
         address              = Mail::Address.new
         address.display_name = "Mikel Lindsaar"
-        address.display_name.should eq 'Mikel Lindsaar'
+        expect(address.display_name).to eq 'Mikel Lindsaar'
       end
     end
 
@@ -619,27 +619,27 @@ describe Mail::Address do
     it "should add an address" do
       address         = Mail::Address.new
       address.address = "mikel@test.lindsaar.net"
-      address.should break_down_to({:address => 'mikel@test.lindsaar.net'})
+      expect(address).to break_down_to({:address => 'mikel@test.lindsaar.net'})
     end
 
     it "should add a display name" do
       address              = Mail::Address.new
       address.display_name = "Mikel Lindsaar"
-      address.display_name.should eq 'Mikel Lindsaar'
+      expect(address.display_name).to eq 'Mikel Lindsaar'
     end
 
     it "should take an address and a display name and join them" do
       address              = Mail::Address.new
       address.address      = "mikel@test.lindsaar.net"
       address.display_name = "Mikel Lindsaar"
-      address.format.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(address.format).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
     it "should take a display name and an address and join them" do
       address              = Mail::Address.new
       address.display_name = "Mikel Lindsaar"
       address.address      = "mikel@test.lindsaar.net"
-      address.format.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(address.format).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
   end
@@ -649,21 +649,21 @@ describe Mail::Address do
       address              = Mail::Address.new
       address.display_name = "Mikel Lindsaar"
       address.address      = "mikel@test.lindsaar.net"
-      address.encoded.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(address.encoded).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
     it "should provide an encoded output for non us-ascii" do
       address              = Mail::Address.new
       address.display_name = "まける"
       address.address      = "mikel@test.lindsaar.net"
-      address.encoded.should eq '=?UTF-8?B?44G+44GR44KL?= <mikel@test.lindsaar.net>'
+      expect(address.encoded).to eq '=?UTF-8?B?44G+44GR44KL?= <mikel@test.lindsaar.net>'
     end
 
     it "should provide an encoded output for non us-ascii" do
       address              = Mail::Address.new
       address.display_name = "まける"
       address.address      = "mikel@test.lindsaar.net"
-      address.decoded.should eq '"まける" <mikel@test.lindsaar.net>'
+      expect(address.decoded).to eq '"まける" <mikel@test.lindsaar.net>'
     end
 
   end

--- a/spec/mail/elements/date_time_element_spec.rb
+++ b/spec/mail/elements/date_time_element_spec.rb
@@ -4,17 +4,17 @@ describe Mail::DateTimeElement do
 
   it "should parse a date" do
     date_text  = 'Wed, 27 Apr 2005 14:15:31 -0700'
-    doing { Mail::DateTimeElement.new(date_text) }.should_not raise_error
+    expect(doing { Mail::DateTimeElement.new(date_text) }).not_to raise_error
   end
 
   it "should raise an error if the input is useless" do
     date_text = nil
-    doing { Mail::DateTimeElement.new(date_text) }.should raise_error
+    expect(doing { Mail::DateTimeElement.new(date_text) }).to raise_error
   end
 
   it "should raise an error if the input is useless" do
     date_text  = '""""""""""""""""'
-    doing { Mail::DateTimeElement.new(date_text) }.should raise_error
+    expect(doing { Mail::DateTimeElement.new(date_text) }).to raise_error
   end
   
 end

--- a/spec/mail/elements/envelope_from_element_spec.rb
+++ b/spec/mail/elements/envelope_from_element_spec.rb
@@ -4,27 +4,27 @@ describe Mail::EnvelopeFromElement do
   
   describe "parsing a from envelope string" do
     it "should parse a full field" do
-      doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug  7 00:39:21 2009") }.should_not raise_error
+      expect(doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug  7 00:39:21 2009") }).not_to raise_error
     end
 
     it "should parse a full field with a double digit day" do
-      doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug 17 00:39:21 2009") }.should_not raise_error
+      expect(doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug 17 00:39:21 2009") }).not_to raise_error
     end
 
     it "should parse a full field with a single space day" do
-      doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009") }.should_not raise_error
+      expect(doing { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009") }).not_to raise_error
     end
   end
 
   describe "accessor methods" do
     it "should return the address" do
       envelope = Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009")
-      envelope.address.should eq "mikel@test.lindsaar.net"
+      expect(envelope.address).to eq "mikel@test.lindsaar.net"
     end
 
     it "should return the date_time" do
       envelope = Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009")
-      envelope.date_time.should eq ::DateTime.parse("Mon Aug 17 00:39:21 2009")
+      expect(envelope.date_time).to eq ::DateTime.parse("Mon Aug 17 00:39:21 2009")
     end
   end
 
@@ -32,7 +32,7 @@ describe Mail::EnvelopeFromElement do
     it 'should format delivery date using UNIX ctime style' do
       time = Time.now
       envelope = Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net #{time.ctime}")
-      envelope.to_s.should eq "mikel@test.lindsaar.net #{time.ctime}"
+      expect(envelope.to_s).to eq "mikel@test.lindsaar.net #{time.ctime}"
     end
   end
 

--- a/spec/mail/elements/message_ids_element_spec.rb
+++ b/spec/mail/elements/message_ids_element_spec.rb
@@ -4,40 +4,40 @@ describe Mail::MessageIdsElement do
 
   it "should parse a message_id" do
     msg_id_text  = '<1234@test.lindsaar.net>'
-    doing { Mail::MessageIdsElement.new(msg_id_text) }.should_not raise_error
+    expect(doing { Mail::MessageIdsElement.new(msg_id_text) }).not_to raise_error
   end
 
   it "should parse multiple message_ids" do
     msg_id_text  = '<1234@test.lindsaar.net> <1234@test.lindsaar.net>'
-    doing { Mail::MessageIdsElement.new(msg_id_text) }.should_not raise_error
+    expect(doing { Mail::MessageIdsElement.new(msg_id_text) }).not_to raise_error
   end
 
   it "should raise an error if the input is useless" do
     msg_id_text = nil
-    doing { Mail::MessageIdsElement.new(msg_id_text) }.should raise_error
+    expect(doing { Mail::MessageIdsElement.new(msg_id_text) }).to raise_error
   end
 
   it "should raise an error if the input is useless" do
     msg_id_text  = '""""""""""""""""'
-    doing { Mail::MessageIdsElement.new(msg_id_text) }.should raise_error
+    expect(doing { Mail::MessageIdsElement.new(msg_id_text) }).to raise_error
   end
 
   it "should respond to message_ids" do
     msg_id_text  = '<1234@test.lindsaar.net> <1234@test.lindsaar.net>'
     msg_ids = Mail::MessageIdsElement.new(msg_id_text)
-    msg_ids.message_ids.should eq ['1234@test.lindsaar.net', '1234@test.lindsaar.net']
+    expect(msg_ids.message_ids).to eq ['1234@test.lindsaar.net', '1234@test.lindsaar.net']
   end
 
   it "should respond to message_id" do
     msg_id_text  = '<1234@test.lindsaar.net>'
     msg_ids = Mail::MessageIdsElement.new(msg_id_text)
-    msg_ids.message_id.should eq '1234@test.lindsaar.net'
+    expect(msg_ids.message_id).to eq '1234@test.lindsaar.net'
   end
   
   it "should not fail to parse a message id with dots in it" do
     text = "<4afb664ca3078_48dc..fdbe32b865532b@ax-desktop.mail>"
     m = Mail::MessageIdsElement.new(text)
-    m.message_id.should eq "4afb664ca3078_48dc..fdbe32b865532b@ax-desktop.mail"
+    expect(m.message_id).to eq "4afb664ca3078_48dc..fdbe32b865532b@ax-desktop.mail"
   end
 
 end

--- a/spec/mail/elements/phrase_list_spec.rb
+++ b/spec/mail/elements/phrase_list_spec.rb
@@ -6,17 +6,17 @@ describe Mail::PhraseList do
   describe "parsing" do
     it "should parse a phrase list" do
       parse_text  = '"Mikel Lindsaar", "Mikel", you, somewhere'
-      doing { Mail::PhraseList.new(parse_text) }.should_not raise_error
+      expect(doing { Mail::PhraseList.new(parse_text) }).not_to raise_error
     end
 
     it "should raise an error if the input is useless" do
       parse_text = nil
-      doing { Mail::PhraseList.new(parse_text) }.should raise_error
+      expect(doing { Mail::PhraseList.new(parse_text) }).to raise_error
     end
 
     it "should not raise an error if the input is empty" do
       parse_text  = '""""""""""""""""'
-      Mail::PhraseList.new(parse_text).phrases.should eq [parse_text[1...-1]]
+      expect(Mail::PhraseList.new(parse_text).phrases).to eq [parse_text[1...-1]]
     end
   end
 end

--- a/spec/mail/elements/received_element_spec.rb
+++ b/spec/mail/elements/received_element_spec.rb
@@ -4,31 +4,31 @@ describe Mail::ReceivedElement do
 
   it "should parse a date" do
     received_text  = 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
-    doing { Mail::ReceivedElement.new(received_text) }.should_not raise_error
+    expect(doing { Mail::ReceivedElement.new(received_text) }).not_to raise_error
   end
 
   it "should raise an error if the input is useless" do
     received_text = nil
-    doing { Mail::ReceivedElement.new(received_text) }.should raise_error
+    expect(doing { Mail::ReceivedElement.new(received_text) }).to raise_error
   end
 
   it "should raise an error if the input is useless" do
     received_text  = '""""""""""""""""'
-    doing { Mail::ReceivedElement.new(received_text) }.should raise_error
+    expect(doing { Mail::ReceivedElement.new(received_text) }).to raise_error
   end
   
   it "should give back the date time" do
     received_text  = 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
     date_text = '10 May 2005 17:26:50 +0000 (GMT)'
     rec = Mail::ReceivedElement.new(received_text)
-    rec.date_time.should eq ::DateTime.parse(date_text)
+    expect(rec.date_time).to eq ::DateTime.parse(date_text)
   end
   
   it "should give back the info" do
     received_text  = 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
     info_text = 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
     rec = Mail::ReceivedElement.new(received_text)
-    rec.info.should eq info_text
+    expect(rec.info).to eq info_text
   end
   
 end

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -6,7 +6,7 @@ describe "mail encoding" do
   it "should allow you to assign a mail wide charset" do
     mail = Mail.new
     mail.charset = 'utf-8'
-    mail.charset.should eq 'utf-8'
+    expect(mail.charset).to eq 'utf-8'
   end
 
   describe "using default encoding" do
@@ -15,7 +15,7 @@ describe "mail encoding" do
       mail.charset = 'utf-8'
       mail.subject = "This is あ string"
       result = "Subject: =?UTF-8?Q?This_is_=E3=81=82_string?=\r\n"
-      mail[:subject].encoded.should eq result
+      expect(mail[:subject].encoded).to eq result
     end
 
     it "should allow you to send in unencoded strings to address fields and encode them" do
@@ -23,7 +23,7 @@ describe "mail encoding" do
       mail.charset = 'utf-8'
       mail.to = "Mikel Lindsああr <mikel@test.lindsaar.net>"
       result = "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
-      mail[:to].encoded.should eq result
+      expect(mail[:to].encoded).to eq result
     end
 
     it "should allow you to send in unencoded strings to address fields and encode them" do
@@ -31,7 +31,7 @@ describe "mail encoding" do
       mail.charset = 'utf-8'
       mail.to = "あdあ <ada@test.lindsaar.net>"
       result = "To: =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
-      mail[:to].encoded.should eq result
+      expect(mail[:to].encoded).to eq result
     end
 
     it "should allow you to send in multiple unencoded strings to address fields and encode them" do
@@ -39,7 +39,7 @@ describe "mail encoding" do
       mail.charset = 'utf-8'
       mail.to = ["Mikel Lindsああr <mikel@test.lindsaar.net>", "あdあ <ada@test.lindsaar.net>"]
       result = "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
-      mail[:to].encoded.should eq result
+      expect(mail[:to].encoded).to eq result
     end
 
     it "should allow you to send unquoted non us-ascii strings, with spaces in them" do
@@ -47,7 +47,7 @@ describe "mail encoding" do
       mail.charset = 'utf-8'
       mail.to = ["Foo áëô îü <extended@example.net>"]
       result = "To: Foo =?UTF-8?B?w6HDq8O0?= =?UTF-8?B?IMOuw7w=?= <extended@example.net>\r\n"
-      mail[:to].encoded.should eq result
+      expect(mail[:to].encoded).to eq result
     end
 
     it "should allow you to send in multiple unencoded strings to any address field" do
@@ -56,7 +56,7 @@ describe "mail encoding" do
       ['To', 'From', 'Cc', 'Reply-To'].each do |field|
         mail.send("#{field.downcase.gsub("-", '_')}=", ["Mikel Lindsああr <mikel@test.lindsaar.net>", "あdあ <ada@test.lindsaar.net>"])
         result = "#{field}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
-        mail[field].encoded.should eq result
+        expect(mail[field].encoded).to eq result
       end
     end
 
@@ -65,7 +65,7 @@ describe "mail encoding" do
       mail.charset = 'utf-8'
       mail.to = "test1@lindsaar.net, group: test2@lindsaar.net, me@lindsaar.net;"
       result = "To: test1@lindsaar.net, \r\n\sgroup: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
-      mail[:to].encoded.should eq result
+      expect(mail[:to].encoded).to eq result
     end
 
     it "should handle groups with funky characters" do
@@ -73,7 +73,7 @@ describe "mail encoding" do
       mail.charset = 'utf-8'
       mail.to = '"Mikel Lindsああr" <test1@lindsaar.net>, group: "あdあ" <test2@lindsaar.net>, me@lindsaar.net;'
       result = "To: =?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <test1@lindsaar.net>, \r\n\sgroup: =?UTF-8?B?44GCZOOBgg==?= <test2@lindsaar.net>, \r\n\sme@lindsaar.net;\r\n"
-      mail[:to].encoded.should eq result
+      expect(mail[:to].encoded).to eq result
     end
 
     describe "quoting token safe chars" do
@@ -82,14 +82,14 @@ describe "mail encoding" do
         mail = Mail.new
         mail.charset = 'utf-8'
         mail.to = 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-        mail[:to].encoded.should eq %{To: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n}
+        expect(mail[:to].encoded).to eq %{To: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n}
       end
 
       it "should not quote the display name if already quoted" do
         mail = Mail.new
         mail.charset = 'utf-8'
         mail.to = '"Mikel Lindsaar" <mikel@test.lindsaar.net>'
-        mail[:to].encoded.should eq %{To: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n}
+        expect(mail[:to].encoded).to eq %{To: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n}
       end
 
     end
@@ -100,14 +100,14 @@ describe "mail encoding" do
         mail = Mail.new
         mail.charset = 'utf-8'
         mail.to = "Mikel @ me Lindsaar <mikel@test.lindsaar.net>"
-        mail[:to].encoded.should eq %{To: "Mikel @ me Lindsaar" <mikel@test.lindsaar.net>\r\n}
+        expect(mail[:to].encoded).to eq %{To: "Mikel @ me Lindsaar" <mikel@test.lindsaar.net>\r\n}
       end
 
       it "should preserve quotes needed from the user and not double quote" do
         mail = Mail.new
         mail.charset = 'utf-8'
         mail.to = %{"Mikel @ me Lindsaar" <mikel@test.lindsaar.net>}
-        mail[:to].encoded.should eq %{To: "Mikel @ me Lindsaar" <mikel@test.lindsaar.net>\r\n}
+        expect(mail[:to].encoded).to eq %{To: "Mikel @ me Lindsaar" <mikel@test.lindsaar.net>\r\n}
       end
     end
   end
@@ -125,7 +125,7 @@ describe "mail encoding" do
         string.force_encoding('ISO8859-1')
         result.force_encoding('ISO8859-1')
       end
-      result.should eq string
+      expect(result).to eq string
     end
 
     it "should allow you to send in unencoded strings to address fields and encode them" do
@@ -140,7 +140,7 @@ describe "mail encoding" do
         string.force_encoding('ISO8859-1')
         result.force_encoding('ISO8859-1')
       end
-      result.should eq string
+      expect(result).to eq string
     end
 
     it "should allow you to send in multiple unencoded strings to address fields and encode them" do
@@ -155,7 +155,7 @@ describe "mail encoding" do
         string.force_encoding('ISO8859-1')
         result.force_encoding('ISO8859-1')
       end
-      result.should eq string
+      expect(result).to eq string
     end
 
     it "should allow you to send in multiple unencoded strings to any address field" do
@@ -171,7 +171,7 @@ describe "mail encoding" do
           string.force_encoding('ISO8859-1')
           result.force_encoding('ISO8859-1')
         end
-        result.should eq string
+        expect(result).to eq string
       end
     end
   end
@@ -183,16 +183,16 @@ describe "mail encoding" do
     part.charset = "ISO-8859-1"
     part.body = "blah"
     mail.add_part(part)
-    mail.parts[0].content_type.should eq "text/html; charset=ISO-8859-1"
+    expect(mail.parts[0].content_type).to eq "text/html; charset=ISO-8859-1"
   end
 
   it "should skip invalid characters" do
     m = Mail.new
     m['Subject'] = Mail::SubjectField.new("=?utf-8?Q?Hello_=96_World?=")
     if RUBY_VERSION > '1.9'
-      lambda { m.subject.should be_valid_encoding }.should_not raise_error
+      expect { expect(m.subject).to be_valid_encoding }.not_to raise_error
     else
-      m.subject.should eq "Hello  World"
+      expect(m.subject).to eq "Hello  World"
     end
   end
 end

--- a/spec/mail/encodings/base64_spec.rb
+++ b/spec/mail/encodings/base64_spec.rb
@@ -4,22 +4,22 @@ describe Mail::Encodings::Base64 do
   
   it "should encode base 64 from text" do
     result = "VGhpcyBpcyBhIHRlc3Q=\r\n"
-    Mail::Encodings::Base64.encode('This is a test').should eq result
+    expect(Mail::Encodings::Base64.encode('This is a test')).to eq result
   end
   
   it "should decode base 64 text" do
     result = 'This is a test'
-    Mail::Encodings::Base64.decode("VGhpcyBpcyBhIHRlc3Q=\n").should eq result
+    expect(Mail::Encodings::Base64.decode("VGhpcyBpcyBhIHRlc3Q=\n")).to eq result
   end
   
   it "should encode base 64 from binary" do
     result = "AAAAAA==\r\n"
-    Mail::Encodings::Base64.encode("\000\000\000\000").should eq result
+    expect(Mail::Encodings::Base64.encode("\000\000\000\000")).to eq result
   end
   
   it "should decode base 64 text" do
     result = "\000\000\000\000"
-    Mail::Encodings::Base64.decode("AAAAAA==\n").should eq result
+    expect(Mail::Encodings::Base64.decode("AAAAAA==\n")).to eq result
   end
   
 end

--- a/spec/mail/encodings/quoted_printable_spec.rb
+++ b/spec/mail/encodings/quoted_printable_spec.rb
@@ -4,39 +4,39 @@ describe Mail::Encodings::QuotedPrintable do
   
   it "should encode quoted printable from text" do
     result = "This is\r\na test=\r\n"
-    Mail::Encodings::QuotedPrintable.encode("This is\na test").should eq result
+    expect(Mail::Encodings::QuotedPrintable.encode("This is\na test")).to eq result
   end
 
   it "should encode quoted printable from crlf text" do
     result = "This is\r\na test=\r\n"
-    Mail::Encodings::QuotedPrintable.encode("This is\r\na test").should eq result
+    expect(Mail::Encodings::QuotedPrintable.encode("This is\r\na test")).to eq result
   end
 
   it "should encode quoted printable from cr text" do
     result = "This is\r\na test=\r\n"
-    Mail::Encodings::QuotedPrintable.encode("This is\ra test").should eq result
+    expect(Mail::Encodings::QuotedPrintable.encode("This is\ra test")).to eq result
   end
   
   it "should decode quoted printable" do
     result = "This is\na test"
-    Mail::Encodings::QuotedPrintable.decode("This is\r\na test").should eq result
+    expect(Mail::Encodings::QuotedPrintable.decode("This is\r\na test")).to eq result
   end
   
   it "should encode quoted printable from binary" do
     result = "=00=00=00=00=\r\n"
-    Mail::Encodings::QuotedPrintable.encode("\000\000\000\000").should eq result
+    expect(Mail::Encodings::QuotedPrintable.encode("\000\000\000\000")).to eq result
   end
   
   it "should decode quoted printable text" do
     result = "\000\000\000\000"
-    Mail::Encodings::QuotedPrintable.decode("=00=00=00=00").should eq result
+    expect(Mail::Encodings::QuotedPrintable.decode("=00=00=00=00")).to eq result
   end
 
   %w(=0D =0A =0D=0A).each do |linebreak|
     expected = "first line wraps\n\nsecond paragraph"
     it "should cope with inappropriate #{linebreak} line break encoding" do
       body = "first line=\r\n wraps#{linebreak}\r\n#{linebreak}\r\nsecond paragraph=\r\n"
-      Mail::Encodings::QuotedPrintable.decode(body).should eq expected
+      expect(Mail::Encodings::QuotedPrintable.decode(body)).to eq expected
     end
   end
 
@@ -44,7 +44,7 @@ describe Mail::Encodings::QuotedPrintable do
     expected = "first line wraps\n\nsecond paragraph"
     it "should allow encoded #{linebreak} line breaks with soft line feeds" do
       body = "first line=\r\n wraps#{linebreak}=\r\n#{linebreak}=\r\nsecond paragraph=\r\n"
-      Mail::Encodings::QuotedPrintable.decode(body).should eq expected
+      expect(Mail::Encodings::QuotedPrintable.decode(body)).to eq expected
     end
   end
   

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -6,27 +6,27 @@ describe Mail::Encodings do
   describe "base64 Encoding" do
 
     it "should return true for base64" do
-      Mail::Encodings.defined?('base64').should be_true
+      expect(Mail::Encodings.defined?('base64')).to be_true
     end
 
     it "should return true for Base64" do
-      Mail::Encodings.defined?('Base64').should be_true
+      expect(Mail::Encodings.defined?('Base64')).to be_true
     end
 
     it "should return true for :base64" do
-      Mail::Encodings.defined?(:base64).should be_true
+      expect(Mail::Encodings.defined?(:base64)).to be_true
     end
 
     it "should return the Base64 Encoding class" do
-      Mail::Encodings.get_encoding('Base64').should eq Mail::Encodings::Base64
+      expect(Mail::Encodings.get_encoding('Base64')).to eq Mail::Encodings::Base64
     end
 
     it "should return the base64 Encoding class" do
-      Mail::Encodings.get_encoding('base64').should eq Mail::Encodings::Base64
+      expect(Mail::Encodings.get_encoding('base64')).to eq Mail::Encodings::Base64
     end
 
     it "should return the base64 Encoding class" do
-      Mail::Encodings.get_encoding(:base64).should eq Mail::Encodings::Base64
+      expect(Mail::Encodings.get_encoding(:base64)).to eq Mail::Encodings::Base64
     end
 
   end
@@ -34,27 +34,27 @@ describe Mail::Encodings do
   describe "quoted-printable Encoding" do
 
     it "should return true for quoted-printable" do
-      Mail::Encodings.defined?('quoted-printable').should be_true
+      expect(Mail::Encodings.defined?('quoted-printable')).to be_true
     end
 
     it "should return true for Quoted-Printable" do
-      Mail::Encodings.defined?('Quoted-Printable').should be_true
+      expect(Mail::Encodings.defined?('Quoted-Printable')).to be_true
     end
 
     it "should return true for :quoted_printable" do
-      Mail::Encodings.defined?(:quoted_printable).should be_true
+      expect(Mail::Encodings.defined?(:quoted_printable)).to be_true
     end
 
     it "should return the QuotedPrintable Encoding class" do
-      Mail::Encodings.get_encoding('quoted-printable').should eq Mail::Encodings::QuotedPrintable
+      expect(Mail::Encodings.get_encoding('quoted-printable')).to eq Mail::Encodings::QuotedPrintable
     end
 
     it "should return the QuotedPrintable Encoding class" do
-      Mail::Encodings.get_encoding('Quoted-Printable').should eq Mail::Encodings::QuotedPrintable
+      expect(Mail::Encodings.get_encoding('Quoted-Printable')).to eq Mail::Encodings::QuotedPrintable
     end
 
     it "should return the QuotedPrintable Encoding class" do
-      Mail::Encodings.get_encoding(:quoted_printable).should eq Mail::Encodings::QuotedPrintable
+      expect(Mail::Encodings.get_encoding(:quoted_printable)).to eq Mail::Encodings::QuotedPrintable
     end
 
   end
@@ -81,10 +81,10 @@ describe Mail::Encodings do
       result = "This is a string"
       if RUBY_VERSION >= "1.9.1"
         string = string.force_encoding('US-ASCII')
-        Mail::Encodings.b_value_encode(string).should eq(result)
+        expect(Mail::Encodings.b_value_encode(string)).to eq(result)
       else
         encoding = 'US-ASCII'
-        Mail::Encodings.b_value_encode(string, encoding).should eq(result)
+        expect(Mail::Encodings.b_value_encode(string, encoding)).to eq(result)
       end
     end
 
@@ -93,11 +93,11 @@ describe Mail::Encodings do
       result = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       if RUBY_VERSION >= "1.9.1"
         string = string.force_encoding('UTF-8')
-        Mail::Encodings.b_value_encode(string).should eq(result)
+        expect(Mail::Encodings.b_value_encode(string)).to eq(result)
       else
         string = "This is あ string"
         encoding = 'UTF-8'
-        Mail::Encodings.b_value_encode(string, encoding).should eq(result)
+        expect(Mail::Encodings.b_value_encode(string, encoding)).to eq(result)
       end
     end
 
@@ -105,9 +105,9 @@ describe Mail::Encodings do
       string = "This is あ string"
       if RUBY_VERSION >= "1.9.1"
         string = string.force_encoding('UTF-8')
-        doing {Mail::Encodings.b_value_encode(string)}.should_not raise_error
+        expect(doing {Mail::Encodings.b_value_encode(string)}).not_to raise_error
       else
-        doing {Mail::Encodings.b_value_encode(string, nil)}.should raise_error("Must supply an encoding")
+        expect(doing {Mail::Encodings.b_value_encode(string, nil)}).to raise_error("Must supply an encoding")
       end
     end
 
@@ -116,10 +116,10 @@ describe Mail::Encodings do
       result = '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
       if RUBY_VERSION >= "1.9.1"
         string = string.force_encoding('UTF-8')
-        Mail::Encodings.b_value_encode(string).should eq(result)
+        expect(Mail::Encodings.b_value_encode(string)).to eq(result)
       else
         encoding = 'UTF-8'
-        Mail::Encodings.b_value_encode(string, encoding).should eq(result)
+        expect(Mail::Encodings.b_value_encode(string, encoding)).to eq(result)
       end
     end
 
@@ -127,65 +127,65 @@ describe Mail::Encodings do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should decode a long encoded string" do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GCIHJl?= =?UTF-8?B?YWxseSBsb25nIHN0cmluZyBUaGlzIGlzIOOBgiByZWFsbHkgbG9uZyBzdHJp?= =?UTF-8?B?bmcgVGhpcyBpcyDjgYIgcmVhbGx5IGxvbmcgc3RyaW5nIFRoaXMgaXMg44GC?= =?UTF-8?B?IHJlYWxseSBsb25nIHN0cmluZw==?='
       result = "This is あ really long string This is あ really long string This is あ really long string This is あ really long string This is あ really long string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should decode UTF-16 encoded string" do
       string = "=?UTF-16?B?MEIwRDBGMEgwSg==?="
       result = "あいうえお"
-      Mail::Encodings.value_decode(string).should == result
+      expect(Mail::Encodings.value_decode(string)).to eq(result)
     end
 
     it "should decode UTF-32 encoded string" do
       string = "=?UTF-32?B?AAAwQgAAMEQAADBGAAAwSAAAMEo=?="
       result = "あいうえお"
-      Mail::Encodings.value_decode(string).should == result
+      expect(Mail::Encodings.value_decode(string)).to eq(result)
     end
 
     it "should decode a string that looks similar to an encoded string (contains '=?')" do
       string = "1+1=?"
-      Mail::Encodings.value_decode(string).should == string
+      expect(Mail::Encodings.value_decode(string)).to eq(string)
     end
 
     it "should collapse adjacent words" do
       string = "=?utf-8?B?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?=\n =?utf-8?B?0LXQtdCy?="
       result = "новый сотрудник — дорофеев"
-      Mail::Encodings.value_decode(string).should == result
+      expect(Mail::Encodings.value_decode(string)).to eq(result)
     end
 
     it "should parse adjacent words with no space" do
       string = "=?utf-8?B?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?==?utf-8?B?0LXQtdCy?="
       result = "новый сотрудник — дорофеев"
-      Mail::Encodings.value_decode(string).should == result
+      expect(Mail::Encodings.value_decode(string)).to eq(result)
     end
 
     if '1.9'.respond_to?(:force_encoding)
       it "should decode 8bit encoded string" do
         string = "=?8bit?Q?ALPH=C3=89E?="
         result = "ALPH\xC3\x89E"
-        Mail::Encodings.value_decode(string).should == result
+        expect(Mail::Encodings.value_decode(string)).to eq(result)
       end
 
       it "should decode ks_c_5601-1987 encoded string" do
         string = '=?ks_c_5601-1987?B?seggx/bB+A==?= <a@b.org>'.force_encoding('us-ascii')
-        Mail::Encodings.value_decode(string).should == "김 현진 <a@b.org>"
+        expect(Mail::Encodings.value_decode(string)).to eq("김 현진 <a@b.org>")
       end
 
       it "should decode shift-jis encoded string" do
         string = '=?shift-jis?Q?=93=FA=96{=8C=EA=?='.force_encoding('us-ascii')
-        Mail::Encodings.value_decode(string).should == "日本語"
+        expect(Mail::Encodings.value_decode(string)).to eq("日本語")
       end
 
       it "should decode GB18030 encoded string misidentified as GB2312" do
         string = '=?GB2312?B?6V8=?='.force_encoding('us-ascii')
-        Mail::Encodings.value_decode(string).should == "開"
+        expect(Mail::Encodings.value_decode(string)).to eq("開")
       end
     end
   end
@@ -211,11 +211,11 @@ describe Mail::Encodings do
       if RUBY_VERSION >= "1.9.1"
         string = "This is a string"
         string = string.force_encoding('US-ASCII')
-        Mail::Encodings.q_value_encode(string).should eq "This is a string"
+        expect(Mail::Encodings.q_value_encode(string)).to eq "This is a string"
       else
         string = "This is a string"
         encoding = 'US-ASCII'
-        Mail::Encodings.q_value_encode(string, encoding).should eq "This is a string"
+        expect(Mail::Encodings.q_value_encode(string, encoding)).to eq "This is a string"
       end
     end
 
@@ -223,10 +223,10 @@ describe Mail::Encodings do
       if RUBY_VERSION >= "1.9.1"
         string = "This is あ string"
         string = string.force_encoding('UTF-8')
-        doing {Mail::Encodings.q_value_encode(string)}.should_not raise_error
+        expect(doing {Mail::Encodings.q_value_encode(string)}).not_to raise_error
       else
         string = "This is あ string"
-        doing {Mail::Encodings.q_value_encode(string)}.should raise_error("Must supply an encoding")
+        expect(doing {Mail::Encodings.q_value_encode(string)}).to raise_error("Must supply an encoding")
       end
     end
 
@@ -234,11 +234,11 @@ describe Mail::Encodings do
       if RUBY_VERSION >= "1.9.1"
         string = "This is あ string"
         string = string.force_encoding('UTF-8')
-        Mail::Encodings.q_value_encode(string).should eq '=?UTF-8?Q?This_is_=E3=81=82_string?='
+        expect(Mail::Encodings.q_value_encode(string)).to eq '=?UTF-8?Q?This_is_=E3=81=82_string?='
       else
         string = "This is あ string"
         encoding = 'UTF-8'
-        Mail::Encodings.q_value_encode(string, encoding).should eq '=?UTF-8?Q?This_is_=E3=81=82_string?='
+        expect(Mail::Encodings.q_value_encode(string, encoding)).to eq '=?UTF-8?Q?This_is_=E3=81=82_string?='
       end
     end
 
@@ -246,21 +246,21 @@ describe Mail::Encodings do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect a q encoded string and decode it" do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should decode q encoded =5F as underscore" do
       string = "=?UTF-8?Q?This_=C2=AD_and=5Fthat?="
       result = "This ­ and_that"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should not fold a long string that has no spaces" do
@@ -273,8 +273,8 @@ describe Mail::Encodings do
       end
       mail = Mail.new
       mail.subject = original
-      mail[:subject].decoded.should eq original
-      mail[:subject].encoded.should eq result
+      expect(mail[:subject].decoded).to eq original
+      expect(mail[:subject].encoded).to eq result
     end
 
     it "should round trip a complex string properly" do
@@ -285,14 +285,14 @@ describe Mail::Encodings do
       result = "Subject: =?UTF-8?Q?=D0=92=D0=BE=D1=81=D1=81=D1=82=D0=B0=D0=BD=D0=BE=D0=B2=D0=BB=D0=B5=D0=BD=D0=B8=D0=B5=D0=92=D0=BE=D1=81=D1=81=D1=82=D0=B0=D0=BD=D0=BE=D0=B2=D0=BB=D0=B5=D0=BD=D0=B8=D0=B5=D0=92=D0=B0=D1=88=D0=B5=D0=B3=D0=BE=D0=BF=D0=B0=D1=80=D0=BE=D0=BB=D1=8F?=\r\n =?UTF-8?Q?_This_is_a_NUT=3F=3F=3F=3F=3FZ=5F=5Fstring_that=3D=3D_could?=\r\n =?UTF-8?Q?_=28break=29_anything?=\r\n"
       mail = Mail.new
       mail.subject = original
-      mail[:subject].decoded.should eq original
-      mail[:subject].encoded.should eq result
+      expect(mail[:subject].decoded).to eq original
+      expect(mail[:subject].encoded).to eq result
       mail = Mail.new(mail.encoded)
-      mail[:subject].decoded.should eq original
-      mail[:subject].encoded.should eq result
+      expect(mail[:subject].decoded).to eq original
+      expect(mail[:subject].encoded).to eq result
       mail = Mail.new(mail.encoded)
-      mail[:subject].decoded.should eq original
-      mail[:subject].encoded.should eq result
+      expect(mail[:subject].decoded).to eq original
+      expect(mail[:subject].encoded).to eq result
     end
 
     it "should round trip another complex string (koi-8)" do
@@ -302,7 +302,7 @@ describe Mail::Encodings do
       mail[:subject].charset = 'koi8-r'
       wrapped = mail[:subject].wrapped_value
       unwrapped = Mail::Encodings.value_decode(wrapped)
-      unwrapped.gsub("Subject: ", "").should eq original
+      expect(unwrapped.gsub("Subject: ", "")).to eq original
     end
   end
 
@@ -311,7 +311,7 @@ describe Mail::Encodings do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= =?UTF-8?Q?_This_was_=E3=81=82_string?='
       result = "This is あ string This was あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
   end
 
@@ -353,54 +353,54 @@ describe Mail::Encodings do
     it "should leave an unencoded string alone" do
       string = "this isn't encoded"
       result = "this isn't encoded"
-      Mail::Encodings.param_decode(string, 'us-ascii').should eq result
+      expect(Mail::Encodings.param_decode(string, 'us-ascii')).to eq result
     end
 
     it "should unencode an encoded string" do
       string = "This%20is%20even%20more%20"
       result = "This is even more "
       result.force_encoding('us-ascii') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.param_decode(string, 'us-ascii').should eq result
+      expect(Mail::Encodings.param_decode(string, 'us-ascii')).to eq result
     end
 
     it "should unencoded an encoded string and return the right charset on 1.9" do
       string = "This%20is%20even%20more%20"
       result = "This is even more "
       result.force_encoding('us-ascii') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.param_decode(string, 'us-ascii').should eq result
+      expect(Mail::Encodings.param_decode(string, 'us-ascii')).to eq result
     end
 
     it "should unencode a complete string that included unencoded parts" do
       string = "This%20is%20even%20more%20%2A%2A%2Afun%2A%2A%2A%20isn't it"
       result = "This is even more ***fun*** isn't it"
       result.force_encoding('iso-8859-1') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.param_decode(string, 'iso-8859-1').should eq result
+      expect(Mail::Encodings.param_decode(string, 'iso-8859-1')).to eq result
     end
 
     it "should encode a string" do
       string = "This is  あ string"
       if RUBY_VERSION >= '1.9'
-        Mail::Encodings.param_encode(string).should eq "utf-8'en'This%20is%20%20%E3%81%82%20string"
+        expect(Mail::Encodings.param_encode(string)).to eq "utf-8'en'This%20is%20%20%E3%81%82%20string"
       else
-        Mail::Encodings.param_encode(string).should eq "utf8'en'This%20is%20%20%E3%81%82%20string"
+        expect(Mail::Encodings.param_encode(string)).to eq "utf8'en'This%20is%20%20%E3%81%82%20string"
       end
     end
 
     it "should just quote US-ASCII with spaces" do
       string = "This is even more"
       if RUBY_VERSION >= '1.9'
-        Mail::Encodings.param_encode(string).should eq '"This is even more"'
+        expect(Mail::Encodings.param_encode(string)).to eq '"This is even more"'
       else
-        Mail::Encodings.param_encode(string).should eq '"This is even more"'
+        expect(Mail::Encodings.param_encode(string)).to eq '"This is even more"'
       end
     end
 
     it "should leave US-ASCII without spaces alone" do
       string = "fun"
       if RUBY_VERSION >= '1.9'
-        Mail::Encodings.param_encode(string).should eq 'fun'
+        expect(Mail::Encodings.param_encode(string)).to eq 'fun'
       else
-        Mail::Encodings.param_encode(string).should eq 'fun'
+        expect(Mail::Encodings.param_encode(string)).to eq 'fun'
       end
     end
 
@@ -412,108 +412,108 @@ describe Mail::Encodings do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect a multiple encoded Base64 string to the decoded string" do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?==?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect a multiple encoded Base64 string with a space to the decoded string" do
       string = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= =?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect a multiple encoded Base64 string with a whitespace to the decoded string" do
       string = "=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= \r\n\s=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?="
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should decode B and Q encodings together if needed" do
       string = "=?UTF-8?Q?This_is_=E3=81=82_string?==?UTF-8?Q?This_is_=E3=81=82_string?= Some non encoded stuff =?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= \r\n\sMore non encoded stuff"
       result = "This is あ stringThis is あ string Some non encoded stuff This is あ string \r\n\sMore non encoded stuff"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect a encoded and unencoded Base64 string to the decoded string" do
       string = "Some non encoded stuff =?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?= \r\n\sMore non encoded stuff"
       result = "Some non encoded stuff This is あ string \r\n\sMore non encoded stuff"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect an encoded QP string to the decoded string" do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should decode UTF-16 encoded string" do
       string = "=?UTF-16?Q?0B0D0F0H0J=?="
       result = "あいうえお"
-      Mail::Encodings.value_decode(string).should == result
+      expect(Mail::Encodings.value_decode(string)).to eq(result)
     end
 
     it "should decode UTF-32 encoded string" do
       string = "=?UTF-32?Q?=00=000B=00=000D=00=000F=00=000H=00=000J=?="
       result = "あいうえお"
-      Mail::Encodings.value_decode(string).should == result
+      expect(Mail::Encodings.value_decode(string)).to eq(result)
     end
 
     it "should detect multiple encoded QP string to the decoded string" do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?==?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect multiple encoded QP string with a space to the decoded string" do
       string = '=?UTF-8?Q?This_is_=E3=81=82_string?= =?UTF-8?Q?This_is_=E3=81=82_string?='
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect multiple encoded QP string with a space to the decoded string" do
       string = "=?UTF-8?Q?This_is_=E3=81=82_string?= \r\n\s=?UTF-8?Q?This_is_=E3=81=82_string?="
       result = "This is あ stringThis is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect a encoded and unencoded QP string to the decoded string" do
       string = "Some non encoded stuff =?UTF-8?Q?This_is_=E3=81=82_string?= \r\n\sMore non encoded stuff"
       result = "Some non encoded stuff This is あ string \r\n\sMore non encoded stuff"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should detect a plain string and return it" do
       string = 'This is あ string'
       result = "This is あ string"
       result.force_encoding('UTF-8') if RUBY_VERSION >= '1.9'
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
 
     it "should handle a very long string efficiently" do
       string = "This is a string " * 10000
-      Mail::Encodings.value_decode(string).should eq string
+      expect(Mail::Encodings.value_decode(string)).to eq string
     end
 
     it "should handle Base64 encoded ISO-2022-JP string" do
       pending
       string = "ISO-2022-JP =?iso-2022-jp?B?GyRCJCQkPSRLITwkXiRrJEskSyE8JDgkJyQkJFQhPBsoQg==?="
       result = "ISO-2022-JP いそにーまるににーじぇいぴー"
-      Mail::Encodings.value_decode(string).should eq result
+      expect(Mail::Encodings.value_decode(string)).to eq result
     end
   end
 
@@ -537,7 +537,7 @@ describe Mail::Encodings do
         else
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :decode).should eq result
+        expect(Mail::Encodings.decode_encode(string, :decode)).to eq result
       end
 
       it "should detect an encoded QP string and return the decoded string" do
@@ -548,7 +548,7 @@ describe Mail::Encodings do
         else
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :decode).should eq result
+        expect(Mail::Encodings.decode_encode(string, :decode)).to eq result
       end
 
       it "should detect an a string is already decoded and leave it alone" do
@@ -559,7 +559,7 @@ describe Mail::Encodings do
         else
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :decode).should eq result
+        expect(Mail::Encodings.decode_encode(string, :decode)).to eq result
       end
 
     end
@@ -575,7 +575,7 @@ describe Mail::Encodings do
           result = '=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n?='
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :encode).should eq result
+        expect(Mail::Encodings.decode_encode(string, :encode)).to eq result
       end
 
       it "should leave a string that doesn't need encoding alone" do
@@ -586,7 +586,7 @@ describe Mail::Encodings do
         else
           $KCODE = 'UTF-8'
         end
-        Mail::Encodings.decode_encode(string, :encode).should eq result
+        expect(Mail::Encodings.decode_encode(string, :encode)).to eq result
       end
 
     end
@@ -595,31 +595,31 @@ describe Mail::Encodings do
       it "should unquote quoted printable and convert to utf-8" do
         a ="=?ISO-8859-1?Q?[166417]_Bekr=E6ftelse_fra_Rejsefeber?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "[166417] Bekr\303\246ftelse fra Rejsefeber"
+        expect(b).to eq "[166417] Bekr\303\246ftelse fra Rejsefeber"
       end
 
       it "should unquote base64 and convert to utf-8" do
         a ="=?ISO-8859-1?B?WzE2NjQxN10gQmVrcuZmdGVsc2UgZnJhIFJlanNlZmViZXI=?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "[166417] Bekr\303\246ftelse fra Rejsefeber"
+        expect(b).to eq "[166417] Bekr\303\246ftelse fra Rejsefeber"
       end
 
       it "should handle no charset" do
         a ="[166417]_Bekr=E6ftelse_fra_Rejsefeber"
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "[166417]_Bekr=E6ftelse_fra_Rejsefeber"
+        expect(b).to eq "[166417]_Bekr=E6ftelse_fra_Rejsefeber"
       end
 
       it "should unquote multiple lines" do
         a ="=?utf-8?q?Re=3A_=5B12=5D_=23137=3A_Inkonsistente_verwendung_von_=22Hin?==?utf-8?b?enVmw7xnZW4i?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "Re: [12] #137: Inkonsistente verwendung von \"Hinzuf\303\274gen\""
+        expect(b).to eq "Re: [12] #137: Inkonsistente verwendung von \"Hinzuf\303\274gen\""
       end
 
       it "should unquote a string in the middle of the text" do
         a ="Re: Photos =?ISO-8859-1?Q?Brosch=FCre_Rand?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "Re: Photos Brosch\303\274re Rand"
+        expect(b).to eq "Re: Photos Brosch\303\274re Rand"
       end
 
       it "should unquote and change to an ISO encoding if we really want" do
@@ -627,13 +627,13 @@ describe Mail::Encodings do
         b = Mail::Encodings.unquote_and_convert_to(a, 'iso-8859-1')
         expected = "Brosch\374re Rand"
         expected.force_encoding('iso-8859-1') if expected.respond_to?(:force_encoding)
-        b.should eq expected
+        expect(b).to eq expected
       end
 
       it "should unquote Shift_JIS QP with trailing =" do
         a = "=?Shift_JIS?Q?=93=FA=96{=8C=EA=?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "日本語"
+        expect(b).to eq "日本語"
       end
 
       it "handles Windows 1252 QP encoding" do
@@ -642,36 +642,36 @@ describe Mail::Encodings do
 
         a = "=?WINDOWS-1252?Q?simple_=96_dash_=96_?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "simple – dash – "
+        expect(b).to eq "simple – dash – "
       end
 
       it "should recognize iso646-us" do
         decoded = Mail::Encodings.value_decode "[kj] =?ISO646-US?Q?Re:_[kj]_[KJ]_Money_is_not_our_god_should_?=\r\n =?ISO646-US?Q?be_played_on_US_Tour...+_Elys=3Fe_Montmartre?="
-        decoded.should == "[kj] Re: [kj] [KJ] Money is not our god should be played on US Tour...+ Elys?e Montmartre"
+        expect(decoded).to eq("[kj] Re: [kj] [KJ] Money is not our god should be played on US Tour...+ Elys?e Montmartre")
       end
 
       it "should unquote multiple strings in the middle of the text" do
         a = "=?Shift_JIS?Q?=93=FA=96{=8C=EA=?= <a@example.com>, =?Shift_JIS?Q?=93=FA=96{=8C=EA=?= <b@example.com>"
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "日本語 <a@example.com>, 日本語 <b@example.com>"
+        expect(b).to eq "日本語 <a@example.com>, 日本語 <b@example.com>"
       end
 
       it "should handle multiline quoted headers with mixed content" do
         a = "=?iso-2022-jp?B?GyRCP3AwQxsoQg==?=2=?iso-2022-jp?B?GyRCIiobKEI=?= =?iso-2022-jp?B?GyRCOkc2YUxnPj4kcj5+JGsySCQsJFskSCRzJEk4K0V2GyhC?= =?iso-2022-jp?B?GyRCJD8kaSRKJCQhKjxkJDckJCQzJEgkRyQ5JE0hI0Z8GyhC?= =?iso-2022-jp?B?GyRCS1wkTiQkJCQkSCQzJG0hIiRvJFMkNSRTJE5AJDMmGyhC?= =?iso-2022-jp?B?GyRCJCw8OiRvJGwkRCREJCIkazg9Ol8hIiRKJHMkSCQrGyhC?= =?iso-2022-jp?B?GyRCOGVAJCRLO0QkNSRNJFAhIkxeQk4kSiQkISokSCReGyhC?= =?iso-2022-jp?B?GyRCJF4kTztXJCYkTiRAISMbKEI=?="
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "瑞庵2→最近門松を飾る家がほとんど見当たらない！寂しいことですね。日本のいいところ、わびさびの世界が失われつつある現在、なんとか後世に残さねば、勿体ない！とままは思うのだ。"
+        expect(b).to eq "瑞庵2→最近門松を飾る家がほとんど見当たらない！寂しいことですね。日本のいいところ、わびさびの世界が失われつつある現在、なんとか後世に残さねば、勿体ない！とままは思うのだ。"
       end
 
       it "should handle quoted string with mixed content that have a plain string at the end" do
         a = 'Der Kunde ist K=?utf-8?B?w7Y=?=nig'
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "Der Kunde ist König"
+        expect(b).to eq "Der Kunde ist König"
       end
 
       it "should handle utf_8" do
         a = 'Der Kunde ist K=?utf_8?B?w7Y=?=nig'
         b = Mail::Encodings.unquote_and_convert_to(a, 'utf-8')
-        b.should eq "Der Kunde ist König"
+        expect(b).to eq "Der Kunde ist König"
       end
 
     end
@@ -680,18 +680,18 @@ describe Mail::Encodings do
   describe "quoted printable encoding and decoding" do
     it "should handle underscores in the text" do
       expected = 'something_with_underscores'
-      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("M").first.should eq expected
+      expect(Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("M").first).to eq expected
     end
 
     it "should handle underscores in the text" do
       expected = 'something with_underscores'
-      Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("M").first.should eq expected
+      expect(Mail::Encodings.get_encoding(:quoted_printable).encode(expected).unpack("M").first).to eq expected
     end
 
     it "should keep the underscores in the text" do
       expected = 'something_with_underscores'
       encoded = Mail::Encodings.get_encoding(:quoted_printable).encode(expected)
-      Mail::Encodings.get_encoding(:quoted_printable).decode(encoded).should eq expected
+      expect(Mail::Encodings.get_encoding(:quoted_printable).decode(encoded)).to eq expected
     end
 
     it "should handle a new line in the text" do
@@ -701,7 +701,7 @@ describe Mail::Encodings do
         expected = Iconv.conv("UTF-8", "ISO-8859-1", "\nRe: ol\341")
       end
       encoded = "=?ISO-8859-1?Q?\nRe=3A_ol=E1?="
-      Mail::Encodings.value_decode(encoded).should eq expected
+      expect(Mail::Encodings.value_decode(encoded)).to eq expected
     end
 
   end
@@ -709,67 +709,67 @@ describe Mail::Encodings do
   describe "pre encoding non usascii text" do
     it "should not change an ascii string" do
       raw     = 'mikel@test.lindsaar.net'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq raw
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq raw
     end
 
     it "should encode a display that contains non usascii" do
       raw     = 'Lindsああr <mikel@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode a single token that contains non usascii" do
       raw     = '<mikelああ@test.lindsaar.net>'
       encoded = Mail::Encodings.encode_non_usascii(raw, 'utf-8')
-      Mail::Encodings.value_decode(encoded).should eq raw
+      expect(Mail::Encodings.value_decode(encoded)).to eq raw
     end
 
     it "should encode a display that contains non usascii with quotes as no quotes" do
       raw     = '"Lindsああr" <mikel@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode a display name with us-ascii and non-usascii parts" do
       raw     = 'Mikel Lindsああr <mikel@test.lindsaar.net>'
       encoded = 'Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode a display name with us-ascii and non-usascii parts ignoring quotes" do
       raw     = '"Mikel Lindsああr" <mikel@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode a quoted display name with us-ascii and non-usascii that ends with a non-usascii part" do
       raw     = '"Marc André" <marc@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TWFyYyBBbmRyw6k=?= <marc@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode multiple addresses correctly" do
       raw     = '"Mikel Lindsああr" <mikel@test.lindsaar.net>, "あdあ" <ada@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode multiple unquoted addresses correctly" do
       raw     = 'Mikel Lindsああr <mikel@test.lindsaar.net>, あdあ <ada@test.lindsaar.net>'
       encoded = 'Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode multiple un bracketed addresses and groups correctly" do
       raw     = '"Mikel Lindsああr" test1@lindsaar.net, group: "あdあ" test2@lindsaar.net, me@lindsaar.net;'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= test1@lindsaar.net, group: =?UTF-8?B?44GCZOOBgg==?= test2@lindsaar.net, me@lindsaar.net;'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
     it "should correctly match and encode non-usascii letters at the end of a quoted string" do
       raw = '"Felix Baarß" <test@example.com>'
       encoded = '=?UTF-8?B?RmVsaXggQmFhcsOf?= <test@example.com>'
-      Mail::Encodings.encode_non_usascii(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
   end
 
@@ -777,45 +777,45 @@ describe Mail::Encodings do
     it "should not do anything to a plain address" do
       raw     = 'mikel@test.lindsaar.net'
       encoded = 'mikel@test.lindsaar.net'
-      Mail::Encodings.address_encode(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.address_encode(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode an address correctly" do
       raw     = '"Mikel Lindsああr" <mikel@test.lindsaar.net>'
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.address_encode(raw, 'utf-8')).to eq encoded
     end
 
     it "should encode multiple addresses correctly" do
       raw     = ['"Mikel Lindsああr" <mikel@test.lindsaar.net>', '"あdあ" <ada@test.lindsaar.net>']
       encoded = '=?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.address_encode(raw, 'utf-8')).to eq encoded
     end
 
     it "should handle a single ascii address correctly from a string" do
       raw     = ['"Mikel Lindsaar" <mikel@test.lindsaar.net>']
       encoded = '"Mikel Lindsaar" <mikel@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.address_encode(raw, 'utf-8')).to eq encoded
     end
 
     it "should handle multiple ascii addresses correctly from a string" do
       raw     = 'Mikel Lindsaar <mikel@test.lindsaar.net>, Ada <ada@test.lindsaar.net>'
       encoded = 'Mikel Lindsaar <mikel@test.lindsaar.net>, Ada <ada@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.address_encode(raw, 'utf-8')).to eq encoded
     end
 
     it "should handle ascii addresses correctly as an array" do
       raw     = ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'Ada <ada@test.lindsaar.net>']
       encoded = 'Mikel Lindsaar <mikel@test.lindsaar.net>, Ada <ada@test.lindsaar.net>'
-      Mail::Encodings.address_encode(raw, 'utf-8').should eq encoded
+      expect(Mail::Encodings.address_encode(raw, 'utf-8')).to eq encoded
     end
 
     it "should ignore single nil" do
-      Mail::Encodings.address_encode(nil, 'utf-8').should eq nil
+      expect(Mail::Encodings.address_encode(nil, 'utf-8')).to eq nil
     end
 
     it "should ignore nil in arrays" do
-      Mail::Encodings.address_encode(["aa@bb.com", nil], 'utf-8').should eq "aa@bb.com"
+      expect(Mail::Encodings.address_encode(["aa@bb.com", nil], 'utf-8')).to eq "aa@bb.com"
     end
   end
 

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -11,11 +11,11 @@ describe "Test emails" do
     # message identifier, and a textual message in the body.
     it "should handle the basic test email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example01.eml'))
-      mail.from.should eq ["jdoe@machine.example"]
-      mail.to.should eq ['mary@example.net']
-      mail.message_id.should eq '1234@local.machine.example'
-      mail.date.should eq ::DateTime.parse('21 Nov 1997 09:55:06 -0600')
-      mail.subject.should eq 'Saying Hello'
+      expect(mail.from).to eq ["jdoe@machine.example"]
+      expect(mail.to).to eq ['mary@example.net']
+      expect(mail.message_id).to eq '1234@local.machine.example'
+      expect(mail.date).to eq ::DateTime.parse('21 Nov 1997 09:55:06 -0600')
+      expect(mail.subject).to eq 'Saying Hello'
     end
 
     # From RFC 2822:
@@ -24,12 +24,12 @@ describe "Test emails" do
     # sender field would be used:
     it "should handle the sender test email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example02.eml'))
-      mail.from.should eq ['jdoe@machine.example']
-      mail.sender.should eq 'mjones@machine.example'
-      mail.to.should eq ['mary@example.net']
-      mail.message_id.should eq '1234@local.machine.example'
-      mail.date.should eq ::DateTime.parse('21 Nov 1997 09:55:06 -0600')
-      mail.subject.should eq 'Saying Hello'
+      expect(mail.from).to eq ['jdoe@machine.example']
+      expect(mail.sender).to eq 'mjones@machine.example'
+      expect(mail.to).to eq ['mary@example.net']
+      expect(mail.message_id).to eq '1234@local.machine.example'
+      expect(mail.date).to eq ::DateTime.parse('21 Nov 1997 09:55:06 -0600')
+      expect(mail.subject).to eq 'Saying Hello'
     end
 
     # From RFC 2822:
@@ -49,11 +49,11 @@ describe "Test emails" do
     # "Giant; \"Big\" Box" <sysservices@example.net>
     it "should handle multiple recipients test email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example03.eml'))
-      mail.from.should eq ['john.q.public@example.com']
-      mail.to.should eq ['mary@x.test', 'jdoe@example.org', 'one@y.test']
-      mail.cc.should eq ['boss@nil.test', "sysservices@example.net"]
-      mail.message_id.should eq '5678.21-Nov-1997@example.com'
-      mail.date.should eq ::DateTime.parse('1 Jul 2003 10:52:37 +0200')
+      expect(mail.from).to eq ['john.q.public@example.com']
+      expect(mail.to).to eq ['mary@x.test', 'jdoe@example.org', 'one@y.test']
+      expect(mail.cc).to eq ['boss@nil.test', "sysservices@example.net"]
+      expect(mail.message_id).to eq '5678.21-Nov-1997@example.com'
+      expect(mail.date).to eq ::DateTime.parse('1 Jul 2003 10:52:37 +0200')
     end
 
     # From RFC 2822:
@@ -63,11 +63,11 @@ describe "Test emails" do
     # group recipient named Undisclosed recipients.
     it "should handle group address email test" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example04.eml'))
-      mail.from.should eq ['pete@silly.example']
-      mail.to.should eq ['c@a.test', 'joe@where.test', 'jdoe@one.test']
-      mail[:cc].group_names.should eq ['Undisclosed recipients']
-      mail.message_id.should eq 'testabcd.1234@silly.example'
-      mail.date.should eq ::DateTime.parse('Thu, 13 Feb 1969 23:32:54 -0330')
+      expect(mail.from).to eq ['pete@silly.example']
+      expect(mail.to).to eq ['c@a.test', 'joe@where.test', 'jdoe@one.test']
+      expect(mail[:cc].group_names).to eq ['Undisclosed recipients']
+      expect(mail.message_id).to eq 'testabcd.1234@silly.example'
+      expect(mail.date).to eq ::DateTime.parse('Thu, 13 Feb 1969 23:32:54 -0330')
     end
 
 
@@ -82,11 +82,11 @@ describe "Test emails" do
     # fields in each message.
     it "should handle reply messages" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example05.eml'))
-      mail.from.should eq ["jdoe@machine.example"]
-      mail.to.should eq ['mary@example.net']
-      mail.subject.should eq 'Saying Hello'
-      mail.message_id.should eq '1234@local.machine.example'
-      mail.date.should eq ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
+      expect(mail.from).to eq ["jdoe@machine.example"]
+      expect(mail.to).to eq ['mary@example.net']
+      expect(mail.subject).to eq 'Saying Hello'
+      expect(mail.message_id).to eq '1234@local.machine.example'
+      expect(mail.date).to eq ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
     end
 
     # From RFC 2822:
@@ -97,27 +97,27 @@ describe "Test emails" do
     # "Reply-To:" field instead of the address in the "From:" field.
     it "should handle reply message 2" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example06.eml'))
-      mail.from.should eq ['mary@example.net']
-      mail.to.should eq ['jdoe@machine.example']
-      mail.reply_to.should eq ['smith@home.example']
-      mail.subject.should eq 'Re: Saying Hello'
-      mail.message_id.should eq '3456@example.net'
-      mail[:in_reply_to].message_ids.should eq ['1234@local.machine.example']
-      mail[:references].message_ids.should eq ['1234@local.machine.example']
-      mail.date.should eq ::DateTime.parse('Fri, 21 Nov 1997 10:01:10 -0600')
+      expect(mail.from).to eq ['mary@example.net']
+      expect(mail.to).to eq ['jdoe@machine.example']
+      expect(mail.reply_to).to eq ['smith@home.example']
+      expect(mail.subject).to eq 'Re: Saying Hello'
+      expect(mail.message_id).to eq '3456@example.net'
+      expect(mail[:in_reply_to].message_ids).to eq ['1234@local.machine.example']
+      expect(mail[:references].message_ids).to eq ['1234@local.machine.example']
+      expect(mail.date).to eq ::DateTime.parse('Fri, 21 Nov 1997 10:01:10 -0600')
     end
 
     # From RFC 2822:
     # Final reply message
     it "should handle the final reply message" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example07.eml'))
-      mail.to.should eq ['smith@home.example']
-      mail.from.should eq ['jdoe@machine.example']
-      mail.subject.should eq 'Re: Saying Hello'
-      mail.date.should eq ::DateTime.parse('Fri, 21 Nov 1997 11:00:00 -0600')
-      mail.message_id.should eq 'abcd.1234@local.machine.tld'
-      mail.in_reply_to.should eq '3456@example.net'
-      mail[:references].message_ids.should eq ['1234@local.machine.example', '3456@example.net']
+      expect(mail.to).to eq ['smith@home.example']
+      expect(mail.from).to eq ['jdoe@machine.example']
+      expect(mail.subject).to eq 'Re: Saying Hello'
+      expect(mail.date).to eq ::DateTime.parse('Fri, 21 Nov 1997 11:00:00 -0600')
+      expect(mail.message_id).to eq 'abcd.1234@local.machine.tld'
+      expect(mail.in_reply_to).to eq '3456@example.net'
+      expect(mail[:references].message_ids).to eq ['1234@local.machine.example', '3456@example.net']
     end
 
     # From RFC2822
@@ -135,15 +135,15 @@ describe "Test emails" do
     # and send that.
     it "should handle the rfc resent example email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example08.eml'))
-      mail.resent_from.should eq ['mary@example.net']
-      mail.resent_to.should eq ['j-brown@other.example']
-      mail.resent_date.should eq ::DateTime.parse('Mon, 24 Nov 1997 14:22:01 -0800')
-      mail.resent_message_id.should eq '78910@example.net'
-      mail.from.should eq ['jdoe@machine.example']
-      mail.to.should eq ['mary@example.net']
-      mail.subject.should eq 'Saying Hello'
-      mail.date.should eq ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
-      mail.message_id.should eq '1234@local.machine.example'
+      expect(mail.resent_from).to eq ['mary@example.net']
+      expect(mail.resent_to).to eq ['j-brown@other.example']
+      expect(mail.resent_date).to eq ::DateTime.parse('Mon, 24 Nov 1997 14:22:01 -0800')
+      expect(mail.resent_message_id).to eq '78910@example.net'
+      expect(mail.from).to eq ['jdoe@machine.example']
+      expect(mail.to).to eq ['mary@example.net']
+      expect(mail.subject).to eq 'Saying Hello'
+      expect(mail.date).to eq ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
+      expect(mail.message_id).to eq '1234@local.machine.example'
     end
 
     # A.4. Messages with trace fields
@@ -154,15 +154,15 @@ describe "Test emails" do
     # can be long.
     it "should handle the RFC trace example email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example09.eml'))
-      mail.received[0].info.should eq 'from x.y.test by example.net via TCP with ESMTP id ABC12345 for <mary@example.net>'
-      mail.received[0].date_time.should eq ::DateTime.parse('21 Nov 1997 10:05:43 -0600')
-      mail.received[1].info.should eq 'from machine.example by x.y.test'
-      mail.received[1].date_time.should eq ::DateTime.parse('21 Nov 1997 10:01:22 -0600')
-      mail.from.should eq ['jdoe@machine.example']
-      mail.to.should eq ['mary@example.net']
-      mail.subject.should eq 'Saying Hello'
-      mail.date.should eq ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
-      mail.message_id.should eq '1234@local.machine.example'
+      expect(mail.received[0].info).to eq 'from x.y.test by example.net via TCP with ESMTP id ABC12345 for <mary@example.net>'
+      expect(mail.received[0].date_time).to eq ::DateTime.parse('21 Nov 1997 10:05:43 -0600')
+      expect(mail.received[1].info).to eq 'from machine.example by x.y.test'
+      expect(mail.received[1].date_time).to eq ::DateTime.parse('21 Nov 1997 10:01:22 -0600')
+      expect(mail.from).to eq ['jdoe@machine.example']
+      expect(mail.to).to eq ['mary@example.net']
+      expect(mail.subject).to eq 'Saying Hello'
+      expect(mail.date).to eq ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
+      expect(mail.message_id).to eq '1234@local.machine.example'
     end
 
     # A.5. White space, comments, and other oddities
@@ -187,11 +187,11 @@ describe "Test emails" do
     it "should handle the rfc whitespace test email" do
       pending "fixed in pr#487"
       mail = Mail.read(fixture('emails', 'rfc2822', 'example10.eml'))
-      mail.from.should eq ["pete(his account)@silly.test"]
-      mail.to.should eq  ["c@public.example", "joe@example.org", "jdoe@one.test"]
-      mail[:cc].group_names.should eq ['(Empty list)(start)Undisclosed recipients ']
-      mail.date.should eq ::DateTime.parse('Thu, 13 Feb 1969 23:32 -0330')
-      mail.message_id.should eq 'testabcd.1234@silly.test'
+      expect(mail.from).to eq ["pete(his account)@silly.test"]
+      expect(mail.to).to eq  ["c@public.example", "joe@example.org", "jdoe@one.test"]
+      expect(mail[:cc].group_names).to eq ['(Empty list)(start)Undisclosed recipients ']
+      expect(mail.date).to eq ::DateTime.parse('Thu, 13 Feb 1969 23:32 -0330')
+      expect(mail.message_id).to eq 'testabcd.1234@silly.test'
     end
 
     # A.6. Obsoleted forms
@@ -206,11 +206,11 @@ describe "Test emails" do
     it "should handle the rfc obsolete addressing" do
       pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example11.eml'))
-      mail[:from].addresses.should eq ['john.q.public@example.com']
-      mail.from.should eq '"Joe Q. Public" <john.q.public@example.com>'
-      mail.to.should eq ["@machine.tld:mary@example.net", 'jdoe@test.example']
-      mail.date.should eq ::DateTime.parse('Tue, 1 Jul 2003 10:52:37 +0200')
-      mail.message_id.should eq '5678.21-Nov-1997@example.com'
+      expect(mail[:from].addresses).to eq ['john.q.public@example.com']
+      expect(mail.from).to eq '"Joe Q. Public" <john.q.public@example.com>'
+      expect(mail.to).to eq ["@machine.tld:mary@example.net", 'jdoe@test.example']
+      expect(mail.date).to eq ::DateTime.parse('Tue, 1 Jul 2003 10:52:37 +0200')
+      expect(mail.message_id).to eq '5678.21-Nov-1997@example.com'
     end
 
     # A.6.2. Obsolete dates
@@ -222,10 +222,10 @@ describe "Test emails" do
     it "should handle the rfc obsolete dates" do
       pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example12.eml'))
-      mail.from.should eq 'jdoe@machine.example'
-      mail.to.should eq 'mary@example.net'
-      mail.date.should eq ::DateTime.parse('21 Nov 97 09:55:06 GMT')
-      mail.message_id.should eq '1234@local.machine.example'
+      expect(mail.from).to eq 'jdoe@machine.example'
+      expect(mail.to).to eq 'mary@example.net'
+      expect(mail.date).to eq ::DateTime.parse('21 Nov 97 09:55:06 GMT')
+      expect(mail.message_id).to eq '1234@local.machine.example'
     end
 
     # A.6.3. Obsolete white space and comments
@@ -243,19 +243,19 @@ describe "Test emails" do
     it "should handle the rfc obsolete whitespace email" do
       pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example13.eml'))
-      mail.from.should eq 'John Doe <jdoe@machine(comment).example>'
-      mail.to.should eq 'Mary Smith <mary@example.net>'
-      mail.date.should eq ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
-      mail.message_id.should eq '1234@local(blah).machine.example'
-      doing { Mail::Message.new(email) }.should_not raise_error
+      expect(mail.from).to eq 'John Doe <jdoe@machine(comment).example>'
+      expect(mail.to).to eq 'Mary Smith <mary@example.net>'
+      expect(mail.date).to eq ::DateTime.parse('Fri, 21 Nov 1997 09:55:06 -0600')
+      expect(mail.message_id).to eq '1234@local(blah).machine.example'
+      expect(doing { Mail::Message.new(email) }).not_to raise_error
     end
 
     it "should handle folding subject" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example14.eml'))
-      mail.from.should eq ["atsushi@example.com"]
-      mail.subject.should eq "Re: TEST テストテスト"
-      mail.message_id.should eq '0CC5E11ED2C1D@example.com'
-      mail.body.decoded.should eq "Hello\n"
+      expect(mail.from).to eq ["atsushi@example.com"]
+      expect(mail.subject).to eq "Re: TEST テストテスト"
+      expect(mail.message_id).to eq '0CC5E11ED2C1D@example.com'
+      expect(mail.body.decoded).to eq "Hello\n"
     end
   end
 
@@ -267,11 +267,11 @@ describe "Test emails" do
       end
 
       it "should return an 'encoded' version without raising a SystemStackError" do
-        doing { @message.encoded }.should_not raise_error
+        expect(doing { @message.encoded }).not_to raise_error
       end
 
       it "should have two parts" do
-        @message.parts.length.should eq 2
+        expect(@message.parts.length).to eq 2
       end
 
     end
@@ -282,12 +282,12 @@ describe "Test emails" do
       end
 
       it "should not error on multiart/signed emails" do
-        doing { @message.encoded }.should_not raise_error
+        expect(doing { @message.encoded }).not_to raise_error
       end
 
       it "should have one attachment called signature.asc" do
-        @message.attachments.length.should eq 1
-        @message.attachments.first.filename.should eq 'signature.asc'
+        expect(@message.attachments.length).to eq 1
+        expect(@message.attachments.first.filename).to eq 'signature.asc'
       end
 
     end
@@ -298,11 +298,11 @@ describe "Test emails" do
       end
 
       it "should parse the email and encode without crashing" do
-        doing { @message.encoded }.should_not raise_error
+        expect(doing { @message.encoded }).not_to raise_error
       end
 
       it "should return an empty groups list" do
-        @message[:to].group_addresses.should eq []
+        expect(@message[:to].group_addresses).to eq []
       end
     end
 
@@ -315,11 +315,11 @@ describe "Test emails" do
     end
 
     it "should parse the email and encode without crashing" do
-      doing { @message.encoded }.should_not raise_error
+      expect(doing { @message.encoded }).not_to raise_error
     end
 
     it "should return an empty groups list" do
-      @message.to.should eq ['user-example@aol.com', 'e-s-a-s-2200@app.ar.com']
+      expect(@message.to).to eq ['user-example@aol.com', 'e-s-a-s-2200@app.ar.com']
     end
 
   end

--- a/spec/mail/field_list_spec.rb
+++ b/spec/mail/field_list_spec.rb
@@ -5,7 +5,7 @@ describe Mail::FieldList do
     fl = Mail::FieldList.new
     fl << Mail::Field.new("To: mikel@me.com")
     fl << Mail::Field.new("From: mikel@me.com")
-    fl.length.should eq 2
+    expect(fl.length).to eq 2
   end
   
   it "should be able to add new fields in the right order" do
@@ -14,10 +14,10 @@ describe Mail::FieldList do
     fl << Mail::Field.new("From: mikel@me.com")
     fl << Mail::Field.new("Received: from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
     fl << Mail::Field.new("Return-Path: mikel@me.com")
-    fl[0].field.class.should eq Mail::ReturnPathField
-    fl[1].field.class.should eq Mail::ReceivedField
-    fl[2].field.class.should eq Mail::FromField
-    fl[3].field.class.should eq Mail::ToField
+    expect(fl[0].field.class).to eq Mail::ReturnPathField
+    expect(fl[1].field.class).to eq Mail::ReceivedField
+    expect(fl[2].field.class).to eq Mail::FromField
+    expect(fl[3].field.class).to eq Mail::ToField
   end
   
   it "should add new Received items after the existing ones" do
@@ -27,7 +27,7 @@ describe Mail::FieldList do
     fl << Mail::Field.new("Received: from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
     fl << Mail::Field.new("Return-Path: mikel@me.com")
     fl << Mail::Field.new("Received: from 123.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
-    fl[2].field.value.should eq 'from 123.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500'
+    expect(fl[2].field.value).to eq 'from 123.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500'
   end
   
 end

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -6,23 +6,23 @@ describe Mail::Field do
   describe "initialization" do
 
     it "should be instantiated" do
-      doing {Mail::Field.new('To: Mikel')}.should_not raise_error
-      Mail::Field.new('To: Mikel').field.class.should eq Mail::ToField
+      expect(doing {Mail::Field.new('To: Mikel')}).not_to raise_error
+      expect(Mail::Field.new('To: Mikel').field.class).to eq Mail::ToField
     end
 
     it "should allow you to init on an array" do
       field = Mail::Field.new("To", ['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>'])
-      field.addresses.should eq ["test1@lindsaar.net", "test2@lindsaar.net"]
+      expect(field.addresses).to eq ["test1@lindsaar.net", "test2@lindsaar.net"]
     end
 
     it "should allow us to pass an empty value" do
-      doing {Mail::Field.new('To')}.should_not raise_error
-      Mail::Field.new('To').field.class.should eq Mail::ToField
+      expect(doing {Mail::Field.new('To')}).not_to raise_error
+      expect(Mail::Field.new('To').field.class).to eq Mail::ToField
     end
 
     it "should allow us to pass a value" do
-      doing {Mail::Field.new('To', 'Mikel')}.should_not raise_error
-      Mail::Field.new('To', 'Mikel').field.class.should eq Mail::ToField
+      expect(doing {Mail::Field.new('To', 'Mikel')}).not_to raise_error
+      expect(Mail::Field.new('To', 'Mikel').field.class).to eq Mail::ToField
     end
 
     it "should match up fields to class names" do
@@ -35,7 +35,7 @@ describe Mail::Field do
       structured_fields.each do |sf|
         words = sf.split("-").map { |a| a.capitalize }
         klass = "#{words.join}Field"
-        Mail::Field.new("#{sf}: ").field.class.should eq Mail.const_get(klass)
+        expect(Mail::Field.new("#{sf}: ").field.class).to eq Mail.const_get(klass)
       end
     end
 
@@ -49,150 +49,150 @@ describe Mail::Field do
       structured_fields.each do |sf|
         words = sf.split("-").map { |a| a.capitalize }
         klass = "#{words.join}Field"
-        Mail::Field.new("#{sf}: ").field.class.should eq Mail.const_get(klass)
+        expect(Mail::Field.new("#{sf}: ").field.class).to eq Mail.const_get(klass)
       end
     end
 
     it "should say anything that is not a known field is an optional field" do
       unstructured_fields = %w[ Too Becc bccc Random X-Mail MySpecialField ]
       unstructured_fields.each do |sf|
-        Mail::Field.new("#{sf}: Value").field.class.should eq Mail::OptionalField
+        expect(Mail::Field.new("#{sf}: Value").field.class).to eq Mail::OptionalField
       end
     end
 
     it "should split the name and values out of the raw field passed in" do
       field = Mail::Field.new('To: Bob')
-      field.name.should eq 'To'
-      field.value.should eq 'Bob'
+      expect(field.name).to eq 'To'
+      expect(field.value).to eq 'Bob'
     end
 
     it "should split the name and values out of the raw field passed in if missing whitespace" do
       field = Mail::Field.new('To:Bob')
-      field.name.should eq 'To'
-      field.value.should eq 'Bob'
+      expect(field.name).to eq 'To'
+      expect(field.value).to eq 'Bob'
     end
 
     it "should split the name and values out of the raw field passed in if having added inapplicable whitespace" do
       field = Mail::Field.new('To                  :                   Bob                      ')
-      field.name.should eq 'To'
-      field.value.should eq 'Bob'
+      expect(field.name).to eq 'To'
+      expect(field.value).to eq 'Bob'
     end
 
     it "should return an unstuctured field if the structured field parsing raises an error" do
-      Mail::ToField.should_receive(:new).and_raise(Mail::Field::ParseError.new(Mail::ToField, 'To: Bob, ,,, Frank, Smith', "Some reason"))
+      expect(Mail::ToField).to receive(:new).and_raise(Mail::Field::ParseError.new(Mail::ToField, 'To: Bob, ,,, Frank, Smith', "Some reason"))
       field = Mail::Field.new('To: Bob, ,,, Frank, Smith')
-      field.field.class.should eq Mail::UnstructuredField
-      field.name.should eq 'To'
-      field.value.should eq 'Bob, ,,, Frank, Smith'
+      expect(field.field.class).to eq Mail::UnstructuredField
+      expect(field.name).to eq 'To'
+      expect(field.value).to eq 'Bob, ,,, Frank, Smith'
     end
 
     it "should call to_s on its field when sent to_s" do
       @field = Mail::SubjectField.new('Subject: Hello bob')
-      Mail::SubjectField.should_receive(:new).and_return(@field)
-      @field.should_receive(:to_s).once
+      expect(Mail::SubjectField).to receive(:new).and_return(@field)
+      expect(@field).to receive(:to_s).once
       Mail::Field.new('Subject: Hello bob').to_s
     end
 
     it "should pass missing methods to its instantiated field class" do
       field = Mail::Field.new('To: Bob')
-      field.field.should_receive(:addresses).once
+      expect(field.field).to receive(:addresses).once
       field.addresses
     end
 
     it "should change its type if you change the name" do
       field = Mail::Field.new("To: mikel@me.com")
-      field.field.class.should eq Mail::ToField
+      expect(field.field.class).to eq Mail::ToField
       field.value = "bob@me.com"
-      field.field.class.should eq Mail::ToField
+      expect(field.field.class).to eq Mail::ToField
     end
 
     it "should create a field without trying to parse if given a symbol" do
       field = Mail::Field.new('Message-ID')
-      field.field.class.should eq Mail::MessageIdField
+      expect(field.field.class).to eq Mail::MessageIdField
     end
 
     it "should inherit charset" do
       charset = 'iso-2022-jp'
       field = Mail::Field.new('Subject: こんにちは', charset)
-      field.charset.should eq charset
+      expect(field.charset).to eq charset
     end
   end
 
   describe "error handling" do
     it "should populate the errors array if it finds a field it can't deal with" do
       field = Mail::Field.new('Content-Transfer-Encoding: 8@bit')
-      field.field.errors.size.should eq 1
-      field.field.errors[0][0].should eq 'Content-Transfer-Encoding'
-      field.field.errors[0][1].should eq '8@bit'
-      field.field.errors[0][2].to_s.should =~ /ContentTransferEncodingElement can not parse |17-bit|/
+      expect(field.field.errors.size).to eq 1
+      expect(field.field.errors[0][0]).to eq 'Content-Transfer-Encoding'
+      expect(field.field.errors[0][1]).to eq '8@bit'
+      expect(field.field.errors[0][2].to_s).to match(/ContentTransferEncodingElement can not parse |17-bit|/)
     end
   end
 
   describe "helper methods" do
     it "should reply if it is responsible for a field name as a capitalized string - structured field" do
       field = Mail::Field.new("To: mikel@test.lindsaar.net")
-      field.responsible_for?("To").should be_true
+      expect(field.responsible_for?("To")).to be_true
     end
 
     it "should reply if it is responsible for a field as a lower case string - structured field" do
       field = Mail::Field.new("To: mikel@test.lindsaar.net")
-      field.responsible_for?("to").should be_true
+      expect(field.responsible_for?("to")).to be_true
     end
 
     it "should reply if it is responsible for a field as a symbol - structured field" do
       field = Mail::Field.new("To: mikel@test.lindsaar.net")
-      field.responsible_for?(:to).should be_true
+      expect(field.responsible_for?(:to)).to be_true
     end
 
     it "should say it is == to another if their field names match" do
-      Mail::Field.new("To: mikel").same(Mail::Field.new("To: bob")).should be_true
+      expect(Mail::Field.new("To: mikel").same(Mail::Field.new("To: bob"))).to be_true
     end
 
     it "should say it is not == to another if their field names do not match" do
-      Mail::Field.new("From: mikel").should_not == Mail::Field.new("To: bob")
+      expect(Mail::Field.new("From: mikel")).not_to eq(Mail::Field.new("To: bob"))
     end
 
     it "should sort according to the field order" do
       list = [Mail::Field.new("To: mikel"), Mail::Field.new("Return-Path: bob")]
-      list.sort[0].name.should eq "Return-Path"
+      expect(list.sort[0].name).to eq "Return-Path"
     end
   end
 
   describe 'user defined fields' do
     it "should say it is == to another if their field names match" do
-      Mail::Field.new("X-Foo: mikel").same(Mail::Field.new("X-Foo: bob")).should be_true
+      expect(Mail::Field.new("X-Foo: mikel").same(Mail::Field.new("X-Foo: bob"))).to be_true
     end
 
     it "should say it is not == to another if their field names do not match" do
-      Mail::Field.new("X-Foo: mikel").should_not == Mail::Field.new("X-Bar: bob")
+      expect(Mail::Field.new("X-Foo: mikel")).not_to eq(Mail::Field.new("X-Bar: bob"))
     end
   end
 
   describe "passing an encoding" do
     it "should allow you to send in unencoded strings to fields and encode them" do
       subject = Mail::SubjectField.new("This is あ string", 'utf-8')
-      subject.encoded.should eq "Subject: =?UTF-8?Q?This_is_=E3=81=82_string?=\r\n"
-      subject.decoded.should eq "This is あ string"
+      expect(subject.encoded).to eq "Subject: =?UTF-8?Q?This_is_=E3=81=82_string?=\r\n"
+      expect(subject.decoded).to eq "This is あ string"
     end
 
     it "should allow you to send in unencoded strings to address fields and encode them" do
       to = Mail::ToField.new('"Mikel Lindsああr" <mikel@test.lindsaar.net>', 'utf-8')
-      to.encoded.should eq "To: =?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
+      expect(to.encoded).to eq "To: =?UTF-8?B?TWlrZWwgTGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
     end
 
     it "should allow you to send in unencoded strings without quotes to address fields and encode them" do
       to = Mail::ToField.new('Mikel Lindsああr <mikel@test.lindsaar.net>', 'utf-8')
-      to.encoded.should eq "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
+      expect(to.encoded).to eq "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>\r\n"
     end
 
     it "should allow you to send in unencoded strings to address fields and encode them" do
       to = Mail::ToField.new("あdあ <ada@test.lindsaar.net>", 'utf-8')
-      to.encoded.should eq "To: =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      expect(to.encoded).to eq "To: =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
     end
 
     it "should allow you to send in multiple unencoded strings to address fields and encode them" do
       to = Mail::ToField.new(["Mikel Lindsああr <mikel@test.lindsaar.net>", "あdあ <ada@test.lindsaar.net>"], 'utf-8')
-      to.encoded.should eq "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      expect(to.encoded).to eq "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
     end
 
     it "should allow you to send in multiple unencoded strings to any address field" do
@@ -200,31 +200,31 @@ describe Mail::Field do
       mail.charset = 'utf-8'
       array = ["Mikel Lindsああr <mikel@test.lindsaar.net>", "あdあ <ada@test.lindsaar.net>"]
       field = Mail::ToField.new(array, 'utf-8')
-      field.encoded.should eq "#{Mail::ToField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      expect(field.encoded).to eq "#{Mail::ToField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
       field = Mail::FromField.new(array, 'utf-8')
-      field.encoded.should eq "#{Mail::FromField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      expect(field.encoded).to eq "#{Mail::FromField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
       field = Mail::CcField.new(array, 'utf-8')
-      field.encoded.should eq "#{Mail::CcField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      expect(field.encoded).to eq "#{Mail::CcField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
       field = Mail::ReplyToField.new(array, 'utf-8')
-      field.encoded.should eq "#{Mail::ReplyToField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      expect(field.encoded).to eq "#{Mail::ReplyToField::CAPITALIZED_FIELD}: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
     end
 
     it "should allow an encoded value in the Subject field and decode it automatically (issue 44)" do
       pending if RUBY_VERSION < '1.9'
       subject = Mail::SubjectField.new("=?ISO-8859-1?Q?2_=FAlt?=", 'utf-8')
-      subject.decoded.should eq "2 últ"
+      expect(subject.decoded).to eq "2 últ"
     end
 
     it "should allow you to encoded text in the middle (issue 44)" do
       pending if RUBY_VERSION < '1.9'
       subject = Mail::SubjectField.new("ma=?ISO-8859-1?Q?=F1ana?=", 'utf-8')
-      subject.decoded.should eq "mañana"
+      expect(subject.decoded).to eq "mañana"
     end
 
     it "more tolerable to encoding definitions, ISO (issue 120)" do
       pending if RUBY_VERSION < '1.9'
       subject = Mail::SubjectField.new("ma=?ISO88591?Q?=F1ana?=", 'utf-8')
-      subject.decoded.should eq "mañana"
+      expect(subject.decoded).to eq "mañana"
     end
 
     it "more tolerable to encoding definitions, ISO-long (issue 120)" do
@@ -235,18 +235,18 @@ describe Mail::Field do
       pending if defined?(JRUBY_VERSION) && JRUBY_VERSION >= '1.7.0'
 
       subject = Mail::SubjectField.new("=?iso2022jp?B?SEVBUlQbJEIkSiQ0TyJNbRsoQg?=", 'utf-8')
-      subject.decoded.should eq  "HEARTなご連絡"
+      expect(subject.decoded).to eq  "HEARTなご連絡"
     end
 
     it "more tolerable to encoding definitions, UTF (issue 120)" do
       to = Mail::ToField.new("=?utf-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>", 'utf-8')
-      to.encoded.should eq "To: =?utf-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
-      to.decoded.should eq "\"あdあ\" <ada@test.lindsaar.net>"
+      expect(to.encoded).to eq "To: =?utf-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
+      expect(to.decoded).to eq "\"あdあ\" <ada@test.lindsaar.net>"
     end
 
     it "more tolerable to encoding definitions, ISO (issue 120)" do
       subject = Mail::SubjectField.new("=?UTF-8?B?UmU6IHRlc3QgZW52w61vIG1lbnNhamUgY29u?=", 'utf-8')
-      subject.decoded.should eq "Re: test envío mensaje con"
+      expect(subject.decoded).to eq "Re: test envío mensaje con"
     end
 
 
@@ -257,14 +257,14 @@ describe Mail::Field do
       pending if defined?(JRUBY_VERSION) && JRUBY_VERSION >= '1.7.0'
 
       subject = Mail::SubjectField.new("=?Windows1252?Q?It=92s_a_test=3F?=", 'utf-8')
-      subject.decoded.should eq "It’s a test?"
+      expect(subject.decoded).to eq "It’s a test?"
     end
 
     it "should support ascii encoded utf-8 subjects" do
       s = "=?utf-8?Q?simp?= =?utf-8?Q?le_=E2=80=93_dash_=E2=80=93_?="
 
       subject = Mail::SubjectField.new(s, 'utf-8')
-      subject.decoded.should == "simple – dash – "
+      expect(subject.decoded).to eq("simple – dash – ")
     end
 
     it "should support ascii encoded windows subjects" do
@@ -276,7 +276,7 @@ describe Mail::Field do
       s = "=?WINDOWS-1252?Q?simp?= =?WINDOWS-1252?Q?le_=96_dash_=96_?="
 
       subject = Mail::SubjectField.new(s, "UTF-8")
-      subject.decoded.should == "simple – dash – "
+      expect(subject.decoded).to eq("simple – dash – ")
     end
   end
 
@@ -288,10 +288,10 @@ describe Mail::Field do
       rescue Mail::Field::ParseError => e
         error = e
       end
-      error.should_not be_nil
-      error.element.should eq Mail::DateTimeElement
-      error.value.should eq "invalid"
-      error.reason.should_not be_nil
+      expect(error).not_to be_nil
+      expect(error.element).to eq Mail::DateTimeElement
+      expect(error.value).to eq "invalid"
+      expect(error.reason).not_to be_nil
     end
 
   end

--- a/spec/mail/fields/bcc_field_spec.rb
+++ b/spec/mail/fields/bcc_field_spec.rb
@@ -26,23 +26,23 @@ describe Mail::BccField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::BccField.new("Bcc: Mikel") }.should_not raise_error
+      expect(doing { Mail::BccField.new("Bcc: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::BccField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::BccField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::BccField.new('Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Bcc'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Bcc'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::BccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Bcc'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Bcc'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -52,35 +52,35 @@ describe Mail::BccField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::BccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::BccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return nothing on encoded as Bcc should not be in the mail" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq ""
+      expect(t.encoded).to eq ""
     end
     
     it "should return the decoded line" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.decoded.should eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
+      expect(t.decoded).to eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
     
   end

--- a/spec/mail/fields/cc_field_spec.rb
+++ b/spec/mail/fields/cc_field_spec.rb
@@ -11,23 +11,23 @@ describe Mail::CcField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::CcField.new("Cc: Mikel") }.should_not raise_error
+      expect(doing { Mail::CcField.new("Cc: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::CcField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::CcField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::CcField.new('Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Cc'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Cc'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::CcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Cc'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Cc'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -37,40 +37,40 @@ describe Mail::CcField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::CcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::CcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line for one address" do
       t = Mail::CcField.new('sam@me.com')
-      t.encoded.should eq "Cc: sam@me.com\r\n"
+      expect(t.encoded).to eq "Cc: sam@me.com\r\n"
     end
     
     it "should return the encoded line" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq "Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      expect(t.encoded).to eq "Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
     it "should return the decoded line" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.decoded.should eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
+      expect(t.decoded).to eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
     
   end

--- a/spec/mail/fields/comments_field_spec.rb
+++ b/spec/mail/fields/comments_field_spec.rb
@@ -6,19 +6,19 @@ describe Mail::CommentsField do
   # comments        =       "Comments:" unstructured CRLF
   
   it "should initialize" do
-    doing { Mail::CommentsField.new("this is a comment") }.should_not raise_error
+    expect(doing { Mail::CommentsField.new("this is a comment") }).not_to raise_error
   end
 
   it "should accept a string with the field name" do
     t = Mail::CommentsField.new('Comments: this is a comment')
-    t.name.should eq 'Comments'
-    t.value.should eq 'this is a comment'
+    expect(t.name).to eq 'Comments'
+    expect(t.value).to eq 'this is a comment'
   end
 
   it "should accept a string with the field name" do
     t = Mail::CommentsField.new('this is a comment')
-    t.name.should eq 'Comments'
-    t.value.should eq 'this is a comment'
+    expect(t.name).to eq 'Comments'
+    expect(t.value).to eq 'this is a comment'
   end
   
   

--- a/spec/mail/fields/common/address_container_spec.rb
+++ b/spec/mail/fields/common/address_container_spec.rb
@@ -4,15 +4,15 @@ require 'spec_helper'
 describe 'AddressContainer' do
   it "should allow you to append an address to an address field result" do
     m = Mail.new("To: mikel@test.lindsaar.net")
-    m.to.should eq ['mikel@test.lindsaar.net']
+    expect(m.to).to eq ['mikel@test.lindsaar.net']
     m.to << 'bob@test.lindsaar.net'
-    m.to.should eq ['mikel@test.lindsaar.net', 'bob@test.lindsaar.net']
+    expect(m.to).to eq ['mikel@test.lindsaar.net', 'bob@test.lindsaar.net']
   end
   
   it "should handle complex addresses correctly" do
     m = Mail.new("From: mikel@test.lindsaar.net")
-    m.from.should eq ['mikel@test.lindsaar.net']
+    expect(m.from).to eq ['mikel@test.lindsaar.net']
     m.from << '"Ada Lindsaar" <ada@test.lindsaar.net>, bob@test.lindsaar.net'
-    m.from.should eq ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net', 'bob@test.lindsaar.net']
+    expect(m.from).to eq ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net', 'bob@test.lindsaar.net']
   end
 end

--- a/spec/mail/fields/common/common_address_spec.rb
+++ b/spec/mail/fields/common/common_address_spec.rb
@@ -7,66 +7,66 @@ describe "Mail::CommonAddress" do
 
     it "should give the addresses it is going to" do
       field = Mail::ToField.new("To: test1@lindsaar.net")
-      field.addresses.first.should eq "test1@lindsaar.net"
+      expect(field.addresses.first).to eq "test1@lindsaar.net"
     end
 
     it "should split up the address list into individual addresses" do
       field = Mail::ToField.new("To: test1@lindsaar.net, test2@lindsaar.net")
-      field.addresses.should eq ["test1@lindsaar.net", "test2@lindsaar.net"]
+      expect(field.addresses).to eq ["test1@lindsaar.net", "test2@lindsaar.net"]
     end
 
     it "should give the formatted addresses" do
       field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
-      field.formatted.should eq ["Mikel <test1@lindsaar.net>", "Bob <test2@lindsaar.net>"]
+      expect(field.formatted).to eq ["Mikel <test1@lindsaar.net>", "Bob <test2@lindsaar.net>"]
     end
 
     it "should give the display names" do
       field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
-      field.display_names.should eq ["Mikel", "Bob"]
+      expect(field.display_names).to eq ["Mikel", "Bob"]
     end
 
     it "should give the actual address objects" do
       field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
       field.addrs.each do |addr|
-        addr.class.should eq Mail::Address
+        expect(addr.class).to eq Mail::Address
       end
     end
 
     it "should handle groups as well" do
       field = Mail::ToField.new("To: test1@lindsaar.net, group: test2@lindsaar.net, me@lindsaar.net;")
-      field.addresses.should eq ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
+      expect(field.addresses).to eq ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
     end
 
     it "should provide a list of groups" do
       field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.group_names.should eq ["My Group"]
+      expect(field.group_names).to eq ["My Group"]
     end
 
     it "should provide a list of addresses per group" do
       field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.groups["My Group"].length.should eq 2
-      field.groups["My Group"].first.to_s.should eq 'test2@lindsaar.net'
-      field.groups["My Group"].last.to_s.should eq 'me@lindsaar.net'
+      expect(field.groups["My Group"].length).to eq 2
+      expect(field.groups["My Group"].first.to_s).to eq 'test2@lindsaar.net'
+      expect(field.groups["My Group"].last.to_s).to eq 'me@lindsaar.net'
     end
 
     it "should provide a list of addresses that are just in the groups" do
       field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.group_addresses.should eq ['test2@lindsaar.net', 'me@lindsaar.net']
+      expect(field.group_addresses).to eq ['test2@lindsaar.net', 'me@lindsaar.net']
     end
 
     describe ".value=" do
       it "should handle initializing as an empty string" do
         field = Mail::ToField.new("")
-        field.addresses.should eq []
+        expect(field.addresses).to eq []
         field.value = 'mikel@test.lindsaar.net'
-        field.addresses.should eq ['mikel@test.lindsaar.net']
+        expect(field.addresses).to eq ['mikel@test.lindsaar.net']
       end
 
       it "should encode to an empty string if it has no addresses or groups" do
         field = Mail::ToField.new("")
-        field.encoded.should eq ''
+        expect(field.encoded).to eq ''
         field.value = 'mikel@test.lindsaar.net'
-        field.encoded.should eq "To: mikel@test.lindsaar.net\r\n"
+        expect(field.encoded).to eq "To: mikel@test.lindsaar.net\r\n"
       end
 
       context "a unquoted multi-byte address is given" do
@@ -76,13 +76,13 @@ describe "Mail::CommonAddress" do
           expected_result = "To: =?UTF-8?B?44G/44GR44KL?= <mikel@test.lindsaar.net>\r\n"
           field = Mail::ToField.new("")
           field.value = given_value
-          field.encoded.should eq expected_result
+          expect(field.encoded).to eq expected_result
         end
 
         it "should keep the given value" do
           field = Mail::ToField.new("")
           field.value = given_value
-          field.value.should eq given_value
+          expect(field.value).to eq given_value
         end
       end
 
@@ -93,13 +93,13 @@ describe "Mail::CommonAddress" do
           expected_result = "To: =?UTF-8?B?44G/44GR44KL?= <mikel@test.lindsaar.net>\r\n"
           field = Mail::ToField.new("")
           field.value = given_value
-          field.encoded.should eq expected_result
+          expect(field.encoded).to eq expected_result
         end
 
         it "should keep the given value" do
           field = Mail::ToField.new("")
           field.value = given_value
-          field.value.should eq given_value
+          expect(field.value).to eq given_value
         end
       end
     end
@@ -108,7 +108,7 @@ describe "Mail::CommonAddress" do
       it "should allow you to append an address" do
         field = Mail::ToField.new("")
         field << 'mikel@test.lindsaar.net'
-        field.addresses.should eq ["mikel@test.lindsaar.net"]
+        expect(field.addresses).to eq ["mikel@test.lindsaar.net"]
       end
 
       context "a unquoted multi-byte address is given" do
@@ -119,13 +119,13 @@ describe "Mail::CommonAddress" do
             expected_result = "To: =?UTF-8?B?44G/44GR44KL?= <mikel@test.lindsaar.net>\r\n"
             field = Mail::ToField.new("")
             field << given_value
-            field.encoded.should eq expected_result
+            expect(field.encoded).to eq expected_result
           end
 
           it "should keep the given value" do
             field = Mail::ToField.new("")
             field << given_value
-            field.value.should eq given_value
+            expect(field.value).to eq given_value
           end
         end
 
@@ -134,7 +134,7 @@ describe "Mail::CommonAddress" do
             expected_result = "To: Mikel <test1@example.com>, \r\n =?UTF-8?B?44G/44GR44KL?= <mikel@test.lindsaar.net>\r\n"
             field = Mail::ToField.new("Mikel <test1@example.com>")
             field << given_value
-            field.encoded.should eq expected_result
+            expect(field.encoded).to eq expected_result
           end
         end
 
@@ -143,13 +143,13 @@ describe "Mail::CommonAddress" do
             expected_result = "To: =?UTF-8?B?44Of44Kx44Or?= <test2@example.com>, \r\n =?UTF-8?B?44G/44GR44KL?= <mikel@test.lindsaar.net>\r\n"
             field = Mail::ToField.new("ミケル <test2@example.com>")
             field << given_value
-            field.encoded.should eq expected_result
+            expect(field.encoded).to eq expected_result
           end
 
           it "should keep the given value" do
             field = Mail::ToField.new("ミケル <test2@example.com>")
             field << given_value
-            field.value.should eq ["ミケル <test2@example.com>", given_value].join(', ')
+            expect(field.value).to eq ["ミケル <test2@example.com>", given_value].join(', ')
           end
         end
       end
@@ -162,13 +162,13 @@ describe "Mail::CommonAddress" do
             expected_result = "To: =?UTF-8?B?44G/44GR44KL?= <mikel@test.lindsaar.net>\r\n"
             field = Mail::ToField.new("")
             field << given_value
-            field.encoded.should eq expected_result
+            expect(field.encoded).to eq expected_result
           end
 
           it "should keep the given value" do
             field = Mail::ToField.new("")
             field << given_value
-            field.value.should eq given_value
+            expect(field.value).to eq given_value
           end
         end
 
@@ -177,7 +177,7 @@ describe "Mail::CommonAddress" do
             expected_result = "To: Mikel <test1@example.com>, \r\n =?UTF-8?B?44G/44GR44KL?= <mikel@test.lindsaar.net>\r\n"
             field = Mail::ToField.new("Mikel <test1@example.com>")
             field << given_value
-            field.encoded.should eq expected_result
+            expect(field.encoded).to eq expected_result
           end
         end
 
@@ -186,13 +186,13 @@ describe "Mail::CommonAddress" do
             expected_result = "To: =?UTF-8?B?44Of44Kx44Or?= <test2@example.com>, \r\n =?UTF-8?B?44G/44GR44KL?= <mikel@test.lindsaar.net>\r\n"
             field = Mail::ToField.new("ミケル <test2@example.com>")
             field << given_value
-            field.encoded.should eq expected_result
+            expect(field.encoded).to eq expected_result
           end
 
           it "should keep the given value" do
             field = Mail::ToField.new("ミケル <test2@example.com>")
             field << given_value
-            field.value.should eq ["ミケル <test2@example.com>", given_value].join(', ')
+            expect(field.value).to eq ["ミケル <test2@example.com>", given_value].join(', ')
           end
         end
       end
@@ -200,22 +200,22 @@ describe "Mail::CommonAddress" do
 
     it "should preserve the display name" do
       field = Mail::ToField.new('"Mikel Lindsaar" <mikel@test.lindsaar.net>')
-      field.display_names.should eq ["Mikel Lindsaar"]
+      expect(field.display_names).to eq ["Mikel Lindsaar"]
     end
 
     it "should handle multiple addresses" do
       field = Mail::ToField.new(['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>'])
-      field.addresses.should eq ['test1@lindsaar.net', 'test2@lindsaar.net']
+      expect(field.addresses).to eq ['test1@lindsaar.net', 'test2@lindsaar.net']
     end
 
     it "should handle missing display names with an angle address" do
       field = Mail::ToField.new('<mikel@test.lindsaar.net>')
-      field.encoded.should eq "To: mikel@test.lindsaar.net\r\n"
+      expect(field.encoded).to eq "To: mikel@test.lindsaar.net\r\n"
     end
 
     it "should handle empty display names with an angle address" do
       field = Mail::ToField.new('"" <mikel@test.lindsaar.net>')
-      field.encoded.should eq "To: mikel@test.lindsaar.net\r\n"
+      expect(field.encoded).to eq "To: mikel@test.lindsaar.net\r\n"
     end
 
   end
@@ -224,32 +224,32 @@ describe "Mail::CommonAddress" do
 
     it "should allow us to encode an address field" do
       field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.encoded.should eq "To: test1@lindsaar.net, \r\n\sMy Group: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
+      expect(field.encoded).to eq "To: test1@lindsaar.net, \r\n\sMy Group: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
     end
 
     it "should allow us to encode a simple address field" do
       field = Mail::ToField.new("test1@lindsaar.net")
-      field.encoded.should eq "To: test1@lindsaar.net\r\n"
+      expect(field.encoded).to eq "To: test1@lindsaar.net\r\n"
     end
 
     it "should allow us to encode an address field" do
       field = Mail::CcField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.encoded.should eq "Cc: test1@lindsaar.net, \r\n\sMy Group: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
+      expect(field.encoded).to eq "Cc: test1@lindsaar.net, \r\n\sMy Group: test2@lindsaar.net, \r\n\sme@lindsaar.net;\r\n"
     end
 
     it "should allow us to decode an address field" do
       field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
-      field.decoded.should eq "test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;"
+      expect(field.decoded).to eq "test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;"
     end
 
     it "should allow us to decode a non ascii address field" do
       field = Mail::ToField.new("=?UTF-8?B?44G/44GR44KL?= <raasdnil@text.lindsaar.net>")
-      field.decoded.should eq '"みける" <raasdnil@text.lindsaar.net>'
+      expect(field.decoded).to eq '"みける" <raasdnil@text.lindsaar.net>'
     end
 
     it "should allow us to decode a non ascii address field" do
       field = Mail::ToField.new("=?UTF-8?B?44G/44GR44KL?= <raasdnil@text.lindsaar.net>, =?UTF-8?B?44G/44GR44KL?= <mikel@text.lindsaar.net>")
-      field.decoded.should eq '"みける" <raasdnil@text.lindsaar.net>, "みける" <mikel@text.lindsaar.net>'
+      expect(field.decoded).to eq '"みける" <raasdnil@text.lindsaar.net>, "みける" <mikel@text.lindsaar.net>'
     end
 
   end
@@ -260,7 +260,7 @@ describe "Mail::CommonAddress" do
     field.each do |address|
       addresses << address.address
     end
-    addresses.should eq ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
+    expect(addresses).to eq ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
   end
 
 end

--- a/spec/mail/fields/common/common_date_spec.rb
+++ b/spec/mail/fields/common/common_date_spec.rb
@@ -6,17 +6,17 @@ describe Mail::CommonAddress do
     
     it "should allow us to encode an date field" do
       field = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
-      field.encoded.should eq "Date: Wed, 12 Aug 2009 00:00:02 +0000\r\n"
+      expect(field.encoded).to eq "Date: Wed, 12 Aug 2009 00:00:02 +0000\r\n"
     end
     
     it "should allow us to encode an resent date field" do
       field = Mail::ResentDateField.new('12 Aug 2009 00:00:02 GMT')
-      field.encoded.should eq "Resent-Date: Wed, 12 Aug 2009 00:00:02 +0000\r\n"
+      expect(field.encoded).to eq "Resent-Date: Wed, 12 Aug 2009 00:00:02 +0000\r\n"
     end
 
     it "should allow us to decode an address field" do
       field = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
-      field.decoded.should eq "Wed, 12 Aug 2009 00:00:02 +0000"
+      expect(field.decoded).to eq "Wed, 12 Aug 2009 00:00:02 +0000"
     end
     
   end

--- a/spec/mail/fields/common/common_field_spec.rb
+++ b/spec/mail/fields/common/common_field_spec.rb
@@ -14,13 +14,13 @@ describe Mail::CommonField do
     end
 
     it "should return '' on to_s if there is no value" do
-      Mail::SubjectField.new(nil).to_s.should eq ''
+      expect(Mail::SubjectField.new(nil).to_s).to eq ''
     end
     
     it "should leave ascii alone" do
       field = Mail::SubjectField.new("This is a test")
-      field.encoded.should eq "Subject: This is a test\r\n"
-      field.decoded.should eq "This is a test"
+      expect(field.encoded).to eq "Subject: This is a test\r\n"
+      expect(field.decoded).to eq "This is a test"
     end
     
     it "should encode a utf-8 string as utf-8 quoted printable" do
@@ -33,9 +33,9 @@ describe Mail::CommonField do
         result = "Subject: =?UTF-8?Q?=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n"
       end
       field = Mail::SubjectField.new(value)
-      field.encoded.should eq result
-      field.decoded.should eq value
-      field.value.should eq value
+      expect(field.encoded).to eq result
+      expect(field.decoded).to eq value
+      expect(field.value).to eq value
     end
 
     it "should wrap an encoded at 60 characters" do
@@ -48,9 +48,9 @@ describe Mail::CommonField do
         result = "Subject: =?UTF-8?Q?=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n\s=?UTF-8?Q?_=E3=81=8B=E3=81=8D=E3=81=8F=E3=81=91=E3=81=93?=\r\n"
       end
       field = Mail::SubjectField.new(value)
-      field.encoded.should eq result
-      field.decoded.should eq value
-      field.value.should eq value
+      expect(field.encoded).to eq result
+      expect(field.decoded).to eq value
+      expect(field.value).to eq value
     end
   
     it "should handle charsets in assigned addresses" do
@@ -63,8 +63,8 @@ describe Mail::CommonField do
         result = "From: =?UTF-8?B?44GL44GN44GP44GR44GT?= <mikel@test.lindsaar.net>\r\n"
       end
       field = Mail::FromField.new(value)
-      field.encoded.should eq result
-      field.decoded.should eq value
+      expect(field.encoded).to eq result
+      expect(field.decoded).to eq value
     end
     
   end

--- a/spec/mail/fields/common/common_message_id_spec.rb
+++ b/spec/mail/fields/common/common_message_id_spec.rb
@@ -7,22 +7,22 @@ describe Mail::CommonMessageId do
     
     it "should allow us to encode a message id field" do
       field = Mail::MessageIdField.new('<ThisIsANonUniqueMessageId@me.com>')
-      field.encoded.should eq "Message-ID: <ThisIsANonUniqueMessageId@me.com>\r\n"
+      expect(field.encoded).to eq "Message-ID: <ThisIsANonUniqueMessageId@me.com>\r\n"
     end
     
     it "should allow us to encode a message id field" do
       field = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      field.encoded.should eq "Message-ID: <1234@test.lindsaar.net>\r\n"
+      expect(field.encoded).to eq "Message-ID: <1234@test.lindsaar.net>\r\n"
     end
     
     it "should allow us to encode an in reply to field" do
       field = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
-      field.encoded.should eq "In-Reply-To: <1234@test.lindsaar.net>\r\n"
+      expect(field.encoded).to eq "In-Reply-To: <1234@test.lindsaar.net>\r\n"
     end
 
     it "should allow us to decode a message id field" do
       field = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      field.decoded.should eq "<1234@test.lindsaar.net>"
+      expect(field.decoded).to eq "<1234@test.lindsaar.net>"
     end
     
   end

--- a/spec/mail/fields/common/parameter_hash_spec.rb
+++ b/spec/mail/fields/common/parameter_hash_spec.rb
@@ -5,41 +5,41 @@ describe Mail::ParameterHash do
   it "should return the values in the hash" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'value2' => 'two'})
-    hash.keys.should include("value1")
-    hash.keys.should include("value2")
-    hash.values.should include('one')
-    hash.values.should include('two')
+    expect(hash.keys).to include("value1")
+    expect(hash.keys).to include("value2")
+    expect(hash.values).to include('one')
+    expect(hash.values).to include('two')
   end
 
   it "should return the values in the hash regardless of symbol or string" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'value2' => 'two'})
-    hash['value1'].should eq 'one'
-    hash['value2'].should eq 'two'
-    hash[:value1].should eq 'one'
-    hash[:value2].should eq 'two'
+    expect(hash['value1']).to eq 'one'
+    expect(hash['value2']).to eq 'two'
+    expect(hash[:value1]).to eq 'one'
+    expect(hash[:value2]).to eq 'two'
   end
 
   it "should return the values in the hash using case-insensitive key matching" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'VALUE2' => 'two'})
-    hash['VALUE1'].should eq 'one'
-    hash['vAlUe2'].should eq 'two'
-    hash[:VaLuE1].should eq 'one'
-    hash[:value2].should eq 'two'
+    expect(hash['VALUE1']).to eq 'one'
+    expect(hash['vAlUe2']).to eq 'two'
+    expect(hash[:VaLuE1]).to eq 'one'
+    expect(hash[:value2]).to eq 'two'
   end
 
   it "should return the correct value if they are not encoded" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'value2' => 'two'})
-    hash['value1'].should eq 'one'
-    hash['value2'].should eq 'two'
+    expect(hash['value1']).to eq 'one'
+    expect(hash['value2']).to eq 'two'
   end
 
   it "should return a name list concatenated" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value*1' => 'one', 'value*2' => 'two'})
-    hash['value'].should eq 'onetwo'
+    expect(hash['value']).to eq 'onetwo'
   end
 
   it "should return a name list concatenated and unencoded" do
@@ -47,13 +47,13 @@ describe Mail::ParameterHash do
     hash.merge!({'value*0*' => "us-ascii'en'This%20is%20even%20more%20",
                  'value*1*' => "%2A%2A%2Afun%2A%2A%2A%20",
                  'value*2'  => "isn't it"})
-    hash['value'].should eq "This is even more ***fun*** isn't it"
+    expect(hash['value']).to eq "This is even more ***fun*** isn't it"
   end
 
   it "should allow us to add a value" do
     hash = Mail::ParameterHash.new
     hash['value'] = 'bob'
-    hash['value'].should eq 'bob'
+    expect(hash['value']).to eq 'bob'
   end
 
   it "should return an encoded value" do
@@ -61,7 +61,7 @@ describe Mail::ParameterHash do
     hash.merge!({'value*0*' => "us-ascii'en'This%20is%20even%20more%20",
                  'value*1*' => "%2A%2A%2Afun%2A%2A%2A%20",
                  'value*2'  => "isn't it"})
-    hash.encoded.should eq %Q{value*0*=us-ascii'en'This%20is%20even%20more%20;\r\n\svalue*1*=%2A%2A%2Afun%2A%2A%2A%20;\r\n\svalue*2="isn't it"}
+    expect(hash.encoded).to eq %Q{value*0*=us-ascii'en'This%20is%20even%20more%20;\r\n\svalue*1*=%2A%2A%2Afun%2A%2A%2A%20;\r\n\svalue*2="isn't it"}
   end
 
 end

--- a/spec/mail/fields/content_description_field_spec.rb
+++ b/spec/mail/fields/content_description_field_spec.rb
@@ -19,19 +19,19 @@ describe Mail::ContentDescriptionField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ContentDescriptionField.new("Content-Description: This is a description") }.should_not raise_error
+      expect(doing { Mail::ContentDescriptionField.new("Content-Description: This is a description") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       t = Mail::ContentDescriptionField.new('Content-Description: This is a description')
-      t.name.should eq 'Content-Description'
-      t.value.should eq 'This is a description'
+      expect(t.name).to eq 'Content-Description'
+      expect(t.value).to eq 'This is a description'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ContentDescriptionField.new('This is a description')
-      t.name.should eq 'Content-Description'
-      t.value.should eq 'This is a description'
+      expect(t.name).to eq 'Content-Description'
+      expect(t.value).to eq 'This is a description'
     end
 
   end

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -5,77 +5,77 @@ describe Mail::ContentDispositionField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ContentDispositionField.new("attachment; filename=File") }.should_not raise_error
+      expect(doing { Mail::ContentDispositionField.new("attachment; filename=File") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      c.name.should eq 'Content-Disposition'
-      c.value.should eq 'attachment; filename=File'
+      expect(c.name).to eq 'Content-Disposition'
+      expect(c.value).to eq 'attachment; filename=File'
     end
 
     it "should accept a string without the field name" do
       c = Mail::ContentDispositionField.new('attachment; filename=File')
-      c.name.should eq 'Content-Disposition'
-      c.value.should eq 'attachment; filename=File'
+      expect(c.name).to eq 'Content-Disposition'
+      expect(c.value).to eq 'attachment; filename=File'
     end
 
     it "should accept a nil value and generate a disposition type" do
       c = Mail::ContentDispositionField.new(nil)
-      c.name.should eq 'Content-Disposition'
-      c.value.should_not be_nil
+      expect(c.name).to eq 'Content-Disposition'
+      expect(c.value).not_to be_nil
     end
 
     it "should render encoded" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      c.encoded.should eq "Content-Disposition: attachment;\r\n\sfilename=File\r\n"
+      expect(c.encoded).to eq "Content-Disposition: attachment;\r\n\sfilename=File\r\n"
     end
 
     it "should render encoded for inline" do
       c = Mail::ContentDispositionField.new('Content-Disposition: inline')
-      c.encoded.should eq "Content-Disposition: inline\r\n"
+      expect(c.encoded).to eq "Content-Disposition: inline\r\n"
     end
 
     it "should wrap a filename in double quotation marks only if the filename contains spaces and does not already have double quotation marks" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=This is a bad filename.txt')
-      c.value.should eq 'attachment; filename="This is a bad filename.txt"'
+      expect(c.value).to eq 'attachment; filename="This is a bad filename.txt"'
 
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=some.jpg')
-      c.value.should eq 'attachment; filename=some.jpg'
+      expect(c.value).to eq 'attachment; filename=some.jpg'
 
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename="Bad filename but at least it is wrapped in quotes.txt"')
-      c.value.should eq 'attachment; filename="Bad filename but at least it is wrapped in quotes.txt"'
+      expect(c.value).to eq 'attachment; filename="Bad filename but at least it is wrapped in quotes.txt"'
     end
 
     it "should render decoded" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      c.decoded.should eq 'attachment; filename=File'
+      expect(c.decoded).to eq 'attachment; filename=File'
     end
 
     it "should render decoded inline" do
       c = Mail::ContentDispositionField.new('Content-Disposition: inline')
-      c.decoded.should eq 'inline'
+      expect(c.decoded).to eq 'inline'
     end
 
     it "should handle upper and mixed case INLINE and AttachMent" do
       c = Mail::ContentDispositionField.new('Content-Disposition: INLINE')
-      c.decoded.should eq 'inline'
+      expect(c.decoded).to eq 'inline'
       c = Mail::ContentDispositionField.new('Content-Disposition: AttachMent')
-      c.decoded.should eq 'attachment'
+      expect(c.decoded).to eq 'attachment'
     end
   end
 
   describe "instance methods" do
     it "should give its disposition type" do
       c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      c.disposition_type.should eq 'attachment'
-      c.parameters.should eql({"filename" => 'File'})
+      expect(c.disposition_type).to eq 'attachment'
+      expect(c.parameters).to eql({"filename" => 'File'})
     end
 
     # see spec/fixtures/trec_2005_corpus/missing_content_disposition.eml
     it "should accept a blank disposition type" do
       c = Mail::ContentDispositionField.new('Content-Disposition: ')
-      c.disposition_type.should_not be_nil
+      expect(c.disposition_type).not_to be_nil
     end
   end
 

--- a/spec/mail/fields/content_id_field_spec.rb
+++ b/spec/mail/fields/content_id_field_spec.rb
@@ -30,37 +30,37 @@ describe Mail::ContentIdField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ContentIdField.new("<1234@test.lindsaar.net>") }.should_not raise_error
+      expect(doing { Mail::ContentIdField.new("<1234@test.lindsaar.net>") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       c = Mail::ContentIdField.new('Content-ID: <1234@test.lindsaar.net>')
-      c.name.should eq 'Content-ID'
-      c.value.should eq '<1234@test.lindsaar.net>'
-      c.content_id.should eq '1234@test.lindsaar.net'
+      expect(c.name).to eq 'Content-ID'
+      expect(c.value).to eq '<1234@test.lindsaar.net>'
+      expect(c.content_id).to eq '1234@test.lindsaar.net'
     end
 
     it "should accept a string without the field name" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.name.should eq 'Content-ID'
-      m.value.should eq '<1234@test.lindsaar.net>'
-      m.content_id.should eq '1234@test.lindsaar.net'
+      expect(m.name).to eq 'Content-ID'
+      expect(m.value).to eq '<1234@test.lindsaar.net>'
+      expect(m.content_id).to eq '1234@test.lindsaar.net'
     end
 
     it "should accept a nil value and generate a content_id" do
       m = Mail::ContentIdField.new(nil)
-      m.name.should eq 'Content-ID'
-      m.value.should_not be_nil
+      expect(m.name).to eq 'Content-ID'
+      expect(m.value).not_to be_nil
     end
 
     it "should allow it to be encoded" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.encoded.should eq "Content-ID: <1234@test.lindsaar.net>\r\n"
+      expect(m.encoded).to eq "Content-ID: <1234@test.lindsaar.net>\r\n"
     end
 
     it "should allow it to be decoded" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.decoded.should eq "<1234@test.lindsaar.net>"
+      expect(m.decoded).to eq "<1234@test.lindsaar.net>"
     end
 
   end
@@ -69,16 +69,16 @@ describe Mail::ContentIdField do
 
     it "should not accept a string with multiple message IDs but only return the first" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      m.name.should eq 'Content-ID'
-      m.to_s.should eq '<1234@test.lindsaar.net>'
-      m.content_id.should eq '1234@test.lindsaar.net'
+      expect(m.name).to eq 'Content-ID'
+      expect(m.to_s).to eq '<1234@test.lindsaar.net>'
+      expect(m.content_id).to eq '1234@test.lindsaar.net'
     end
 
     it "should change the message id if given a new message id" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.to_s.should eq '<1234@test.lindsaar.net>'
+      expect(m.to_s).to eq '<1234@test.lindsaar.net>'
       m.value = '<4567@test.lindsaar.net>'
-      m.to_s.should eq '<4567@test.lindsaar.net>'
+      expect(m.to_s).to eq '<4567@test.lindsaar.net>'
     end
 
   end
@@ -86,31 +86,31 @@ describe Mail::ContentIdField do
   describe "instance methods" do
     it "should provide to_s" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.to_s.should eq '<1234@test.lindsaar.net>'
-      m.content_id.to_s.should eq '1234@test.lindsaar.net'
+      expect(m.to_s).to eq '<1234@test.lindsaar.net>'
+      expect(m.content_id.to_s).to eq '1234@test.lindsaar.net'
     end
 
     it "should provide encoded" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.encoded.should eq "Content-ID: <1234@test.lindsaar.net>\r\n"
+      expect(m.encoded).to eq "Content-ID: <1234@test.lindsaar.net>\r\n"
     end
     
     it "should respond to :responsible_for?" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
-      m.should respond_to(:responsible_for?)
+      expect(m).to respond_to(:responsible_for?)
     end
   end
 
   describe "generating a message id" do
     it "should generate a message ID if it has no value" do
       m = Mail::ContentIdField.new
-      m.content_id.should_not be_blank
+      expect(m.content_id).not_to be_blank
     end
     
     it "should generate a random message ID" do
       m = Mail::ContentIdField.new
       1.upto(100) do
-        m.content_id.should_not == Mail::ContentIdField.new.content_id
+        expect(m.content_id).not_to eq(Mail::ContentIdField.new.content_id)
       end
     end
   end

--- a/spec/mail/fields/content_location_field_spec.rb
+++ b/spec/mail/fields/content_location_field_spec.rb
@@ -7,29 +7,29 @@ describe Mail::ContentLocationField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ContentLocationField.new("Content-Location", "7bit") }.should_not raise_error
+      expect(doing { Mail::ContentLocationField.new("Content-Location", "7bit") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       t = Mail::ContentLocationField.new('Content-Location: photo.jpg')
-      t.name.should eq 'Content-Location'
-      t.value.should eq 'photo.jpg'
+      expect(t.name).to eq 'Content-Location'
+      expect(t.value).to eq 'photo.jpg'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ContentLocationField.new('photo.jpg')
-      t.name.should eq 'Content-Location'
-      t.value.should eq 'photo.jpg'
+      expect(t.name).to eq 'Content-Location'
+      expect(t.value).to eq 'photo.jpg'
     end
 
     it "should render an encoded field" do
       t = Mail::ContentLocationField.new('photo.jpg')
-      t.encoded.should eq "Content-Location: photo.jpg\r\n"
+      expect(t.encoded).to eq "Content-Location: photo.jpg\r\n"
     end
 
     it "should render a decoded field" do
       t = Mail::ContentLocationField.new('photo.jpg')
-      t.decoded.should eq 'photo.jpg'
+      expect(t.decoded).to eq 'photo.jpg'
     end
 
   end
@@ -38,7 +38,7 @@ describe Mail::ContentLocationField do
     
     it "should return an encoding string unquoted" do
       t = Mail::ContentLocationField.new('"A quoted filename.jpg"')
-      t.location.should eq 'A quoted filename.jpg'
+      expect(t.location).to eq 'A quoted filename.jpg'
     end
     
   end

--- a/spec/mail/fields/content_transfer_encoding_field_spec.rb
+++ b/spec/mail/fields/content_transfer_encoding_field_spec.rb
@@ -40,29 +40,29 @@ describe Mail::ContentTransferEncodingField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ContentTransferEncodingField.new("Content-Transfer-Encoding: 7bit") }.should_not raise_error
+      expect(doing { Mail::ContentTransferEncodingField.new("Content-Transfer-Encoding: 7bit") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       t = Mail::ContentTransferEncodingField.new('Content-Transfer-Encoding: 7bit')
-      t.name.should eq 'Content-Transfer-Encoding'
-      t.value.should eq '7bit'
+      expect(t.name).to eq 'Content-Transfer-Encoding'
+      expect(t.value).to eq '7bit'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ContentTransferEncodingField.new('7bit')
-      t.name.should eq 'Content-Transfer-Encoding'
-      t.value.should eq '7bit'
+      expect(t.name).to eq 'Content-Transfer-Encoding'
+      expect(t.value).to eq '7bit'
     end
 
     it "should render an encoded field" do
       t = Mail::ContentTransferEncodingField.new('7bit')
-      t.encoded.should eq "Content-Transfer-Encoding: 7bit\r\n"
+      expect(t.encoded).to eq "Content-Transfer-Encoding: 7bit\r\n"
     end
 
     it "should render a decoded field" do
       t = Mail::ContentTransferEncodingField.new('7bit')
-      t.decoded.should eq '7bit'
+      expect(t.decoded).to eq '7bit'
     end
 
   end
@@ -72,55 +72,55 @@ describe Mail::ContentTransferEncodingField do
     it "should return an encoding string" do
       ["7bit", "8bit", "binary", 'quoted-printable', "base64"].each do |encoding|
         t = Mail::ContentTransferEncodingField.new(encoding)
-        t.encoding.should eq encoding
+        expect(t.encoding).to eq encoding
       end
     end
 
     it "should treat 7bits/7-bit and 8bits/8-bit as 7bit and 8bit" do
       %w(7bits 7-bit).each do |mechanism|
-        Mail::ContentTransferEncodingField.new(mechanism).encoding.should eq '7bit'
+        expect(Mail::ContentTransferEncodingField.new(mechanism).encoding).to eq '7bit'
       end
 
       %w(8bits 8-bit).each do |mechanism|
-        Mail::ContentTransferEncodingField.new(mechanism).encoding.should eq '8bit'
+        expect(Mail::ContentTransferEncodingField.new(mechanism).encoding).to eq '8bit'
       end
     end
     
     it "should handle any valid 'x-token' value" do
       t = Mail::ContentTransferEncodingField.new('X-This-is_MY-encoding')
-      t.encoding.should eq 'x-this-is_my-encoding'
+      expect(t.encoding).to eq 'x-this-is_my-encoding'
     end
     
     it "should handle an x-encoding" do
       t = Mail::ContentTransferEncodingField.new("x-uuencode")
-      t.encoding.should eq "x-uuencode"
+      expect(t.encoding).to eq "x-uuencode"
     end
 
     it "should handle an ietf encoding (practically, any token)" do
       t = Mail::ContentTransferEncodingField.new("ietf-token")
-      t.encoding.should eq "ietf-token"
+      expect(t.encoding).to eq "ietf-token"
     end
 
     it "should replace the existing value" do
       t = Mail::ContentTransferEncodingField.new("7bit")
       t.parse("quoted-printable")
-      t.encoding.should eq 'quoted-printable'
+      expect(t.encoding).to eq 'quoted-printable'
     end
 
     it "should raise an error on bogus values" do
-      doing { Mail::ContentTransferEncodingField.new("broken@foo") }.should raise_error
+      expect(doing { Mail::ContentTransferEncodingField.new("broken@foo") }).to raise_error
     end 
     
     it "should handle an empty content transfer encoding" do
       t = Mail::ContentTransferEncodingField.new("")
-      t.encoding.should eq ""
+      expect(t.encoding).to eq ""
     end
 
     it "should handle a hyphen" do
       t = Mail::ContentTransferEncodingField.new('7-bit')
-      t.decoded.should eq '7bit'
+      expect(t.decoded).to eq '7bit'
       t = Mail::ContentTransferEncodingField.new('8-bit')
-      t.decoded.should eq '8bit'
+      expect(t.decoded).to eq '8bit'
     end
 
   end

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -71,115 +71,115 @@ describe Mail::ContentTypeField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ContentTypeField.new("<1234@test.lindsaar.net>") }.should_not raise_error
+      expect(doing { Mail::ContentTypeField.new("<1234@test.lindsaar.net>") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       c = Mail::ContentTypeField.new('Content-Type: text/plain')
-      c.name.should eq 'Content-Type'
-      c.value.should eq 'text/plain'
+      expect(c.name).to eq 'Content-Type'
+      expect(c.value).to eq 'text/plain'
     end
 
     it "should accept a string without the field name" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.name.should eq 'Content-Type'
-      c.value.should eq 'text/plain'
+      expect(c.name).to eq 'Content-Type'
+      expect(c.value).to eq 'text/plain'
     end
 
     it "should accept a nil value and generate a content_type" do
       c = Mail::ContentTypeField.new('Content-Type', nil)
-      c.name.should eq 'Content-Type'
-      c.value.should_not be_nil
+      expect(c.name).to eq 'Content-Type'
+      expect(c.value).not_to be_nil
     end
 
     it "should render encoded" do
       c = Mail::ContentTypeField.new('Content-Type: text/plain')
-      c.encoded.should eq "Content-Type: text/plain\r\n"
+      expect(c.encoded).to eq "Content-Type: text/plain\r\n"
     end
 
     it "should render encoded with parameters" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII; format=flowed')
-      c.encoded.should eq %Q{Content-Type: text/plain;\r\n\scharset=US-ASCII;\r\n\sformat=flowed\r\n}
+      expect(c.encoded).to eq %Q{Content-Type: text/plain;\r\n\scharset=US-ASCII;\r\n\sformat=flowed\r\n}
     end
 
     it "should render quoted values encoded" do
       c = Mail::ContentTypeField.new('text/plain; example="foo bar"')
-      c.encoded.should eq %Q{Content-Type: text/plain;\r\n\sexample="foo bar"\r\n}
+      expect(c.encoded).to eq %Q{Content-Type: text/plain;\r\n\sexample="foo bar"\r\n}
     end
 
     it "should render decoded" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII; format=flowed')
-      c.decoded.should eq 'text/plain; charset=US-ASCII; format=flowed'
+      expect(c.decoded).to eq 'text/plain; charset=US-ASCII; format=flowed'
     end
 
     it "should render quoted values decoded" do
       c = Mail::ContentTypeField.new('text/plain; example="foo bar"')
-      c.decoded.should eq 'text/plain; example="foo bar"'
+      expect(c.decoded).to eq 'text/plain; example="foo bar"'
     end
 
     it "should render " do
       c = Mail::ContentTypeField.new('message/delivery-status')
-      c.main_type.should eq 'message'
-      c.sub_type.should eq 'delivery-status'
+      expect(c.main_type).to eq 'message'
+      expect(c.sub_type).to eq 'delivery-status'
     end
 
     it "should wrap a filename in double quotation marks only if the filename contains spaces and does not already have double quotation marks" do
       c = Mail::ContentTypeField.new('text/plain; name=This is a bad filename.txt')
-      c.value.should eq 'text/plain; name="This is a bad filename.txt"'
+      expect(c.value).to eq 'text/plain; name="This is a bad filename.txt"'
 
       c = Mail::ContentTypeField.new('image/jpg; name=some.jpg; size=100')
-      c.value.should eq 'image/jpg; name=some.jpg; size=100'
+      expect(c.value).to eq 'image/jpg; name=some.jpg; size=100'
 
       c = Mail::ContentTypeField.new('text/plain; name="Bad filename but at least it is wrapped in quotes.txt"')
-      c.value.should eq 'text/plain; name="Bad filename but at least it is wrapped in quotes.txt"'
+      expect(c.value).to eq 'text/plain; name="Bad filename but at least it is wrapped in quotes.txt"'
     end
 
     it "should only wrap filenames in double quotation marks" do
       c = Mail::ContentTypeField.new("image/jpg;\r\n\sname=some .jpg\r\n\ssize=100")
-      c.value.should eq %Q{image/jpg;\r\n\sname="some .jpg"\r\n\ssize=100}
+      expect(c.value).to eq %Q{image/jpg;\r\n\sname="some .jpg"\r\n\ssize=100}
     end
   end
 
   describe "instance methods" do
     it "should return a content_type" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.content_type.should eq 'text/plain'
+      expect(c.content_type).to eq 'text/plain'
     end
 
     it "should return a content_type for the :string method" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.string.should eq 'text/plain'
+      expect(c.string).to eq 'text/plain'
     end
 
     it "should return a main_type" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.main_type.should eq 'text'
+      expect(c.main_type).to eq 'text'
     end
 
     it "should return a sub_type" do
       c = Mail::ContentTypeField.new('text/plain')
-      c.main_type.should eq 'text'
+      expect(c.main_type).to eq 'text'
     end
 
     it "should return a parameter as a hash" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII')
-      c.parameters.should eql({"charset" => 'US-ASCII'})
+      expect(c.parameters).to eql({"charset" => 'US-ASCII'})
     end
 
     it "should return multiple parameters as a hash" do
       c = Mail::ContentTypeField.new('text/plain; charset=US-ASCII; format=flowed')
-      c.parameters.should eql({"charset" => 'US-ASCII', "format" => 'flowed'})
+      expect(c.parameters).to eql({"charset" => 'US-ASCII', "format" => 'flowed'})
     end
 
     it "should return boundry parameters" do
       c = Mail::ContentTypeField.new('multipart/mixed; boundary=Apple-Mail-13-196941151')
-      c.parameters.should eql({"boundary" => 'Apple-Mail-13-196941151'})
+      expect(c.parameters).to eql({"boundary" => 'Apple-Mail-13-196941151'})
     end
 
     it "should be indifferent with the access" do
       c = Mail::ContentTypeField.new('multipart/mixed; boundary=Apple')
-      c.parameters[:boundary].should eq "Apple"
-      c.parameters['boundary'].should eq "Apple"
+      expect(c.parameters[:boundary]).to eq "Apple"
+      expect(c.parameters['boundary']).to eq "Apple"
     end
 
   end
@@ -187,19 +187,19 @@ describe Mail::ContentTypeField do
   describe "class methods" do
     it "should give back an initialized instance with a unique boundary" do
       boundary = Mail::ContentTypeField.with_boundary('multipart/mixed')
-      boundary.encoded.should =~ %r{Content-Type: multipart/mixed;\r\n\sboundary="--==_mimepart_[\w]+_[\w]+"\r\n}
+      expect(boundary.encoded).to match(%r{Content-Type: multipart/mixed;\r\n\sboundary="--==_mimepart_[\w]+_[\w]+"\r\n})
     end
 
     it "should give back an initialized instance with different type with a unique boundary" do
       boundary = Mail::ContentTypeField.with_boundary('multipart/alternative')
-      boundary.encoded.should =~ %r{Content-Type: multipart/alternative;\r\n\sboundary="--==_mimepart_[\w]+_[\w]+"\r\n}
+      expect(boundary.encoded).to match(%r{Content-Type: multipart/alternative;\r\n\sboundary="--==_mimepart_[\w]+_[\w]+"\r\n})
     end
 
     it "should give unique boundaries" do
       boundary1 = Mail::ContentTypeField.with_boundary('multipart/alternative').parameters['boundary']
       0.upto(250) do
         boundary2 = Mail::ContentTypeField.with_boundary('multipart/alternative').parameters['boundary']
-        boundary1.should_not == boundary2
+        expect(boundary1).not_to eq(boundary2)
       end
     end
 
@@ -210,404 +210,404 @@ describe Mail::ContentTypeField do
     it "should handle 'application/octet-stream; name*=iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3'" do
       string = %q{application/octet-stream; name*=iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'application/octet-stream'
-      c.main_type.should eq 'application'
-      c.sub_type.should eq 'octet-stream'
-      c.parameters.should eql({'name*' => "iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3"})
+      expect(c.content_type).to eq 'application/octet-stream'
+      expect(c.main_type).to eq 'application'
+      expect(c.sub_type).to eq 'octet-stream'
+      expect(c.parameters).to eql({'name*' => "iso-2022-jp'ja'01%20Quien%20Te%20Dij%8aat.%20Pitbull.mp3"})
     end
 
     it "should handle 'application/pdf;'" do
       string = %q{application/pdf;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'application/pdf'
-      c.main_type.should eq 'application'
-      c.sub_type.should eq 'pdf'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'application/pdf'
+      expect(c.main_type).to eq 'application'
+      expect(c.sub_type).to eq 'pdf'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'application/pdf; name=\"broken.pdf\"'" do
       string = %q{application/pdf; name="broken.pdf"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'application/pdf'
-      c.main_type.should eq 'application'
-      c.sub_type.should eq 'pdf'
-      c.parameters.should eql({"name" => "broken.pdf"})
+      expect(c.content_type).to eq 'application/pdf'
+      expect(c.main_type).to eq 'application'
+      expect(c.sub_type).to eq 'pdf'
+      expect(c.parameters).to eql({"name" => "broken.pdf"})
     end
 
     it "should handle 'application/pkcs7-signature;'" do
       string = %q{application/pkcs7-signature;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'application/pkcs7-signature'
-      c.main_type.should eq 'application'
-      c.sub_type.should eq 'pkcs7-signature'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'application/pkcs7-signature'
+      expect(c.main_type).to eq 'application'
+      expect(c.sub_type).to eq 'pkcs7-signature'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'application/pkcs7-signature; name=smime.p7s'" do
       string = %q{application/pkcs7-signature; name=smime.p7s}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'application/pkcs7-signature'
-      c.main_type.should eq 'application'
-      c.sub_type.should eq 'pkcs7-signature'
-      c.parameters.should eql({"name" => "smime.p7s"})
+      expect(c.content_type).to eq 'application/pkcs7-signature'
+      expect(c.main_type).to eq 'application'
+      expect(c.sub_type).to eq 'pkcs7-signature'
+      expect(c.parameters).to eql({"name" => "smime.p7s"})
     end
 
     it "should handle 'application/x-gzip; NAME=blah.gz'" do
       string = %q{application/x-gzip; NAME=blah.gz}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'application/x-gzip'
-      c.main_type.should eq 'application'
-      c.sub_type.should eq 'x-gzip'
-      c.parameters.should eql({"NAME" => "blah.gz"})
+      expect(c.content_type).to eq 'application/x-gzip'
+      expect(c.main_type).to eq 'application'
+      expect(c.sub_type).to eq 'x-gzip'
+      expect(c.parameters).to eql({"NAME" => "blah.gz"})
     end
 
     it "should handle 'image/jpeg'" do
       string = %q{image/jpeg}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'image/jpeg'
-      c.main_type.should eq 'image'
-      c.sub_type.should eq 'jpeg'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'image/jpeg'
+      expect(c.main_type).to eq 'image'
+      expect(c.sub_type).to eq 'jpeg'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'image/jpeg'" do
       string = %q{image/jpeg}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'image/jpeg'
-      c.main_type.should eq 'image'
-      c.sub_type.should eq 'jpeg'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'image/jpeg'
+      expect(c.main_type).to eq 'image'
+      expect(c.sub_type).to eq 'jpeg'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'image/jpeg;'" do
       string = %q{image/jpeg}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'image/jpeg'
-      c.main_type.should eq 'image'
-      c.sub_type.should eq 'jpeg'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'image/jpeg'
+      expect(c.main_type).to eq 'image'
+      expect(c.sub_type).to eq 'jpeg'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'image/png;'" do
       string = %q{image/png}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'image/png'
-      c.main_type.should eq 'image'
-      c.sub_type.should eq 'png'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'image/png'
+      expect(c.main_type).to eq 'image'
+      expect(c.sub_type).to eq 'png'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'message/delivery-status'" do
       string = %q{message/delivery-status}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'message/delivery-status'
-      c.main_type.should eq 'message'
-      c.sub_type.should eq 'delivery-status'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'message/delivery-status'
+      expect(c.main_type).to eq 'message'
+      expect(c.sub_type).to eq 'delivery-status'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'message/rfc822'" do
       string = %q{message/rfc822}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'message/rfc822'
-      c.main_type.should eq 'message'
-      c.sub_type.should eq 'rfc822'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'message/rfc822'
+      expect(c.main_type).to eq 'message'
+      expect(c.sub_type).to eq 'rfc822'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'multipart/alternative;'" do
       string = %q{multipart/alternative;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/alternative'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'alternative'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'multipart/alternative'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'alternative'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'multipart/alternative; boundary=\"----=_NextPart_000_0093_01C81419.EB75E850\"'" do
       string = %q{multipart/alternative; boundary="----=_NextPart_000_0093_01C81419.EB75E850"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/alternative'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'alternative'
-      c.parameters.should eql({"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"})
+      expect(c.content_type).to eq 'multipart/alternative'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'alternative'
+      expect(c.parameters).to eql({"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"})
     end
 
     it "should handle 'multipart/alternative; boundary=----=_NextPart_000_0093_01C81419.EB75E850'" do
       string = %q{multipart/alternative; boundary="----=_NextPart_000_0093_01C81419.EB75E850"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/alternative'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'alternative'
-      c.parameters.should eql({"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"})
+      expect(c.content_type).to eq 'multipart/alternative'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'alternative'
+      expect(c.parameters).to eql({"boundary" =>"----=_NextPart_000_0093_01C81419.EB75E850"})
     end
 
     it "should handle 'Multipart/Alternative;boundary=MuLtIpArT_BoUnDaRy'" do
       string = %q{Multipart/Alternative; boundary=MuLtIpArT_BoUnDaRy}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/alternative'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'alternative'
-      c.parameters.should eql({"boundary" =>"MuLtIpArT_BoUnDaRy"})
+      expect(c.content_type).to eq 'multipart/alternative'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'alternative'
+      expect(c.parameters).to eql({"boundary" =>"MuLtIpArT_BoUnDaRy"})
     end
 
     it "should handle 'Multipart/Alternative;boundary=MuLtIpArT_BoUnDaRy'" do
       string = %q{Multipart/Alternative;boundary=MuLtIpArT_BoUnDaRy}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/alternative'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'alternative'
-      c.parameters.should eql({"boundary" =>"MuLtIpArT_BoUnDaRy"})
+      expect(c.content_type).to eq 'multipart/alternative'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'alternative'
+      expect(c.parameters).to eql({"boundary" =>"MuLtIpArT_BoUnDaRy"})
     end
 
     it %(should handle 'multipart/alternative; boundary="----jkhkjgyurlkmn789809";; charset="us-ascii"') do
       string = %(multipart/alternative; boundary="----jkhkjgyurlkmn789809";; charset="us-ascii")
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/alternative'
-      c.parameters['boundary'].should == '----jkhkjgyurlkmn789809'
+      expect(c.content_type).to eq 'multipart/alternative'
+      expect(c.parameters['boundary']).to eq('----jkhkjgyurlkmn789809')
     end
 
     it "should handle 'multipart/mixed'" do
       string = %q{multipart/mixed}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/mixed'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'mixed'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'multipart/mixed'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'mixed'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'multipart/mixed;'" do
       string = %q{multipart/mixed;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/mixed'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'mixed'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'multipart/mixed'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'mixed'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'multipart/mixed; boundary=Apple-Mail-13-196941151'" do
       string = %q{multipart/mixed; boundary=Apple-Mail-13-196941151}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/mixed'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'mixed'
-      c.parameters.should eql({"boundary" => "Apple-Mail-13-196941151"})
+      expect(c.content_type).to eq 'multipart/mixed'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'mixed'
+      expect(c.parameters).to eql({"boundary" => "Apple-Mail-13-196941151"})
     end
 
     it "should handle 'multipart/mixed; boundary=mimepart_427e4cb4ca329_133ae40413c81ef'" do
       string = %q{multipart/mixed; boundary=mimepart_427e4cb4ca329_133ae40413c81ef}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/mixed'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'mixed'
-      c.parameters.should eql({"boundary" => "mimepart_427e4cb4ca329_133ae40413c81ef"})
+      expect(c.content_type).to eq 'multipart/mixed'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'mixed'
+      expect(c.parameters).to eql({"boundary" => "mimepart_427e4cb4ca329_133ae40413c81ef"})
     end
 
     it "should handle 'multipart/report; report-type=delivery-status;'" do
       string = %q{multipart/report; report-type=delivery-status;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/report'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'report'
-      c.parameters.should eql({"report-type" => "delivery-status"})
+      expect(c.content_type).to eq 'multipart/report'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'report'
+      expect(c.parameters).to eql({"report-type" => "delivery-status"})
     end
 
     it "should handle 'multipart/signed;'" do
       string = %q{multipart/signed;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/signed'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'signed'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'multipart/signed'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'signed'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'text/enriched;'" do
       string = %q{text/enriched;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/enriched'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'enriched'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'text/enriched'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'enriched'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'text/html;'" do
       string = %q{text/html;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/html'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'html'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'text/html'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'html'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'text/html; charset=iso-8859-1;'" do
       string = %q{text/html; charset=iso-8859-1;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/html'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'html'
-      c.parameters.should eql({"charset" => 'iso-8859-1'})
+      expect(c.content_type).to eq 'text/html'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'html'
+      expect(c.parameters).to eql({"charset" => 'iso-8859-1'})
     end
 
     it "should handle 'TEXT/PLAIN; charset=ISO-8859-1;'" do
       string = %q{TEXT/PLAIN; charset=ISO-8859-1;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({"charset" => 'ISO-8859-1'})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({"charset" => 'ISO-8859-1'})
     end
 
     it "should handle 'text/plain'" do
       string = %q{text/plain}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'text/plain;'" do
       string = %q{text/plain;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'text/plain; charset=ISO-8859-1'" do
       string = %q{text/plain; charset=ISO-8859-1}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({"charset" => 'ISO-8859-1'})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({"charset" => 'ISO-8859-1'})
     end
 
     it "should handle 'text/plain; charset=ISO-8859-1;'" do
       string = %q{text/plain; charset=ISO-8859-1; format=flowed}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({"charset" => 'ISO-8859-1', "format" => 'flowed'})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({"charset" => 'ISO-8859-1', "format" => 'flowed'})
     end
 
     it "should handle 'text/plain; charset=us-ascii;'" do
       string = %q{text/plain; charset=us-ascii}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({"charset" => 'us-ascii'})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({"charset" => 'us-ascii'})
     end
 
     it "should handle 'text/plain; charset=US-ASCII; format=flowed'" do
       string = %q{text/plain; charset=US-ASCII; format=flowed}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({"charset" => 'US-ASCII', "format" => 'flowed'})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({"charset" => 'US-ASCII', "format" => 'flowed'})
     end
 
     it "should handle 'text/plain; charset=US-ASCII; format=flowed'" do
       string = %q{text/plain; charset=US-ASCII; format=flowed}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({"charset" => 'US-ASCII', "format" => 'flowed'})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({"charset" => 'US-ASCII', "format" => 'flowed'})
     end
 
     it "should handle 'text/plain; charset=utf-8'" do
       string = %q{text/plain; charset=utf-8}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({"charset" => 'utf-8'})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({"charset" => 'utf-8'})
     end
 
     it "should handle 'text/plain; charset=utf-8'" do
       string = %q{text/plain; charset=X-UNKNOWN}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/plain'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'plain'
-      c.parameters.should eql({"charset" => 'X-UNKNOWN'})
+      expect(c.content_type).to eq 'text/plain'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'plain'
+      expect(c.parameters).to eql({"charset" => 'X-UNKNOWN'})
     end
 
     it "should handle 'text/x-ruby-script;'" do
       string = %q{text/x-ruby-script;}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/x-ruby-script'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'x-ruby-script'
-      c.parameters.should eql({})
+      expect(c.content_type).to eq 'text/x-ruby-script'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'x-ruby-script'
+      expect(c.parameters).to eql({})
     end
 
     it "should handle 'text/x-ruby-script; name=\"hello.rb\"'" do
       string = %q{text/x-ruby-script; name="hello.rb"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'text/x-ruby-script'
-      c.main_type.should eq 'text'
-      c.sub_type.should eq 'x-ruby-script'
-      c.parameters.should eql({"name" => 'hello.rb'})
+      expect(c.content_type).to eq 'text/x-ruby-script'
+      expect(c.main_type).to eq 'text'
+      expect(c.sub_type).to eq 'x-ruby-script'
+      expect(c.parameters).to eql({"name" => 'hello.rb'})
     end
 
     it "should handle 'multipart/mixed; boundary=\"=_NextPart_Lycos_15031600484464_ID\"" do
       string = %q{multipart/mixed; boundary="=_NextPart_Lycos_15031600484464_ID"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/mixed'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'mixed'
-      c.parameters.should eql({"boundary" => '=_NextPart_Lycos_15031600484464_ID'})
+      expect(c.content_type).to eq 'multipart/mixed'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'mixed'
+      expect(c.parameters).to eql({"boundary" => '=_NextPart_Lycos_15031600484464_ID'})
     end
 
     it "should handle 'multipart/alternative; boundary=----=_=NextPart_000_0093_01C81419.EB75E850" do
       string = %q{multipart/alternative; boundary=----=_=NextPart_000_0093_01C81419.EB75E850}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/alternative'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'alternative'
-      c.parameters.should eql({"boundary" => '----=_=NextPart_000_0093_01C81419.EB75E850'})
+      expect(c.content_type).to eq 'multipart/alternative'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'alternative'
+      expect(c.parameters).to eql({"boundary" => '----=_=NextPart_000_0093_01C81419.EB75E850'})
     end
 
     it "should handle 'multipart/alternative; boundary=\"----=_=NextPart_000_0093_01C81419.EB75E850\"" do
       string = %q{multipart/alternative; boundary="----=_=NextPart_000_0093_01C81419.EB75E850"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/alternative'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'alternative'
-      c.parameters.should eql({"boundary" => '----=_=NextPart_000_0093_01C81419.EB75E850'})
+      expect(c.content_type).to eq 'multipart/alternative'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'alternative'
+      expect(c.parameters).to eql({"boundary" => '----=_=NextPart_000_0093_01C81419.EB75E850'})
     end
 
     it "should handle 'multipart/related;boundary=1_4626B816_9F1690;Type=\"application/smil\";Start=\"<mms.smil.txt>\"'" do
       string = %q{multipart/related;boundary=1_4626B816_9F1690;Type="application/smil";Start="<mms.smil.txt>"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'multipart/related'
-      c.main_type.should eq 'multipart'
-      c.sub_type.should eq 'related'
-      c.parameters.should eql({"boundary" => '1_4626B816_9F1690', "Type" => 'application/smil', "Start" => '<mms.smil.txt>'})
+      expect(c.content_type).to eq 'multipart/related'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'related'
+      expect(c.parameters).to eql({"boundary" => '1_4626B816_9F1690', "Type" => 'application/smil', "Start" => '<mms.smil.txt>'})
     end
 
     it "should handle 'IMAGE/JPEG; name=\"IM 006.jpg\"'" do
       string = %q{IMAGE/JPEG; name="IM 006.jpg"}
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'image/jpeg'
-      c.main_type.should eq 'image'
-      c.sub_type.should eq 'jpeg'
-      c.parameters.should eql({"name" => "IM 006.jpg"})
+      expect(c.content_type).to eq 'image/jpeg'
+      expect(c.main_type).to eq 'image'
+      expect(c.sub_type).to eq 'jpeg'
+      expect(c.parameters).to eql({"name" => "IM 006.jpg"})
     end
 
     it "should handle 'unknown/unknown'" do
       string = %(unknown/unknown; charset=iso-8859-1; name=IMSTP19.gif)
       c = Mail::ContentTypeField.new(string)
-      c.content_type.should eq 'unknown/unknown'
-      c.main_type.should eq 'unknown'
-      c.sub_type.should eq 'unknown'
-      c.parameters.should eql('charset' => 'iso-8859-1', 'name' => 'IMSTP19.gif')
+      expect(c.content_type).to eq 'unknown/unknown'
+      expect(c.main_type).to eq 'unknown'
+      expect(c.sub_type).to eq 'unknown'
+      expect(c.parameters).to eql('charset' => 'iso-8859-1', 'name' => 'IMSTP19.gif')
     end
 
   end
@@ -617,13 +617,13 @@ describe Mail::ContentTypeField do
     it "should locate a filename if there is a filename" do
       string = %q{application/octet-stream; filename=mikel.jpg}
       c = Mail::ContentTypeField.new(string)
-      c.filename.should eq 'mikel.jpg'
+      expect(c.filename).to eq 'mikel.jpg'
     end
 
     it "should locate a name if there is no filename" do
       string = %q{application/octet-stream; name=mikel.jpg}
       c = Mail::ContentTypeField.new(string)
-      c.filename.should eq 'mikel.jpg'
+      expect(c.filename).to eq 'mikel.jpg'
     end
 
     it "should locate an encoded name as a filename" do
@@ -636,7 +636,7 @@ describe Mail::ContentTypeField do
         expected = "01 Quien Te Dij\221at. Pitbull.mp3"
         result = c.filename
       end
-      expected.should eq result
+      expect(expected).to eq result
     end
 
     it "should encode a non us-ascii filename" do
@@ -658,8 +658,8 @@ describe Mail::ContentTypeField do
         result = %Q{Content-Type: application/octet-stream;\r\n\sfilename*=sjis'jp'01%20Quien%20Te%20Dij%91at.%20Pitbull.mp3\r\n}
       end
       c.filename = string
-      c.parameters.should eql({"filename" => string})
-      c.encoded.should eq result
+      expect(c.parameters).to eql({"filename" => string})
+      expect(c.encoded).to eq result
       $KCODE = @original if RUBY_VERSION < '1.9'
     end
 
@@ -669,13 +669,13 @@ describe Mail::ContentTypeField do
 
     it "should handle missing sub-type on a text content type" do
       c = Mail::ContentTypeField.new('Content-Type: text')
-      c.content_type.should eq 'text/plain'
+      expect(c.content_type).to eq 'text/plain'
     end
 
     it "should handle missing ; after content-type" do
       c = Mail::ContentTypeField.new('Content-Type: multipart/mixed boundary="----=_NextPart_000_000F_01C17754.8C3CAF30"')
-      c.content_type.should eq 'multipart/mixed'
-      c.parameters['boundary'].should eq '----=_NextPart_000_000F_01C17754.8C3CAF30'
+      expect(c.content_type).to eq 'multipart/mixed'
+      expect(c.parameters['boundary']).to eq '----=_NextPart_000_000F_01C17754.8C3CAF30'
     end
 
   end
@@ -683,82 +683,82 @@ describe Mail::ContentTypeField do
   describe "initializing with an array" do
     it "should initialize with an array" do
       c = Mail::ContentTypeField.new(['text', 'html', {'charset' => 'UTF-8'}])
-      c.content_type.should eq 'text/html'
-      c.parameters['charset'].should eq 'UTF-8'
+      expect(c.content_type).to eq 'text/html'
+      expect(c.parameters['charset']).to eq 'UTF-8'
     end
 
     it "should allow many parameters to be passed in" do
       c = Mail::ContentTypeField.new(['text', 'html', {"format"=>"flowed", "charset"=>"utf-8"}])
-      c.content_type.should eq 'text/html'
-      c.parameters['charset'].should eq 'utf-8'
-      c.parameters['format'].should eq 'flowed'
+      expect(c.content_type).to eq 'text/html'
+      expect(c.parameters['charset']).to eq 'utf-8'
+      expect(c.parameters['format']).to eq 'flowed'
     end
   end
 
   describe "special case values needing sanity" do
     it "should handle 'text/plain;ISO-8559-1'" do
       c = Mail::ContentTypeField.new('text/plain;ISO-8559-1')
-      c.string.should eq 'text/plain'
-      c.parameters['charset'].should eq 'iso-8559-1'
+      expect(c.string).to eq 'text/plain'
+      expect(c.parameters['charset']).to eq 'iso-8559-1'
     end
 
     it "should handle 'text/plain; charset = \"iso-8859-1\"'" do
       c = Mail::ContentTypeField.new('text/plain; charset = "iso-8859-1"')
-      c.string.should eq 'text/plain'
-      c.parameters['charset'].should eq 'iso-8859-1'
+      expect(c.string).to eq 'text/plain'
+      expect(c.parameters['charset']).to eq 'iso-8859-1'
     end
 
     it "should handle text; params" do
       c = Mail::ContentTypeField.new('text; charset=utf-8')
-      c.string.should eq 'text/plain'
-      c.parameters['charset'].should eq 'utf-8'
+      expect(c.string).to eq 'text/plain'
+      expect(c.parameters['charset']).to eq 'utf-8'
     end
 
     it 'should handle text/html; charset="charset="GB2312""' do
       c = Mail::ContentTypeField.new('text/html; charset="charset="GB2312""')
-      c.string.should eq 'text/html'
-      c.parameters['charset'].should eq 'gb2312'
+      expect(c.string).to eq 'text/html'
+      expect(c.parameters['charset']).to eq 'gb2312'
     end
 
     it "should handle application/octet-stream; name=archiveshelp1[1].htm" do
       c = Mail::ContentTypeField.new('application/octet-stream; name=archiveshelp1[1].htm')
-      c.string.should eq 'application/octet-stream'
-      c.parameters['name'].should eq 'archiveshelp1[1].htm'
+      expect(c.string).to eq 'application/octet-stream'
+      expect(c.parameters['name']).to eq 'archiveshelp1[1].htm'
     end
 
     it 'should handle text/plain;; format="flowed"' do
       c = Mail::ContentTypeField.new('text/plain;; format="flowed"')
-      c.string.should eq 'text/plain'
-      c.parameters['format'].should eq 'flowed'
+      expect(c.string).to eq 'text/plain'
+      expect(c.parameters['format']).to eq 'flowed'
     end
 
     it 'set an empty content type to text/plain' do
       c = Mail::ContentTypeField.new('')
-      c.string.should eq 'text/plain'
+      expect(c.string).to eq 'text/plain'
     end
 
     it "should just ignore illegal params like audio/x-midi;\r\n\sname=Part .exe" do
       pending "fixed in pr #481"
       c = Mail::ContentTypeField.new("audio/x-midi;\r\n\sname=Part .exe")
-      c.string.should eq 'audio/x-midi'
-      c.parameters['name'].should eq nil
+      expect(c.string).to eq 'audio/x-midi'
+      expect(c.parameters['name']).to eq nil
     end
 
     it "should handle: rfc822; format=flowed; charset=iso-8859-15" do
       c = Mail::ContentTypeField.new("rfc822; format=flowed; charset=iso-8859-15")
-      c.string.should eq 'text/plain'
-      c.parameters['format'].should eq 'flowed'
-      c.parameters['charset'].should eq 'iso-8859-15'
+      expect(c.string).to eq 'text/plain'
+      expect(c.parameters['format']).to eq 'flowed'
+      expect(c.parameters['charset']).to eq 'iso-8859-15'
     end
 
     it "should just get the mime type if all else fails with some real garbage" do
       c = Mail::ContentTypeField.new("text/html; format=flowed; charset=iso-8859-15  Mime-Version: 1.0")
-      c.string.should eq 'text/html'
+      expect(c.string).to eq 'text/html'
     end
 
     it "shouldn't include separating semicolon in parameter value when sanitizing" do
       c = Mail::ContentTypeField.new(%Q{Multipart/Related;boundary=boundary123?WUT; type="application/xml";})
-      c.parameters['boundary'].should eq 'boundary123?WUT'
+      expect(c.parameters['boundary']).to eq 'boundary123?WUT'
     end
 
   end

--- a/spec/mail/fields/date_field_spec.rb
+++ b/spec/mail/fields/date_field_spec.rb
@@ -23,55 +23,55 @@ describe Mail::DateField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::DateField.new("12 Aug 2009 00:00:02 GMT") }.should_not raise_error
+      expect(doing { Mail::DateField.new("12 Aug 2009 00:00:02 GMT") }).not_to raise_error
     end
 
     it "should be able to tell the time" do
-      Mail::DateField.new("12 Aug 2009 00:00:02 GMT").date_time.class.should eq DateTime
+      expect(Mail::DateField.new("12 Aug 2009 00:00:02 GMT").date_time.class).to eq DateTime
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::DateField.included_modules.should include(Mail::CommonDate) 
+      expect(Mail::DateField.included_modules).to include(Mail::CommonDate) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::DateField.new('Date: 12 Aug 2009 00:00:02 GMT')
-      t.name.should eq 'Date'
-      t.value.should eq 'Wed, 12 Aug 2009 00:00:02 +0000'
-      t.date_time.should eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
+      expect(t.name).to eq 'Date'
+      expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
+      expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
     end
 
     it "should accept a string without the field name" do
       t = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
-      t.name.should eq 'Date'
-      t.value.should eq 'Wed, 12 Aug 2009 00:00:02 +0000'
-      t.date_time.should eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
+      expect(t.name).to eq 'Date'
+      expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
+      expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
     end
     
     it "should accept nil as a value" do
       t = Mail::DateField.new(nil)
-      t.date_time.should_not be_nil
+      expect(t.date_time).not_to be_nil
     end
     
     it "should allow us to encode an date field" do
       field = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
-      field.encoded.should eq "Date: Wed, 12 Aug 2009 00:00:02 +0000\r\n"
+      expect(field.encoded).to eq "Date: Wed, 12 Aug 2009 00:00:02 +0000\r\n"
     end
     
     it "should allow us to decode an address field" do
       field = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
-      field.decoded.should eq "Wed, 12 Aug 2009 00:00:02 +0000"
+      expect(field.decoded).to eq "Wed, 12 Aug 2009 00:00:02 +0000"
     end
 
     it "should be able to parse a really bad spacing example" do
       field = Mail::DateField.new("Fri, 21 Nov 1997 09(comment):   55  :  06 -0600")
-      field.decoded.should eq "Fri, 21 Nov 1997 09:55:06 -0600"
+      expect(field.decoded).to eq "Fri, 21 Nov 1997 09:55:06 -0600"
     end
 
     it "should give today's date if no date is specified" do
       now = Time.now
-      Time.stub!(:now).and_return(now)
-      Mail::DateField.new.date_time.should eq ::DateTime.parse(now.to_s)
+      allow(Time).to receive(:now).and_return(now)
+      expect(Mail::DateField.new.date_time).to eq ::DateTime.parse(now.to_s)
     end
     
   end

--- a/spec/mail/fields/envelope_spec.rb
+++ b/spec/mail/fields/envelope_spec.rb
@@ -25,18 +25,18 @@ describe Mail::Envelope do
   #        an end-of-line marker.
 
   it "should initialize" do
-    doing { Mail::Envelope.new('mikel@test.lindsaar.net Mon May  2 16:07:05 2005') }.should_not raise_error
+    expect(doing { Mail::Envelope.new('mikel@test.lindsaar.net Mon May  2 16:07:05 2005') }).not_to raise_error
   end
 
   describe "accessor methods" do
     it "should return the address" do
       envelope = Mail::Envelope.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009")
-      envelope.from.should eq "mikel@test.lindsaar.net"
+      expect(envelope.from).to eq "mikel@test.lindsaar.net"
     end
 
     it "should return the date_time" do
       envelope = Mail::Envelope.new("mikel@test.lindsaar.net Mon Aug 17 00:39:21 2009")
-      envelope.date.should eq ::DateTime.parse("Mon Aug 17 00:39:21 2009")
+      expect(envelope.date).to eq ::DateTime.parse("Mon Aug 17 00:39:21 2009")
     end
   end
 

--- a/spec/mail/fields/from_field_spec.rb
+++ b/spec/mail/fields/from_field_spec.rb
@@ -9,23 +9,23 @@ describe Mail::FromField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::FromField.new("From: Mikel") }.should_not raise_error
+      expect(doing { Mail::FromField.new("From: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::FromField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::FromField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::FromField.new('From: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'From'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'From'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::FromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'From'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'From'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -35,55 +35,55 @@ describe Mail::FromField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::FromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::FromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::FromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::FromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::FromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq "From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      expect(t.encoded).to eq "From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
     it "should return the encoded line" do
       t = Mail::FromField.new("bob@me.com")
-      t.encoded.should eq "From: bob@me.com\r\n"
+      expect(t.encoded).to eq "From: bob@me.com\r\n"
     end
     
     it "should return the decoded line" do
       t = Mail::FromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.decoded.should eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
+      expect(t.decoded).to eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
     
   end
   
   it "should handle non ascii" do
     t = Mail::FromField.new('"Foo áëô îü" <extended@example.net>')
-    t.decoded.should eq '"Foo áëô îü" <extended@example.net>'
-    t.encoded.should eq "From: =?UTF-8?B?Rm9vIMOhw6vDtCDDrsO8?= <extended@example.net>\r\n"
+    expect(t.decoded).to eq '"Foo áëô îü" <extended@example.net>'
+    expect(t.encoded).to eq "From: =?UTF-8?B?Rm9vIMOhw6vDtCDDrsO8?= <extended@example.net>\r\n"
   end
   
   
   it "should work without quotes" do
     t = Mail::FromField.new('Foo áëô îü <extended@example.net>')
-    t.encoded.should eq "From: Foo =?UTF-8?B?w6HDq8O0?= =?UTF-8?B?IMOuw7w=?= <extended@example.net>\r\n"
-    t.decoded.should eq '"Foo áëô îü" <extended@example.net>'
+    expect(t.encoded).to eq "From: Foo =?UTF-8?B?w6HDq8O0?= =?UTF-8?B?IMOuw7w=?= <extended@example.net>\r\n"
+    expect(t.decoded).to eq '"Foo áëô îü" <extended@example.net>'
   end
 
 end

--- a/spec/mail/fields/in_reply_to_field_spec.rb
+++ b/spec/mail/fields/in_reply_to_field_spec.rb
@@ -13,52 +13,52 @@ describe Mail::InReplyToField do
 
   describe "initialization" do
     it "should initialize" do
-      doing { Mail::InReplyToField.new("<1234@test.lindsaar.net>") }.should_not raise_error
+      expect(doing { Mail::InReplyToField.new("<1234@test.lindsaar.net>") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       t = Mail::InReplyToField.new('In-Reply-To: <1234@test.lindsaar.net>')
-      t.name.should eq 'In-Reply-To'
-      t.value.should eq '<1234@test.lindsaar.net>'
-      t.message_id.should eq '1234@test.lindsaar.net'
+      expect(t.name).to eq 'In-Reply-To'
+      expect(t.value).to eq '<1234@test.lindsaar.net>'
+      expect(t.message_id).to eq '1234@test.lindsaar.net'
     end
 
     it "should accept a string without the field name" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
-      t.name.should eq 'In-Reply-To'
-      t.value.should eq '<1234@test.lindsaar.net>'
-      t.message_id.should eq '1234@test.lindsaar.net'
+      expect(t.name).to eq 'In-Reply-To'
+      expect(t.value).to eq '<1234@test.lindsaar.net>'
+      expect(t.message_id).to eq '1234@test.lindsaar.net'
     end
     
     it "should provide encoded" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
-      t.encoded.should eq "In-Reply-To: <1234@test.lindsaar.net>\r\n"
+      expect(t.encoded).to eq "In-Reply-To: <1234@test.lindsaar.net>\r\n"
     end
     
     it "should handle many encoded message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      t.encoded.should eq "In-Reply-To: <1234@test.lindsaar.net>\r\n <4567@test.lindsaar.net>\r\n"
+      expect(t.encoded).to eq "In-Reply-To: <1234@test.lindsaar.net>\r\n <4567@test.lindsaar.net>\r\n"
     end
 
     it "should handle an array of message IDs" do
       t = Mail::InReplyToField.new(['<1234@test.lindsaar.net>', '<4567@test.lindsaar.net>'])
-      t.encoded.should eq "In-Reply-To: <1234@test.lindsaar.net>\r\n <4567@test.lindsaar.net>\r\n"
+      expect(t.encoded).to eq "In-Reply-To: <1234@test.lindsaar.net>\r\n <4567@test.lindsaar.net>\r\n"
     end
 
     it "should provide decoded" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
-      t.decoded.should eq "<1234@test.lindsaar.net>"
+      expect(t.decoded).to eq "<1234@test.lindsaar.net>"
     end
     
     it "should handle many decoded message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      t.decoded.should eq '<1234@test.lindsaar.net> <4567@test.lindsaar.net>'
+      expect(t.decoded).to eq '<1234@test.lindsaar.net> <4567@test.lindsaar.net>'
     end
     
     it "should handle an empty value" do
       t = Mail::InReplyToField.new('')
-      t.name.should eq 'In-Reply-To'
-      t.decoded.should eq nil
+      expect(t.name).to eq 'In-Reply-To'
+      expect(t.decoded).to eq nil
     end
     
   end
@@ -66,15 +66,15 @@ describe Mail::InReplyToField do
   describe "handlign multiple message ids" do
     it "should handle many message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      t.name.should eq 'In-Reply-To'
-      t.message_ids.should eq ['1234@test.lindsaar.net', '4567@test.lindsaar.net']
+      expect(t.name).to eq 'In-Reply-To'
+      expect(t.message_ids).to eq ['1234@test.lindsaar.net', '4567@test.lindsaar.net']
     end
   end
 
   it "should output lines shorter than 998 chars" do
     k = Mail::InReplyToField.new('<Kohciuku@apholoVu.com> <foovohPu@Thegahsh.com> <UuseZeow@oocieBie.com> <UchaeKoo@eeJoukie.com> <ieKahque@ieGoochu.com> <aZaXaeva@ungaiGai.com> <sheiraiK@ookaiSha.com> <weijooPi@ahfuRaeh.com> <FiruJeur@weiphohP.com> <cuadoiQu@aiZuuqua.com> <YohGieVe@Reacepae.com> <Ieyechum@ephooGho.com> <uGhievoo@vusaeciM.com> <ouhieTha@leizaeTi.com> <ohgohGhu@jieNgooh.com> <ahNookah@oChiecoo.com> <taeWieTu@iuwiLooZ.com> <Kohraiji@AizohGoa.com> <hiQuaegh@eeluThii.com> <Uunaesoh@UogheeCh.com> <JeQuahMa@Thahchoh.com> <aaxohJoh@ahfaeCho.com> <Pahneehu@eehooChi.com> <angeoKah@Wahsaeme.com> <ietovoaV@muewaeZi.com> <aebiuZur@oteeYaiF.com> <pheiXahw@Muquahba.com> <aNgiaPha@bohliNge.com> <Eikawohf@IevaiQuu.com> <gihaeduZ@Raighiey.com> <Theequoh@hoamaeSa.com> <VeiVooyi@aimuQuoo.com> <ahGoocie@BohpheVi.com> <roivahPa@uPhoghai.com> <gioZohli@Gaochoow.com> <eireLair@phaevieR.com> <TahthaeC@oolaiBei.com> <phuYeika@leiKauPh.com> <BieYenoh@Xaebaalo.com> <xohvaeWa@ahghaeRe.com> <thoQuohV@Ubooheay.com> <pheeWohV@feicaeNg.com>')
     lines = k.encoded.split("\r\n\s")
-    lines.each { |line| line.length.should < 998 }
+    lines.each { |line| expect(line.length).to be < 998 }
   end
 
 end

--- a/spec/mail/fields/keywords_field_spec.rb
+++ b/spec/mail/fields/keywords_field_spec.rb
@@ -6,19 +6,19 @@ describe Mail::KeywordsField do
   describe "initializing" do
     
     it "should initialize" do
-      doing { Mail::KeywordsField.new("this, is, email") }.should_not raise_error
+      expect(doing { Mail::KeywordsField.new("this, is, email") }).not_to raise_error
     end
     
     it "should accept a string with the field name" do
       k = Mail::KeywordsField.new('Keywords: these are keywords, so there')
-      k.name.should eq 'Keywords'
-      k.value.should eq 'these are keywords, so there'
+      expect(k.name).to eq 'Keywords'
+      expect(k.value).to eq 'these are keywords, so there'
     end
     
     it "should accept a string with the field name" do
       k = Mail::KeywordsField.new('these are keywords, so there')
-      k.name.should eq 'Keywords'
-      k.value.should eq 'these are keywords, so there'
+      expect(k.name).to eq 'Keywords'
+      expect(k.value).to eq 'these are keywords, so there'
     end
     
   end
@@ -26,27 +26,27 @@ describe Mail::KeywordsField do
   describe "giving a list of keywords" do
     it "should return a list of keywords" do
       k = Mail::KeywordsField.new('these are keywords, so there')
-      k.keywords.should eq ['these are keywords', 'so there']
+      expect(k.keywords).to eq ['these are keywords', 'so there']
     end
     
     it "should handle phrases" do
       k = Mail::KeywordsField.new('"these, are keywords", so there')
-      k.keywords.should eq ['these, are keywords', 'so there']
+      expect(k.keywords).to eq ['these, are keywords', 'so there']
     end
     
     it "should handle comments" do
       k = Mail::KeywordsField.new('"these, are keywords", so there (This is an irrelevant comment)')
-      k.keywords.should eq ['these, are keywords', 'so there (This is an irrelevant comment)']
+      expect(k.keywords).to eq ['these, are keywords', 'so there (This is an irrelevant comment)']
     end
     
     it "should handle comments" do
       k = Mail::KeywordsField.new('"these, are keywords", so there (This is an irrelevant comment)')
-      k.keywords.should eq ['these, are keywords', 'so there (This is an irrelevant comment)']
+      expect(k.keywords).to eq ['these, are keywords', 'so there (This is an irrelevant comment)']
     end
     
     it "should handle comments in quotes" do
       k = Mail::KeywordsField.new('"these, are keywords (another comment to be ignored)", so there (This is an irrelevant comment)')
-      k.keywords.should eq ['these, are keywords (another comment to be ignored)', 'so there (This is an irrelevant comment)']
+      expect(k.keywords).to eq ['these, are keywords (another comment to be ignored)', 'so there (This is an irrelevant comment)']
     end
     
   end
@@ -54,19 +54,19 @@ describe Mail::KeywordsField do
   describe "encoding and decoding" do
     it "should encode" do
       k = Mail::KeywordsField.new('these are keywords, so there')
-      k.encoded.should eq "Keywords: these are keywords,\r\n so there\r\n"
+      expect(k.encoded).to eq "Keywords: these are keywords,\r\n so there\r\n"
     end
 
     it "should decode" do
       k = Mail::KeywordsField.new('these are keywords, so there')
-      k.decoded.should eq "these are keywords, so there"
+      expect(k.decoded).to eq "these are keywords, so there"
     end
   end
 
   it "should output lines shorter than 998 chars" do
     k = Mail::KeywordsField.new('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed placerat euismod velit nec convallis. Cras bibendum mattis arcu a tincidunt. Nullam ac orci vitae massa elementum ultricies ultricies nec quam. Praesent eleifend viverra semper. Sed id ultricies ipsum. Pellentesque sed nunc mauris, at varius sem. Curabitur pretium pellentesque velit, eget pellentesque dolor interdum eget. Duis ac lectus nec arcu pharetra lobortis. Integer risus felis, convallis ut feugiat quis, imperdiet ut sapien. Nullam imperdiet leo nec lectus imperdiet mollis. Proin nec lectus id erat pellentesque pretium vitae sit amet massa. Proin interdum pellentesque mi, at tristique sem facilisis ut. Donec enim mauris, viverra ut lacinia pharetra, elementum nec mi. Ut at interdum massa. Integer placerat tortor at tellus lobortis a mattis massa ultricies. Vivamus nec dolor at justo fringilla laoreet rhoncus fermentum lectus. Praesent tincidunt congue mauris vitae aliquam. Mauris arcu mauris, faucibus sed turpis duis.')
     lines = k.encoded.split("\r\n\s")
-    lines.each { |line| line.length.should < 998 }
+    lines.each { |line| expect(line.length).to be < 998 }
   end
 
 end

--- a/spec/mail/fields/message_id_field_spec.rb
+++ b/spec/mail/fields/message_id_field_spec.rb
@@ -57,27 +57,27 @@ describe Mail::MessageIdField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::MessageIdField.new("<1234@test.lindsaar.net>") }.should_not raise_error
+      expect(doing { Mail::MessageIdField.new("<1234@test.lindsaar.net>") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       m = Mail::MessageIdField.new('Message-ID: <1234@test.lindsaar.net>')
-      m.name.should eq 'Message-ID'
-      m.value.should eq '<1234@test.lindsaar.net>'
-      m.message_id.should eq '1234@test.lindsaar.net'
+      expect(m.name).to eq 'Message-ID'
+      expect(m.value).to eq '<1234@test.lindsaar.net>'
+      expect(m.message_id).to eq '1234@test.lindsaar.net'
     end
 
     it "should accept a string without the field name" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.name.should eq 'Message-ID'
-      m.value.should eq '<1234@test.lindsaar.net>'
-      m.message_id.should eq '1234@test.lindsaar.net'
+      expect(m.name).to eq 'Message-ID'
+      expect(m.value).to eq '<1234@test.lindsaar.net>'
+      expect(m.message_id).to eq '1234@test.lindsaar.net'
     end
 
     it "should accept a nil value and generate a message_id" do
       m = Mail::MessageIdField.new(nil)
-      m.name.should eq 'Message-ID'
-      m.value.should_not be_nil
+      expect(m.name).to eq 'Message-ID'
+      expect(m.value).not_to be_nil
     end
 
   end
@@ -86,17 +86,17 @@ describe Mail::MessageIdField do
 
     it "should not accept a string with multiple message IDs but only return the first" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
-      m.name.should eq 'Message-ID'
-      m.to_s.should eq '<1234@test.lindsaar.net>'
-      m.message_id.should eq '1234@test.lindsaar.net'
-      m.message_ids.should eq ['1234@test.lindsaar.net']
+      expect(m.name).to eq 'Message-ID'
+      expect(m.to_s).to eq '<1234@test.lindsaar.net>'
+      expect(m.message_id).to eq '1234@test.lindsaar.net'
+      expect(m.message_ids).to eq ['1234@test.lindsaar.net']
     end
 
     it "should change the message id if given a new message id" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.to_s.should eq '<1234@test.lindsaar.net>'
+      expect(m.to_s).to eq '<1234@test.lindsaar.net>'
       m.value = '<4567@test.lindsaar.net>'
-      m.to_s.should eq '<4567@test.lindsaar.net>'
+      expect(m.to_s).to eq '<4567@test.lindsaar.net>'
     end
 
   end
@@ -104,36 +104,36 @@ describe Mail::MessageIdField do
   describe "instance methods" do
     it "should provide to_s" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.to_s.should eq '<1234@test.lindsaar.net>'
-      m.message_id.to_s.should eq '1234@test.lindsaar.net'
+      expect(m.to_s).to eq '<1234@test.lindsaar.net>'
+      expect(m.message_id.to_s).to eq '1234@test.lindsaar.net'
     end
 
     it "should provide encoded" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.encoded.should eq "Message-ID: <1234@test.lindsaar.net>\r\n"
+      expect(m.encoded).to eq "Message-ID: <1234@test.lindsaar.net>\r\n"
     end
 
     it "should provide decoded" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.decoded.should eq "<1234@test.lindsaar.net>"
+      expect(m.decoded).to eq "<1234@test.lindsaar.net>"
     end
     
     it "should respond to :responsible_for?" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
-      m.should respond_to(:responsible_for?)
+      expect(m).to respond_to(:responsible_for?)
     end
   end
 
   describe "generating a message id" do
     it "should generate a message ID if it has no value" do
       m = Mail::MessageIdField.new
-      m.message_id.should_not be_blank
+      expect(m.message_id).not_to be_blank
     end
     
     it "should generate a random message ID" do
       m = Mail::MessageIdField.new
       1.upto(100) do
-        m.message_id.should_not == Mail::MessageIdField.new.message_id
+        expect(m.message_id).not_to eq(Mail::MessageIdField.new.message_id)
       end
     end
   end
@@ -141,7 +141,7 @@ describe Mail::MessageIdField do
   describe "weird message IDs" do
     it "should be able to parse <000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com>" do
       m = Mail::MessageIdField.new('<000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com>')
-      m.message_id.should eq '000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com'
+      expect(m.message_id).to eq '000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com'
     end
   end
 end

--- a/spec/mail/fields/mime_version_field_spec.rb
+++ b/spec/mail/fields/mime_version_field_spec.rb
@@ -83,19 +83,19 @@ describe Mail::MimeVersionField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::MimeVersionField.new("1.0") }.should_not raise_error
+      expect(doing { Mail::MimeVersionField.new("1.0") }).not_to raise_error
     end
 
     it "should accept a string with the field name" do
       t = Mail::MimeVersionField.new('Mime-Version: 1.0')
-      t.name.should eq 'Mime-Version'
-      t.value.should eq '1.0'
+      expect(t.name).to eq 'Mime-Version'
+      expect(t.value).to eq '1.0'
     end
 
     it "should accept a string without the field name" do
       t = Mail::MimeVersionField.new('1.0')
-      t.name.should eq 'Mime-Version'
-      t.value.should eq '1.0'
+      expect(t.name).to eq 'Mime-Version'
+      expect(t.value).to eq '1.0'
     end
 
   end
@@ -103,62 +103,62 @@ describe Mail::MimeVersionField do
   describe "parsing a version string" do
     it "should get a major value" do
       t = Mail::MimeVersionField.new('1.0')
-      t.major.should eq 1
+      expect(t.major).to eq 1
     end
 
     it "should get a minor value" do
       t = Mail::MimeVersionField.new('1.0')
-      t.minor.should eq 0
+      expect(t.minor).to eq 0
     end
 
     it "should get a version string" do
       t = Mail::MimeVersionField.new('1.0')
-      t.version.should eq '1.0'
+      expect(t.version).to eq '1.0'
     end
     
     it "should handle comments before the major version" do
       t = Mail::MimeVersionField.new('(This is a comment) 1.0')
-      t.version.should eq '1.0'
+      expect(t.version).to eq '1.0'
     end
 
     it "should handle comments before the major version without space" do
       t = Mail::MimeVersionField.new('(This is a comment)1.0')
-      t.version.should eq '1.0'
+      expect(t.version).to eq '1.0'
     end
 
     it "should handle comments after the major version without space" do
       t = Mail::MimeVersionField.new('1(This is a comment).0')
-      t.version.should eq '1.0'
+      expect(t.version).to eq '1.0'
     end
 
     it "should handle comments before the minor version without space" do
       t = Mail::MimeVersionField.new('1.(This is a comment)0')
-      t.version.should eq '1.0'
+      expect(t.version).to eq '1.0'
     end
 
     it "should handle comments after the minor version without space" do
       t = Mail::MimeVersionField.new('1.0(This is a comment)')
-      t.version.should eq '1.0'
+      expect(t.version).to eq '1.0'
     end
 
     it "should handle comments after the minor version" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
-      t.version.should eq '1.0'
+      expect(t.version).to eq '1.0'
     end
     
     it "should accept nil as a value" do
       t = Mail::MimeVersionField.new(nil)
-      t.version.should_not be_nil
+      expect(t.version).not_to be_nil
     end
     
     it "should provide an encoded value" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
-      t.encoded.should eq "Mime-Version: 1.0\r\n"
+      expect(t.encoded).to eq "Mime-Version: 1.0\r\n"
     end
 
     it "should provide an decoded value" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
-      t.decoded.should eq '1.0'
+      expect(t.decoded).to eq '1.0'
     end
 
   end

--- a/spec/mail/fields/received_field_spec.rb
+++ b/spec/mail/fields/received_field_spec.rb
@@ -4,53 +4,53 @@ require 'spec_helper'
 describe Mail::ReceivedField do
 
   it "should initialize" do
-    doing { Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)") }.should_not raise_error
+    expect(doing { Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)") }).not_to raise_error
   end
 
   it "should be able to tell the time" do
-    Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)").date_time.class.should eq DateTime
+    expect(Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)").date_time.class).to eq DateTime
   end
 
   it "should accept a string with the field name" do
     t = Mail::ReceivedField.new('Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    t.name.should eq 'Received'
-    t.value.should eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
-    t.info.should eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
-    t.date_time.should eq ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
+    expect(t.name).to eq 'Received'
+    expect(t.value).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
+    expect(t.info).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
+    expect(t.date_time).to eq ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
   end
   
   it "should accept a string without the field name" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    t.name.should eq 'Received'
-    t.value.should eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
-    t.info.should eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
-    t.date_time.should eq ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
+    expect(t.name).to eq 'Received'
+    expect(t.value).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
+    expect(t.info).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
+    expect(t.date_time).to eq ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
   end
 
   it "should provide an encoded value" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    t.encoded.should eq "Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000\r\n"
+    expect(t.encoded).to eq "Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000\r\n"
   end
 
   it "should provide an encoded value with correct timezone" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 -0500 (EST)')
-    t.encoded.should eq "Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 -0500\r\n"
+    expect(t.encoded).to eq "Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 -0500\r\n"
   end
 
   it "should provide an decoded value" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    t.decoded.should eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000'
+    expect(t.decoded).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000'
   end
 
   it "should handle empty name-value lists with a comment only (qmail style)" do
     t = Mail::ReceivedField.new('(qmail 24365 invoked by uid 99); 25 Jan 2011 12:31:11 -0000')
-    t.info.should eq '(qmail 24365 invoked by uid 99)'
+    expect(t.info).to eq '(qmail 24365 invoked by uid 99)'
   end
 
   it "should handle a blank value" do
     t = Mail::ReceivedField.new('')
-    t.decoded.should eq ''
-    t.encoded.should eq "Received: \r\n"
+    expect(t.decoded).to eq ''
+    expect(t.encoded).to eq "Received: \r\n"
   end
   
 end

--- a/spec/mail/fields/references_field_spec.rb
+++ b/spec/mail/fields/references_field_spec.rb
@@ -15,47 +15,47 @@ require 'spec_helper'
 describe Mail::ReferencesField do
 
   it "should initialize" do
-    doing { Mail::ReferencesField.new("<1234@test.lindsaar.net>") }.should_not raise_error
+    expect(doing { Mail::ReferencesField.new("<1234@test.lindsaar.net>") }).not_to raise_error
   end
 
   it "should accept a string with the field name" do
     t = Mail::ReferencesField.new('References: <1234@test.lindsaar.net>')
-    t.name.should eq 'References'
-    t.value.should eq '<1234@test.lindsaar.net>'
-    t.message_id.should eq '1234@test.lindsaar.net'
+    expect(t.name).to eq 'References'
+    expect(t.value).to eq '<1234@test.lindsaar.net>'
+    expect(t.message_id).to eq '1234@test.lindsaar.net'
   end
   
   it "should accept a string without the field name" do
     t = Mail::ReferencesField.new('<1234@test.lindsaar.net>')
-    t.name.should eq 'References'
-    t.value.should eq '<1234@test.lindsaar.net>'
-    t.message_id.should eq '1234@test.lindsaar.net'
+    expect(t.name).to eq 'References'
+    expect(t.value).to eq '<1234@test.lindsaar.net>'
+    expect(t.message_id).to eq '1234@test.lindsaar.net'
   end
 
   it "should accept multiple message ids" do
     t = Mail::ReferencesField.new('<1234@test.lindsaar.net> <5678@test.lindsaar.net>')
-    t.name.should eq 'References'
-    t.value.should eq '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
-    t.message_id.should eq '1234@test.lindsaar.net'
-    t.message_ids.should eq ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
-    t.to_s.should eq '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
+    expect(t.name).to eq 'References'
+    expect(t.value).to eq '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
+    expect(t.message_id).to eq '1234@test.lindsaar.net'
+    expect(t.message_ids).to eq ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
+    expect(t.to_s).to eq '<1234@test.lindsaar.net> <5678@test.lindsaar.net>'
   end
 
   it "should accept an array of message ids" do
     t = Mail::ReferencesField.new(['<1234@test.lindsaar.net>', '<5678@test.lindsaar.net>'])
-    t.encoded.should eq "References: <1234@test.lindsaar.net>\r\n <5678@test.lindsaar.net>\r\n"
+    expect(t.encoded).to eq "References: <1234@test.lindsaar.net>\r\n <5678@test.lindsaar.net>\r\n"
   end
 
   it "should accept no message ids" do
     t = Mail::ReferencesField.new('')
-    t.name.should eq 'References'
-    t.decoded.should eq nil
+    expect(t.name).to eq 'References'
+    expect(t.decoded).to eq nil
   end
 
   it "should output lines shorter than 998 chars" do
     k = Mail::ReferencesField.new('<Kohciuku@apholoVu.com> <foovohPu@Thegahsh.com> <UuseZeow@oocieBie.com> <UchaeKoo@eeJoukie.com> <ieKahque@ieGoochu.com> <aZaXaeva@ungaiGai.com> <sheiraiK@ookaiSha.com> <weijooPi@ahfuRaeh.com> <FiruJeur@weiphohP.com> <cuadoiQu@aiZuuqua.com> <YohGieVe@Reacepae.com> <Ieyechum@ephooGho.com> <uGhievoo@vusaeciM.com> <ouhieTha@leizaeTi.com> <ohgohGhu@jieNgooh.com> <ahNookah@oChiecoo.com> <taeWieTu@iuwiLooZ.com> <Kohraiji@AizohGoa.com> <hiQuaegh@eeluThii.com> <Uunaesoh@UogheeCh.com> <JeQuahMa@Thahchoh.com> <aaxohJoh@ahfaeCho.com> <Pahneehu@eehooChi.com> <angeoKah@Wahsaeme.com> <ietovoaV@muewaeZi.com> <aebiuZur@oteeYaiF.com> <pheiXahw@Muquahba.com> <aNgiaPha@bohliNge.com> <Eikawohf@IevaiQuu.com> <gihaeduZ@Raighiey.com> <Theequoh@hoamaeSa.com> <VeiVooyi@aimuQuoo.com> <ahGoocie@BohpheVi.com> <roivahPa@uPhoghai.com> <gioZohli@Gaochoow.com> <eireLair@phaevieR.com> <TahthaeC@oolaiBei.com> <phuYeika@leiKauPh.com> <BieYenoh@Xaebaalo.com> <xohvaeWa@ahghaeRe.com> <thoQuohV@Ubooheay.com> <pheeWohV@feicaeNg.com>')
     lines = k.encoded.split("\r\n\s")
-    lines.each { |line| line.length.should < 998 }
+    lines.each { |line| expect(line.length).to be < 998 }
   end
 
 end

--- a/spec/mail/fields/reply_to_field_spec.rb
+++ b/spec/mail/fields/reply_to_field_spec.rb
@@ -9,23 +9,23 @@ describe Mail::ReplyToField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ReplyToField.new("Reply-To: Mikel") }.should_not raise_error
+      expect(doing { Mail::ReplyToField.new("Reply-To: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::ReplyToField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::ReplyToField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::ReplyToField.new('Reply-To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Reply-To'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Reply-To'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ReplyToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Reply-To'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Reply-To'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -35,30 +35,30 @@ describe Mail::ReplyToField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ReplyToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ReplyToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ReplyToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ReplyToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ReplyToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq "Reply-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      expect(t.encoded).to eq "Reply-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_bcc_field_spec.rb
+++ b/spec/mail/fields/resent_bcc_field_spec.rb
@@ -8,23 +8,23 @@ describe Mail::ResentBccField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentBccField.new("Resent-Bcc: Mikel") }.should_not raise_error
+      expect(doing { Mail::ResentBccField.new("Resent-Bcc: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::ResentBccField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::ResentBccField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::ResentBccField.new('Resent-Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-Bcc'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-Bcc'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentBccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-Bcc'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-Bcc'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,30 +34,30 @@ describe Mail::ResentBccField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentBccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentBccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ResentBccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentBccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentBccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq "Resent-Bcc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      expect(t.encoded).to eq "Resent-Bcc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_cc_field_spec.rb
+++ b/spec/mail/fields/resent_cc_field_spec.rb
@@ -8,23 +8,23 @@ describe Mail::ResentCcField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentCcField.new("Resent-Cc: Mikel") }.should_not raise_error
+      expect(doing { Mail::ResentCcField.new("Resent-Cc: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::ResentCcField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::ResentCcField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::ResentCcField.new('Resent-Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-Cc'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-Cc'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentCcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-Cc'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-Cc'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,30 +34,30 @@ describe Mail::ResentCcField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentCcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentCcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ResentCcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentCcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentCcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq "Resent-Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      expect(t.encoded).to eq "Resent-Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_date_field_spec.rb
+++ b/spec/mail/fields/resent_date_field_spec.rb
@@ -3,37 +3,37 @@ require 'spec_helper'
 
 describe Mail::ResentDateField do
   it "should initialize" do
-    doing { Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT") }.should_not raise_error
+    expect(doing { Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT") }).not_to raise_error
   end
   
   it "should be able to tell the time" do
-    Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT").date_time.class.should eq DateTime
+    expect(Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT").date_time.class).to eq DateTime
   end
   
   it "should mix in the CommonAddress module" do
-    Mail::ResentDateField.included_modules.should include(Mail::CommonDate) 
+    expect(Mail::ResentDateField.included_modules).to include(Mail::CommonDate) 
   end
 
   it "should accept a string with the field name" do
     t = Mail::ResentDateField.new('Resent-Date: 12 Aug 2009 00:00:02 GMT')
-    t.name.should eq 'Resent-Date'
-    t.value.should eq 'Wed, 12 Aug 2009 00:00:02 +0000'
-    t.date_time.should eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
+    expect(t.name).to eq 'Resent-Date'
+    expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
+    expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
   end
   
   it "should accept a string without the field name" do
     t = Mail::ResentDateField.new('12 Aug 2009 00:00:02 GMT')
-    t.name.should eq 'Resent-Date'
-    t.value.should eq 'Wed, 12 Aug 2009 00:00:02 +0000'
-    t.date_time.should eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
+    expect(t.name).to eq 'Resent-Date'
+    expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
+    expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
   end
   
   it "should give today's date if no date is specified" do
     now = Time.now
-    Time.stub!(:now).and_return(now)
+    allow(Time).to receive(:now).and_return(now)
     t = Mail::ResentDateField.new
-    t.name.should eq 'Resent-Date'
-    t.date_time.should eq ::DateTime.parse(now.to_s)
+    expect(t.name).to eq 'Resent-Date'
+    expect(t.date_time).to eq ::DateTime.parse(now.to_s)
   end
 
 end

--- a/spec/mail/fields/resent_from_field_spec.rb
+++ b/spec/mail/fields/resent_from_field_spec.rb
@@ -8,23 +8,23 @@ describe Mail::ResentFromField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentFromField.new("Resent-From: Mikel") }.should_not raise_error
+      expect(doing { Mail::ResentFromField.new("Resent-From: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::ResentFromField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::ResentFromField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::ResentFromField.new('Resent-From: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-From'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-From'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentFromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-From'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-From'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,30 +34,30 @@ describe Mail::ResentFromField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentFromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentFromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ResentFromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentFromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentFromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq "Resent-From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      expect(t.encoded).to eq "Resent-From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_message_id_field_spec.rb
+++ b/spec/mail/fields/resent_message_id_field_spec.rb
@@ -4,26 +4,26 @@ require 'spec_helper'
 describe Mail::ResentMessageIdField do
 
   it "should initialize" do
-    doing { Mail::ResentMessageIdField.new("<1234@test.lindsaar.net>") }.should_not raise_error
+    expect(doing { Mail::ResentMessageIdField.new("<1234@test.lindsaar.net>") }).not_to raise_error
   end
 
   it "should accept a string with the field name" do
     t = Mail::ResentMessageIdField.new('Resent-Message-ID: <1234@test.lindsaar.net>')
-    t.name.should eq 'Resent-Message-ID'
-    t.value.should eq '<1234@test.lindsaar.net>'
-    t.message_id.should eq '1234@test.lindsaar.net'
+    expect(t.name).to eq 'Resent-Message-ID'
+    expect(t.value).to eq '<1234@test.lindsaar.net>'
+    expect(t.message_id).to eq '1234@test.lindsaar.net'
   end
   
   it "should accept a string without the field name" do
     t = Mail::ResentMessageIdField.new('<1234@test.lindsaar.net>')
-    t.name.should eq 'Resent-Message-ID'
-    t.value.should eq '<1234@test.lindsaar.net>'
-    t.message_id.should eq '1234@test.lindsaar.net'
+    expect(t.name).to eq 'Resent-Message-ID'
+    expect(t.value).to eq '<1234@test.lindsaar.net>'
+    expect(t.message_id).to eq '1234@test.lindsaar.net'
   end
 
   it "should output lines shorter than 998 chars" do
     k = Mail::ResentMessageIdField.new('<Kohciuku@apholoVu.com> <foovohPu@Thegahsh.com> <UuseZeow@oocieBie.com> <UchaeKoo@eeJoukie.com> <ieKahque@ieGoochu.com> <aZaXaeva@ungaiGai.com> <sheiraiK@ookaiSha.com> <weijooPi@ahfuRaeh.com> <FiruJeur@weiphohP.com> <cuadoiQu@aiZuuqua.com> <YohGieVe@Reacepae.com> <Ieyechum@ephooGho.com> <uGhievoo@vusaeciM.com> <ouhieTha@leizaeTi.com> <ohgohGhu@jieNgooh.com> <ahNookah@oChiecoo.com> <taeWieTu@iuwiLooZ.com> <Kohraiji@AizohGoa.com> <hiQuaegh@eeluThii.com> <Uunaesoh@UogheeCh.com> <JeQuahMa@Thahchoh.com> <aaxohJoh@ahfaeCho.com> <Pahneehu@eehooChi.com> <angeoKah@Wahsaeme.com> <ietovoaV@muewaeZi.com> <aebiuZur@oteeYaiF.com> <pheiXahw@Muquahba.com> <aNgiaPha@bohliNge.com> <Eikawohf@IevaiQuu.com> <gihaeduZ@Raighiey.com> <Theequoh@hoamaeSa.com> <VeiVooyi@aimuQuoo.com> <ahGoocie@BohpheVi.com> <roivahPa@uPhoghai.com> <gioZohli@Gaochoow.com> <eireLair@phaevieR.com> <TahthaeC@oolaiBei.com> <phuYeika@leiKauPh.com> <BieYenoh@Xaebaalo.com> <xohvaeWa@ahghaeRe.com> <thoQuohV@Ubooheay.com> <pheeWohV@feicaeNg.com>')
     lines = k.encoded.split("\r\n\s")
-    lines.each { |line| line.length.should < 998 }
+    lines.each { |line| expect(line.length).to be < 998 }
   end
 end

--- a/spec/mail/fields/resent_sender_field_spec.rb
+++ b/spec/mail/fields/resent_sender_field_spec.rb
@@ -8,23 +8,23 @@ describe Mail::ResentSenderField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentSenderField.new("Resent-Sender: Mikel") }.should_not raise_error
+      expect(doing { Mail::ResentSenderField.new("Resent-Sender: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::ResentSenderField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::ResentSenderField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::ResentSenderField.new('Resent-Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-Sender'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-Sender'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-Sender'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-Sender'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,22 +34,22 @@ describe Mail::ResentSenderField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.address.to_s.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.address.to_s).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.encoded.should eq "Resent-Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
+      expect(t.encoded).to eq "Resent-Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
     end
     
   end

--- a/spec/mail/fields/resent_to_field_spec.rb
+++ b/spec/mail/fields/resent_to_field_spec.rb
@@ -8,23 +8,23 @@ describe Mail::ResentToField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ResentToField.new("Resent-To: Mikel") }.should_not raise_error
+      expect(doing { Mail::ResentToField.new("Resent-To: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::ResentToField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::ResentToField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::ResentToField.new('Resent-To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-To'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-To'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ResentToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'Resent-To'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'Resent-To'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -34,30 +34,30 @@ describe Mail::ResentToField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ResentToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ResentToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ResentToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ResentToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ResentToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq "Resent-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      expect(t.encoded).to eq "Resent-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
   end

--- a/spec/mail/fields/return_path_field_spec.rb
+++ b/spec/mail/fields/return_path_field_spec.rb
@@ -3,17 +3,17 @@ require 'spec_helper'
 describe Mail::ReturnPathField do
   it "should allow you to specify a field" do
     rp = Mail::ReturnPathField.new('Return-Path: mikel@test.lindsaar.net')
-    rp.address.should eq 'mikel@test.lindsaar.net'
+    expect(rp.address).to eq 'mikel@test.lindsaar.net'
   end
   
   it "should encode the addr_spec in <>" do
     rp = Mail::ReturnPathField.new('Return-Path: mikel@test.lindsaar.net')
-    rp.encoded.should eq "Return-Path: <mikel@test.lindsaar.net>\r\n"
+    expect(rp.encoded).to eq "Return-Path: <mikel@test.lindsaar.net>\r\n"
   end
 
   it "should accept <>" do
     rp = Mail::ReturnPathField.new('<>')
-    rp.encoded.should eq "Return-Path: <>\r\n"
+    expect(rp.encoded).to eq "Return-Path: <>\r\n"
   end
   
   it "should set the return path" do
@@ -25,7 +25,7 @@ describe Mail::ReturnPathField do
       message_id "<1234@someemail.com>"
       body "body"
     end
-    mail.return_path.should eq "bounce@someemail.com"
+    expect(mail.return_path).to eq "bounce@someemail.com"
   end
   
   it "should set the return path" do
@@ -38,7 +38,7 @@ describe Mail::ReturnPathField do
       body "body"
     end
     encoded_mail = Mail.new(mail.encoded)
-    encoded_mail.return_path.should eq "bounce@someemail.com"
+    expect(encoded_mail.return_path).to eq "bounce@someemail.com"
   end
   
   it "should wrap the return path addr_spec in <>" do
@@ -50,7 +50,7 @@ describe Mail::ReturnPathField do
       message_id "<1234@someemail.com>"
       body "body"
     end
-    mail.encoded.should =~ /<bounce@someemail\.com>/
+    expect(mail.encoded).to match(/<bounce@someemail\.com>/)
   end
   
   

--- a/spec/mail/fields/sender_field_spec.rb
+++ b/spec/mail/fields/sender_field_spec.rb
@@ -8,28 +8,28 @@ describe Mail::SenderField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::SenderField.new("Sender: Mikel") }.should_not raise_error
+      expect(doing { Mail::SenderField.new("Sender: Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::SenderField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::SenderField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.name.should eq 'Sender'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.name).to eq 'Sender'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.name.should eq 'Sender'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.name).to eq 'Sender'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
     it "should reject headers with multiple mailboxes" do
       pending 'Sender accepts an address list now, but should only accept a single address'
-      doing { Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>') }.should raise_error
+      expect(doing { Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>') }).to raise_error
     end
 
   end
@@ -39,22 +39,22 @@ describe Mail::SenderField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.address.to_s.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.address.to_s).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
     
     it "should return the encoded line" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.encoded.should eq "Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
+      expect(t.encoded).to eq "Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
     end
     
   end

--- a/spec/mail/fields/structured_field_spec.rb
+++ b/spec/mail/fields/structured_field_spec.rb
@@ -6,7 +6,7 @@ describe Mail::StructuredField do
   describe "initialization" do
     
     it "should be instantiated" do
-      doing {Mail::StructuredField.new("From", "bob@me.com")}.should_not raise_error
+      expect(doing {Mail::StructuredField.new("From", "bob@me.com")}).not_to raise_error
     end
     
   end
@@ -18,16 +18,16 @@ describe Mail::StructuredField do
     end
     
     it "should allow us to set a text value at initialization" do
-      doing{Mail::StructuredField.new("From", "bob@me.com")}.should_not raise_error
+      expect(doing{Mail::StructuredField.new("From", "bob@me.com")}).not_to raise_error
     end
     
     it "should provide access to the text of the field once set" do
-      @field.value.should eq "bob@me.com"
+      expect(@field.value).to eq "bob@me.com"
     end
     
     it "should provide a means to change the value" do
       @field.value = "bob@you.com"
-      @field.value.should eq "bob@you.com"
+      expect(@field.value).to eq "bob@you.com"
     end
   end
 
@@ -38,25 +38,25 @@ describe Mail::StructuredField do
     end
     
     it "should provide a to_s function that returns the decoded string" do
-      @field.to_s.should eq "bob@me.com"
+      expect(@field.to_s).to eq "bob@me.com"
     end
     
     it "should return '' on to_s if there is no value" do
       @field.value = nil
-      @field.encoded.should eq ''
+      expect(@field.encoded).to eq ''
     end
     
     it "should give an encoded value ready to insert into an email" do
-      @field.encoded.should eq "From: bob@me.com\r\n"
+      expect(@field.encoded).to eq "From: bob@me.com\r\n"
     end
     
     it "should return an empty string on encoded if it has no value" do
       @field.value = nil
-      @field.encoded.should eq ''
+      expect(@field.encoded).to eq ''
     end
     
     it "should return the field name and value in proper format when called to_s" do
-      @field.encoded.should eq "From: bob@me.com\r\n"
+      expect(@field.encoded).to eq "From: bob@me.com\r\n"
     end
     
   end
@@ -64,8 +64,8 @@ describe Mail::StructuredField do
   describe "structured field template methods" do
     it "should raise an error if attempting to call :encoded or :decoded on the parent StructuredField class" do
       field = Mail::StructuredField.new
-      doing { field.encoded }.should raise_error(NoMethodError)
-      doing { field.decoded }.should raise_error(NoMethodError)
+      expect(doing { field.encoded }).to raise_error(NoMethodError)
+      expect(doing { field.decoded }).to raise_error(NoMethodError)
     end
   end
 

--- a/spec/mail/fields/to_field_spec.rb
+++ b/spec/mail/fields/to_field_spec.rb
@@ -9,23 +9,23 @@ describe Mail::ToField do
   describe "initialization" do
 
     it "should initialize" do
-      doing { Mail::ToField.new("Mikel") }.should_not raise_error
+      expect(doing { Mail::ToField.new("Mikel") }).not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      Mail::ToField.included_modules.should include(Mail::CommonAddress) 
+      expect(Mail::ToField.included_modules).to include(Mail::CommonAddress) 
     end
 
     it "should accept a string with the field name" do
       t = Mail::ToField.new('To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'To'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'To'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do
       t = Mail::ToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      t.name.should eq 'To'
-      t.value.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(t.name).to eq 'To'
+      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
   end
@@ -35,58 +35,58 @@ describe Mail::ToField do
   describe "instance methods" do
     it "should return an address" do
       t = Mail::ToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
-      t.formatted.should eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
+      expect(t.formatted).to eq ['Mikel Lindsaar <mikel@test.lindsaar.net>']
     end
 
     it "should return two addresses" do
       t = Mail::ToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, Ada Lindsaar <ada@test.lindsaar.net>')
-      t.formatted.first.should eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
-      t.addresses.last.should eq 'ada@test.lindsaar.net'
+      expect(t.formatted.first).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
+      expect(t.addresses.last).to eq 'ada@test.lindsaar.net'
     end
 
     it "should return one address and a group" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses[0].should eq 'sam@me.com'
-      t.addresses[1].should eq 'mikel@me.com'
-      t.addresses[2].should eq 'bob@you.com'
+      expect(t.addresses[0]).to eq 'sam@me.com'
+      expect(t.addresses[1]).to eq 'mikel@me.com'
+      expect(t.addresses[2]).to eq 'bob@you.com'
     end
     
     it "should return the formatted line on to_s" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.value.should eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
+      expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
     it "should return the encoded line" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.encoded.should eq "To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
+      expect(t.encoded).to eq "To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
     it "should return the decoded line" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.decoded.should eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
+      expect(t.decoded).to eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
     
     it "should get multiple address out from a group list" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
-      t.addresses.should eq ["sam@me.com", "mikel@me.com", "bob@you.com"]
+      expect(t.addresses).to eq ["sam@me.com", "mikel@me.com", "bob@you.com"]
     end
     
     it "should handle commas in the address" do
       t = Mail::ToField.new('"Long, stupid email address" <mikel@test.lindsaar.net>')
-      t.addresses.should eq ["mikel@test.lindsaar.net"]
+      expect(t.addresses).to eq ["mikel@test.lindsaar.net"]
     end
     
     it "should handle commas in the address for multiple fields" do
       t = Mail::ToField.new('"Long, stupid email address" <mikel@test.lindsaar.net>, "Another, really, really, long, stupid email address" <bob@test.lindsaar.net>')
-      t.addresses.should eq ["mikel@test.lindsaar.net", "bob@test.lindsaar.net"]
+      expect(t.addresses).to eq ["mikel@test.lindsaar.net", "bob@test.lindsaar.net"]
     end
     
   end
   
   it "should not crash if it can't understand a name" do
     t = Mail.new('To: <"Undisclosed-Recipient:"@msr19.hinet.net;>')
-    doing { t.encoded }.should_not raise_error
-    t.encoded.should =~ /To\:\s<"Undisclosed\-Recipient\:"@msr19\.hinet\.net;>\r\n/
+    expect(doing { t.encoded }).not_to raise_error
+    expect(t.encoded).to match(/To\:\s<"Undisclosed\-Recipient\:"@msr19\.hinet\.net;>\r\n/)
   end
   
 end

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -6,7 +6,7 @@ describe Mail::UnstructuredField do
   describe "initialization" do
 
     it "should be instantiated" do
-      doing {Mail::UnstructuredField.new("Name", "Value")}.should_not raise_error
+      expect(doing {Mail::UnstructuredField.new("Name", "Value")}).not_to raise_error
     end
 
   end
@@ -18,16 +18,16 @@ describe Mail::UnstructuredField do
     end
 
     it "should allow us to set a text value at initialization" do
-      doing{Mail::UnstructuredField.new("Subject", "Value")}.should_not raise_error
+      expect(doing{Mail::UnstructuredField.new("Subject", "Value")}).not_to raise_error
     end
 
     it "should provide access to the text of the field once set" do
-      @field.value.should eq "Hello Frank"
+      expect(@field.value).to eq "Hello Frank"
     end
 
     it "should provide a means to change the value" do
       @field.value = "Goodbye Frank"
-      @field.value.should eq "Goodbye Frank"
+      expect(@field.value).to eq "Goodbye Frank"
     end
   end
 
@@ -38,76 +38,76 @@ describe Mail::UnstructuredField do
     end
 
     it "should provide a to_s function that returns the field name and value" do
-      @field.value.should eq "Hello Frank"
+      expect(@field.value).to eq "Hello Frank"
     end
 
     it "should return '' on to_s if there is no value" do
       @field.value = nil
-      @field.to_s.should eq ''
+      expect(@field.to_s).to eq ''
     end
 
     it "should give an encoded value ready to insert into an email" do
-      @field.encoded.should eq "Subject: Hello Frank\r\n"
+      expect(@field.encoded).to eq "Subject: Hello Frank\r\n"
     end
 
     it "should return nil on encoded if it has no value" do
       @field.value = nil
-      @field.encoded.should eq ''
+      expect(@field.encoded).to eq ''
     end
 
     it "should handle array" do
       @field = Mail::UnstructuredField.new("To", ['mikel@example.com', 'bob@example.com'])
-      @field.encoded.should eq "To: mikel@example.com, bob@example.com\r\n"
+      expect(@field.encoded).to eq "To: mikel@example.com, bob@example.com\r\n"
     end
 
     it "should handle string" do
       @field.value = 'test'
-      @field.encoded.should eq "Subject: test\r\n"
+      expect(@field.encoded).to eq "Subject: test\r\n"
     end
 
     it "should give an decoded value ready to insert into an email" do
-      @field.decoded.should eq "Hello Frank"
+      expect(@field.decoded).to eq "Hello Frank"
     end
 
     it "should return a nil on decoded if it has no value" do
       @field.value = nil
-      @field.decoded.should eq nil
+      expect(@field.decoded).to eq nil
     end
 
     it "should just add the CRLF at the end of the line" do
       @field = Mail::SubjectField.new("Subject: =?utf-8?Q?testing_testing_=D6=A4?=")
       result = "Subject: =?UTF-8?Q?testing_testing_=D6=A4?=\r\n"
-      @field.encoded.should eq result
-      @field.decoded.should eq "testing testing \326\244"
+      expect(@field.encoded).to eq result
+      expect(@field.decoded).to eq "testing testing \326\244"
     end
 
     it "should do encoded-words encoding correctly without extra equal sign" do
       @field = Mail::SubjectField.new("testing testing æøå")
       result = "Subject: =?UTF-8?Q?testing_testing_=C3=A6=C3=B8=C3=A5?=\r\n"
-      @field.encoded.should eq result
-      @field.decoded.should eq "testing testing æøå"
+      expect(@field.encoded).to eq result
+      expect(@field.decoded).to eq "testing testing æøå"
     end
 
     it "should encode the space between two adjacent encoded-words" do
       @field = Mail::SubjectField.new("Her er æ ø å")
       result = "Subject: =?UTF-8?Q?Her_er_=C3=A6_=C3=B8_=C3=A5?=\r\n"
-      @field.encoded.should eq result
-      @field.decoded.should eq "Her er æ ø å"
+      expect(@field.encoded).to eq result
+      expect(@field.decoded).to eq "Her er æ ø å"
     end
 
     it "should encode additional special characters inside encoded-word-encoded strings" do
       string = %Q(Her er æ()<>@,;:\\"/[]?.=)
       @field = Mail::SubjectField.new(string)
       result = %Q(Subject: =?UTF-8?Q?Her_er_=C3=A6=28=29<>@,;:\\=22/[]=3F.=3D?=\r\n)
-      @field.encoded.should eq result
-      @field.decoded.should eq string
+      expect(@field.encoded).to eq result
+      expect(@field.decoded).to eq string
     end
 
     if !'1.9'.respond_to?(:force_encoding)
       it "shouldn't get fooled into encoding on 1.8 due to an unrelated Encoding constant" do
         begin
           Mail::UnstructuredField::Encoding = 'derp'
-          @field.encoded.should eq "Subject: Hello Frank\r\n"
+          expect(@field.encoded).to eq "Subject: Hello Frank\r\n"
         ensure
           Mail::UnstructuredField.send :remove_const, :Encoding
         end
@@ -119,33 +119,33 @@ describe Mail::UnstructuredField do
 
     it "should not fold itself if it is 78 chracters long" do
       @field = Mail::UnstructuredField.new("Subject", "This is a subject header message that is _exactly_ 78 characters....")
-      @field.encoded.should eq "Subject: This is a subject header message that is _exactly_ 78 characters....\r\n"
+      expect(@field.encoded).to eq "Subject: This is a subject header message that is _exactly_ 78 characters....\r\n"
     end
 
     it "should fold itself if it is 79 chracters long" do
       @field = Mail::UnstructuredField.new("Subject", "This is a subject header message that is absolutely 79 characters long")
       result = "Subject: This is a subject header message that is absolutely 79 characters\r\n\slong\r\n"
-      @field.encoded.should eq result
+      expect(@field.encoded).to eq result
     end
 
     it "should fold itself if it is 997 chracters long" do
       @field = Mail::UnstructuredField.new("Subject", "This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. This is a subject header message that is going to be 997 characters long. And this makes it 997....")
       lines = @field.encoded.split("\r\n\s")
-      lines.each { |line| line.length.should < 78 }
+      lines.each { |line| expect(line.length).to be < 78 }
     end
 
     it "should fold itself if it is 998 characters long" do
       value = "This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. This is a subject header message that is going to be 998 characters long. And this makes it 998 long"
       @field = Mail::UnstructuredField.new("Subject", value)
       lines = @field.encoded.split("\r\n\s")
-      lines.each { |line| line.length.should < 78 }
+      lines.each { |line| expect(line.length).to be < 78 }
     end
 
     it "should fold itself if it is 999 characters long" do
       value = "This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. This is a subject header message that is going to be 999 characters long. And this makes it 999 long."
       @field = Mail::UnstructuredField.new("Subject", value)
       lines = @field.encoded.split("\r\n\s")
-      lines.each { |line| line.length.should < 78 }
+      lines.each { |line| expect(line.length).to be < 78 }
     end
 
     it "should fold itself if it is non us-ascii" do
@@ -158,8 +158,8 @@ describe Mail::UnstructuredField do
         $KCODE = 'u'
       end
       result = "Subject: =?UTF-8?Q?This_is_=E3=81=82_really_long_string_This_is_=E3=81=82?=\r\n\s=?UTF-8?Q?_really_long_string_This_is_=E3=81=82_really_long_string_This_is?=\r\n\s=?UTF-8?Q?_=E3=81=82_really_long_string_This_is_=E3=81=82_really_long?=\r\n\s=?UTF-8?Q?_string?=\r\n"
-      @field.encoded.should eq result
-      @field.decoded.should eq string
+      expect(@field.encoded).to eq result
+      expect(@field.decoded).to eq string
       $KCODE = @original if RUBY_VERSION < '1.9'
     end
 
@@ -173,15 +173,15 @@ describe Mail::UnstructuredField do
         $KCODE = 'u'
       end
       result = "X-SMTPAPI: =?UTF-8?Q?{=22unique=5Fargs=22:_{=22mailing=5Fid=22:147,=22a?=\r\n =?UTF-8?Q?ccount=5Fid=22:2},_=22to=22:_[=22larspind@gmail.com=22],_=22categ?=\r\n =?UTF-8?Q?ory=22:_=22mailing=22,_=22filters=22:_{=22domainkeys=22:_{=22sett?=\r\n =?UTF-8?Q?ings=22:_{=22domain=22:1,=22enable=22:1}}},_=22sub=22:_{=22{{op?=\r\n =?UTF-8?Q?en=5Fimage=5Furl}}=22:_[=22http://betaling.larspind.local/O?=\r\n =?UTF-8?Q?/token/147/Mailing::FakeRecipient=22],_=22{{name}}=22:_[=22[FIRST?=\r\n =?UTF-8?Q?_NAME]=22],_=22{{signup=5Freminder}}=22:_[=22=28her_kommer_til_at?=\r\n =?UTF-8?Q?_st=C3=A5_hvorn=C3=A5r_folk_har_skrevet_sig_op_...=29=22],?=\r\n =?UTF-8?Q?_=22{{unsubscribe=5Furl}}=22:_[=22http://betaling.larspind.?=\r\n =?UTF-8?Q?local/U/token/147/Mailing::FakeRecipient=22],_=22{{email}}=22:?=\r\n =?UTF-8?Q?_[=22larspind@gmail.com=22],_=22{{link:308}}=22:_[=22http://beta?=\r\n =?UTF-8?Q?ling.larspind.local/L/308/0/Mailing::FakeRecipient=22],_=22{{con?=\r\n =?UTF-8?Q?firm=5Furl}}=22:_[=22=22],_=22{{ref}}=22:_[=22[REF]=22]}}?=\r\n"
-      @field.encoded.should eq result
-      @field.decoded.should eq string
+      expect(@field.encoded).to eq result
+      expect(@field.decoded).to eq string
       $KCODE = @original if RUBY_VERSION < '1.9'
     end
 
     it "should fold properly with continuous spaces around the linebreak" do
       @field = Mail::UnstructuredField.new("Subject", "This is a header that has continuous spaces around line break point,     which should be folded properly")
       result = "Subject: This is a header that has continuous spaces around line break point,\s\r\n\s\s\s\swhich should be folded properly\r\n"
-      @field.encoded.should eq result
+      expect(@field.encoded).to eq result
     end
 
   end
@@ -190,7 +190,7 @@ describe Mail::UnstructuredField do
     it "should encode an ascii string that has carriage returns if asked to" do
       result = "Subject: =0Aasdf=0A\r\n"
       @field = Mail::UnstructuredField.new("Subject", "\nasdf\n")
-      @field.encoded.should eq result
+      expect(@field.encoded).to eq result
     end
   end
 
@@ -199,7 +199,7 @@ describe Mail::UnstructuredField do
       @field = Mail::UnstructuredField.new("Subject", "あいうえお")
       @field.charset = 'iso-2022-jp'
       expect = (RUBY_VERSION < '1.9') ? "Subject: =?ISO-2022-JP?Q?=E3=81=82=E3=81=84=E3=81=86=E3=81=88=E3=81=8A?=\r\n" : "Subject: =?ISO-2022-JP?Q?=1B$B$=22$$$&$=28$*=1B=28B?=\r\n"
-      @field.encoded.should eq expect
+      expect(@field.encoded).to eq expect
     end
   end
 end

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -6,11 +6,11 @@ describe Mail::Header do
   describe "initialization" do
     
     it "should instantiate empty" do
-      doing { Mail::Header.new }.should_not raise_error
+      expect(doing { Mail::Header.new }).not_to raise_error
     end
 
     it "should instantiate with a string passed in" do
-      doing { Mail::Header.new("To: Mikel\r\nFrom: bob\r\n") }.should_not raise_error
+      expect(doing { Mail::Header.new("To: Mikel\r\nFrom: bob\r\n") }).not_to raise_error
     end
 
   end
@@ -19,55 +19,55 @@ describe Mail::Header do
     
     it "should save away the raw source of the header that it is passed" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header.raw_source.should eq "To: Mikel\r\nFrom: bob\r\n"
+      expect(header.raw_source).to eq "To: Mikel\r\nFrom: bob\r\n"
     end
     
     it "should say if it has a message_id field defined" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header.should_not be_has_message_id
+      expect(header).not_to be_has_message_id
     end
     
     it "should say if it has a message_id field defined" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\nMessage-ID: 1234")
-      header.should be_has_message_id
+      expect(header).to be_has_message_id
     end
     
     it "should say if it has a content_id field defined" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header.should_not be_has_content_id
+      expect(header).not_to be_has_content_id
     end
     
     it "should say if it has a content_id field defined" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\nContent-ID: <1234@me.com>")
-      header.should be_has_content_id
+      expect(header).to be_has_content_id
     end
     
     it "should know its own charset" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\nContent-ID: <1234@me.com>")
-      header.charset.should eq nil
+      expect(header.charset).to eq nil
     end
     
     it "should know its own charset if set" do
       header = Mail::Header.new
       header['content-type'] = 'text/plain; charset=utf-8'
-      header.charset.should eq 'utf-8'
+      expect(header.charset).to eq 'utf-8'
     end
 
     it "should not unset previously set charset if content-type is set without charset" do
       header = Mail::Header.new(nil, 'utf-8')
       header['content-type'] = 'text/plain'
-      header.charset.should eq 'utf-8'
+      expect(header.charset).to eq 'utf-8'
     end
     
     it "shouldn't die when queried for a charset and the content-type header is invalid" do
       header = Mail::Header.new
       header['Content-Type'] = 'invalid/invalid; charset="iso-8859-1"'
-      doing { header.charset }.should_not raise_error
+      expect(doing { header.charset }).not_to raise_error
     end
 
     it "should be Enumerable" do
       header = Mail::Header.new("To: James Random\r\nFrom: Santa Claus\r\n")
-      header.find {|f| f.responsible_for?('From') }.should be_a(Mail::Field)
+      expect(header.find {|f| f.responsible_for?('From') }).to be_a(Mail::Field)
     end
   end
 
@@ -75,175 +75,175 @@ describe Mail::Header do
       it "should recognise a bcc field" do
         header = Mail::Header.new
         header['bcc'] = 'mikel@test.lindsaar.net'
-        header['bcc'].field.class.should eq Mail::BccField
+        expect(header['bcc'].field.class).to eq Mail::BccField
       end
       
       it "should recognise a cc field" do
         header = Mail::Header.new
         header['cc'] = 'mikel@test.lindsaar.net'
-        header['cc'].field.class.should eq Mail::CcField
+        expect(header['cc'].field.class).to eq Mail::CcField
       end
       
       it "should recognise a content-description field" do
         header = Mail::Header.new
         header['content-description'] = 'Text'
-        header['content-description'].field.class.should eq Mail::ContentDescriptionField
+        expect(header['content-description'].field.class).to eq Mail::ContentDescriptionField
       end
       
       it "should recognise a content-disposition field" do
         header = Mail::Header.new
         header['content-disposition'] = 'attachment; filename=File'
-        header['content-disposition'].field.class.should eq Mail::ContentDispositionField
+        expect(header['content-disposition'].field.class).to eq Mail::ContentDispositionField
       end
 
       it "should recognise an inline content-disposition field" do
         header = Mail::Header.new
         header['content-disposition'] = 'inline'
-        header['content-disposition'].field.class.should eq Mail::ContentDispositionField
+        expect(header['content-disposition'].field.class).to eq Mail::ContentDispositionField
       end
 
 
       it "should recognise a content-id field" do
         header = Mail::Header.new
         header['content-id'] = '<1234@test.lindsaar.net>'
-        header['content-id'].field.class.should eq Mail::ContentIdField
+        expect(header['content-id'].field.class).to eq Mail::ContentIdField
       end
       
       it "should recognise a content-transfer-encoding field" do
         header = Mail::Header.new
         header['content-transfer-encoding'] = '7bit'
-        header['content-transfer-encoding'].field.class.should eq Mail::ContentTransferEncodingField
+        expect(header['content-transfer-encoding'].field.class).to eq Mail::ContentTransferEncodingField
       end
       
       it "should recognise a content-type field" do
         header = Mail::Header.new
         header['content-type'] = 'text/plain'
-        header['content-type'].field.class.should eq Mail::ContentTypeField
+        expect(header['content-type'].field.class).to eq Mail::ContentTypeField
       end
       
       it "should recognise a date field" do
         header = Mail::Header.new
         header['date'] = 'Fri, 21 Nov 1997 09:55:06 -0600'
-        header['date'].field.class.should eq Mail::DateField
+        expect(header['date'].field.class).to eq Mail::DateField
       end
       
       it "should recognise a from field" do
         header = Mail::Header.new
         header['from'] = 'mikel@test.lindsaar.net'
-        header['from'].field.class.should eq Mail::FromField
+        expect(header['from'].field.class).to eq Mail::FromField
       end
       
       it "should recognise a in-reply-to field" do
         header = Mail::Header.new
         header['in-reply-to'] = '<1234@test.lindsaar.net>'
-        header['in-reply-to'].field.class.should eq Mail::InReplyToField
+        expect(header['in-reply-to'].field.class).to eq Mail::InReplyToField
       end
       
       it "should recognise a keywords field" do
         header = Mail::Header.new
         header['keywords'] = 'mikel test lindsaar net'
-        header['keywords'].field.class.should eq Mail::KeywordsField
+        expect(header['keywords'].field.class).to eq Mail::KeywordsField
       end
       
       it "should recognise a message-id field" do
         header = Mail::Header.new
         header['message-id'] = '<1234@test.lindsaar.net>'
-        header['message-id'].field.class.should eq Mail::MessageIdField
+        expect(header['message-id'].field.class).to eq Mail::MessageIdField
       end
       
       it "should recognise a mime-version field" do
         header = Mail::Header.new
         header['mime-version'] = '1.0'
-        header['mime-version'].field.class.should eq Mail::MimeVersionField
+        expect(header['mime-version'].field.class).to eq Mail::MimeVersionField
       end
       
       it "should recognise a received field" do
         header = Mail::Header.new
         header['received'] = 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id C1B953B4CB6 for <xxxxx@Exxx.xxxx.xxx>; Tue, 10 May 2005 15:27:05 -0500'
-        header['received'].field.class.should eq Mail::ReceivedField
+        expect(header['received'].field.class).to eq Mail::ReceivedField
       end
       
       it "should recognise a references field" do
         header = Mail::Header.new
         header['references'] = '<1234@test.lindsaar.net>'
-        header['references'].field.class.should eq Mail::ReferencesField
+        expect(header['references'].field.class).to eq Mail::ReferencesField
       end
       
       it "should recognise a reply-to field" do
         header = Mail::Header.new
         header['reply-to'] = 'mikel@test.lindsaar.net'
-        header['reply-to'].field.class.should eq Mail::ReplyToField
+        expect(header['reply-to'].field.class).to eq Mail::ReplyToField
       end
       
       it "should recognise a resent-bcc field" do
         header = Mail::Header.new
         header['resent-bcc'] = 'mikel@test.lindsaar.net'
-        header['resent-bcc'].field.class.should eq Mail::ResentBccField
+        expect(header['resent-bcc'].field.class).to eq Mail::ResentBccField
       end
       
       it "should recognise a resent-cc field" do
         header = Mail::Header.new
         header['resent-cc'] = 'mikel@test.lindsaar.net'
-        header['resent-cc'].field.class.should eq Mail::ResentCcField
+        expect(header['resent-cc'].field.class).to eq Mail::ResentCcField
       end
       
       it "should recognise a resent-date field" do
         header = Mail::Header.new
         header['resent-date'] = 'Fri, 21 Nov 1997 09:55:06 -0600'
-        header['resent-date'].field.class.should eq Mail::ResentDateField
+        expect(header['resent-date'].field.class).to eq Mail::ResentDateField
       end
       
       it "should recognise a resent-from field" do
         header = Mail::Header.new
         header['resent-from'] = 'mikel@test.lindsaar.net'
-        header['resent-from'].field.class.should eq Mail::ResentFromField
+        expect(header['resent-from'].field.class).to eq Mail::ResentFromField
       end
       
       it "should recognise a resent-message-id field" do
         header = Mail::Header.new
         header['resent-message-id'] = '<1234@mail.baci.local>'
-        header['resent-message-id'].field.class.should eq Mail::ResentMessageIdField
+        expect(header['resent-message-id'].field.class).to eq Mail::ResentMessageIdField
       end
       
       it "should recognise a resent-sender field" do
         header = Mail::Header.new
         header['resent-sender'] = 'mikel@test.lindsaar.net'
-        header['resent-sender'].field.class.should eq Mail::ResentSenderField
+        expect(header['resent-sender'].field.class).to eq Mail::ResentSenderField
       end
       
       it "should recognise a resent-to field" do
         header = Mail::Header.new
         header['resent-to'] = 'mikel@test.lindsaar.net'
-        header['resent-to'].field.class.should eq Mail::ResentToField
+        expect(header['resent-to'].field.class).to eq Mail::ResentToField
       end
       
       it "should recognise a return-path field" do
         header = Mail::Header.new
         header['return-path'] = '<mikel@me.com>'
-        header['return-path'].field.class.should eq Mail::ReturnPathField
+        expect(header['return-path'].field.class).to eq Mail::ReturnPathField
       end
       
       it "should recognise a sender field" do
         header = Mail::Header.new
         header['sender'] = 'mikel@test.lindsaar.net'
-        header['sender'].field.class.should eq Mail::SenderField
+        expect(header['sender'].field.class).to eq Mail::SenderField
       end
       
       it "should recognise a to field" do
         header = Mail::Header.new
         header['to'] = 'mikel@test.lindsaar.net'
-        header['to'].field.class.should eq Mail::ToField
+        expect(header['to'].field.class).to eq Mail::ToField
       end
 
       it "should maintain header case" do
         header = Mail::Header.new
         header['User-Agent'] = 'My funky mailer'
-        header.encoded.should match(/^User-Agent: /)
-        header.encoded.should_not match(/^user-agent: /)
+        expect(header.encoded).to match(/^User-Agent: /)
+        expect(header.encoded).not_to match(/^user-agent: /)
       end
 
       it "should not accept field names containing colons" do
-        doing { Mail::Header.new['a:b'] = 'c' }.should raise_error
+        expect(doing { Mail::Header.new['a:b'] = 'c' }).to raise_error
       end
       
     end
@@ -253,12 +253,12 @@ describe Mail::Header do
 
     it "should split the header into separate fields" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header.fields.length.should eq 2
+      expect(header.fields.length).to eq 2
     end
     
     it "should not split a wrapped header in two" do
       header = Mail::Header.new("To: mikel lindsaar\r\n\s<mikel@lindsaar>\r\nFrom: bob\r\nSubject: This is\r\n a long\r\n\s \t \t \t    badly formatted             \r\n       \t\t  \t       field")
-      header.fields.length.should eq 3
+      expect(header.fields.length).to eq 3
     end
     
     #  Header fields are lines composed of a field name, followed by a colon
@@ -268,14 +268,14 @@ describe Mail::Header do
     #  colon.
     it "should accept any valid header field name" do
       test_name = ascii.reject { |c| c == ':' }.join
-      doing { Mail::Header.new("#{test_name}: This is a crazy name") }.should_not raise_error
+      expect(doing { Mail::Header.new("#{test_name}: This is a crazy name") }).not_to raise_error
     end
 
     it "should not try to accept colons in header field names" do
       header = Mail::Header.new("Colon:in:header: oops")
-      header.fields.size.should eq 1
-      header.fields.first.name.should eq 'Colon'
-      header['Colon'].value.should eq 'in:header: oops'
+      expect(header.fields.size).to eq 1
+      expect(header.fields.first.name).to eq 'Colon'
+      expect(header['Colon'].value).to eq 'in:header: oops'
     end
 
     # A field body may be composed of any US-ASCII characters,
@@ -286,129 +286,129 @@ describe Mail::Header do
       test_value = ascii.reject { |c| c == ':' }
       test_value << ' '
       test_value << '\r\n'
-      doing {Mail::Header.new("header: #{test_value}")}.should_not raise_error
+      expect(doing {Mail::Header.new("header: #{test_value}")}).not_to raise_error
     end
 
     it "should split each field into an name and value" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header.fields[0].name.should eq "From"
-      header.fields[0].value.should eq "bob"
-      header.fields[1].name.should eq "To"
-      header.fields[1].value.should eq "Mikel"
+      expect(header.fields[0].name).to eq "From"
+      expect(header.fields[0].value).to eq "bob"
+      expect(header.fields[1].name).to eq "To"
+      expect(header.fields[1].value).to eq "Mikel"
     end
     
     it "should split each field into an name and value - even if whitespace is missing" do
       header = Mail::Header.new("To: Mikel\r\nFrom:bob\r\n")
-      header.fields[0].name.should eq "From"
-      header.fields[0].value.should eq "bob"
-      header.fields[1].name.should eq "To"
-      header.fields[1].value.should eq "Mikel"
+      expect(header.fields[0].name).to eq "From"
+      expect(header.fields[0].value).to eq "bob"
+      expect(header.fields[1].name).to eq "To"
+      expect(header.fields[1].value).to eq "Mikel"
     end
     
     it "should preserve the order of the fields it is given" do
       header = Mail::Header.new
       header.fields = ['From: mikel@me.com', 'To: bob@you.com', 'Subject: This is a badly formed email']
-      header.fields[0].name.should eq 'From'
-      header.fields[1].name.should eq 'To'
-      header.fields[2].name.should eq 'Subject'
+      expect(header.fields[0].name).to eq 'From'
+      expect(header.fields[1].name).to eq 'To'
+      expect(header.fields[2].name).to eq 'Subject'
     end
     
     it "should allow you to reference each field and value by literal string name" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header['To'].value.should eq "Mikel"
-      header['From'].value.should eq "bob"
+      expect(header['To'].value).to eq "Mikel"
+      expect(header['From'].value).to eq "bob"
     end
 
     it "should return an array of fields if there is more than one match" do
       header = Mail::Header.new
       header.fields = ['From: mikel@me.com', 'X-Mail-SPAM: 15', 'X-Mail-SPAM: 23']
-      header['X-Mail-SPAM'].map { |x| x.value }.should eq ['15', '23']
+      expect(header['X-Mail-SPAM'].map { |x| x.value }).to eq ['15', '23']
     end
 
     it "should return nil if no value in the header" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
-      header['Subject'].should be_nil
+      expect(header['Subject']).to be_nil
     end
     
     it "should add a new field if the field does not exist" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
       header['Subject'] = "G'Day!"
-      header['Subject'].value.should eq "G'Day!"
+      expect(header['Subject'].value).to eq "G'Day!"
     end
     
     it "should allow you to pass in an array of raw fields" do
       header = Mail::Header.new
       header.fields = ['From: mikel@test.lindsaar.net', 'To: bob@you.com']
-      header['To'].value.should eq 'bob@you.com'
-      header['From'].value.should eq 'mikel@test.lindsaar.net'
+      expect(header['To'].value).to eq 'bob@you.com'
+      expect(header['From'].value).to eq 'mikel@test.lindsaar.net'
     end
     
     it "should reset the value of a single-only field if it already exists" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n")
       header['To'] = 'George'
-      header['To'].value.should eq "George"
+      expect(header['To'].value).to eq "George"
     end
     
     it "should allow you to delete a field by setting it to nil" do
       header = Mail::Header.new
       header.fields = ['To: bob@you.com']
-      header.fields.length.should eq 1
+      expect(header.fields.length).to eq 1
       header['To'] = nil
-      header.fields.length.should eq 0
+      expect(header.fields.length).to eq 0
     end
     
     it "should delete all matching fields found if there are multiple options" do
       header = Mail::Header.new
       header.fields = ['X-SPAM: 1000', 'X-SPAM: 20']
       header['X-SPAM'] = nil
-      header.fields.length.should eq 0
+      expect(header.fields.length).to eq 0
     end
     
     it "should delete only matching fields found" do
       header = Mail::Header.new
       header.fields = ['X-SPAM: 1000', 'X-AUTHOR: Steve']
       header['X-SPAM'] = nil
-      header['X-AUTHOR'].should_not be_nil
-      header.fields.length.should eq 1
+      expect(header['X-AUTHOR']).not_to be_nil
+      expect(header.fields.length).to eq 1
     end
     
     # Handle empty X-Optional header from Microsoft Exchange
     it "should handle an empty X-* header value" do
       header = Mail::Header.new("X-MS-TNEF-Correlator:\r\n")
-      header.fields.length.should eq 1
-      header['X-MS-TNEF-Correlator'].decoded.should eq nil
-      header['X-MS-TNEF-Correlator'].encoded.should eq "X-MS-TNEF-Correlator: \r\n"
+      expect(header.fields.length).to eq 1
+      expect(header['X-MS-TNEF-Correlator'].decoded).to eq nil
+      expect(header['X-MS-TNEF-Correlator'].encoded).to eq "X-MS-TNEF-Correlator: \r\n"
     end
     
     it "should accept X- option fields from MS-Exchange" do
       header = Mail::Header.new("X-Ms-Has-Attach:\r\nX-MS-TNEF-Correlator: \r\n")
-      header.fields.length.should eq 2
-      header['X-Ms-Has-Attach'].decoded.should eq nil
-      header['X-Ms-Has-Attach'].encoded.should eq "X-Ms-Has-Attach: \r\n"
-      header['X-MS-TNEF-Correlator'].decoded.should eq nil
-      header['X-MS-TNEF-Correlator'].encoded.should eq "X-MS-TNEF-Correlator: \r\n"
+      expect(header.fields.length).to eq 2
+      expect(header['X-Ms-Has-Attach'].decoded).to eq nil
+      expect(header['X-Ms-Has-Attach'].encoded).to eq "X-Ms-Has-Attach: \r\n"
+      expect(header['X-MS-TNEF-Correlator'].decoded).to eq nil
+      expect(header['X-MS-TNEF-Correlator'].encoded).to eq "X-MS-TNEF-Correlator: \r\n"
     end
     
     it "should return nil if asked for the value of a non existent field" do
       header = Mail::Header.new
-      header['Bobs-Field'].should eq nil
+      expect(header['Bobs-Field']).to eq nil
     end
     
     it "should allow you to replace a from field" do
       header = Mail::Header.new
-      header['From'].should eq nil
+      expect(header['From']).to eq nil
       header['From'] = 'mikel@test.lindsaar.net'
-      header['From'].decoded.should eq 'mikel@test.lindsaar.net'
+      expect(header['From'].decoded).to eq 'mikel@test.lindsaar.net'
       header['From'] = 'bob@test.lindsaar.net'
-      header['From'].decoded.should eq 'bob@test.lindsaar.net'
+      expect(header['From'].decoded).to eq 'bob@test.lindsaar.net'
     end
     
     it "should maintain the class of the field" do
       header = Mail::Header.new
       header['From'] = 'mikel@test.lindsaar.net'
-      header['From'].field.class.should eq Mail::FromField
+      expect(header['From'].field.class).to eq Mail::FromField
       header['From'] = 'bob@test.lindsaar.net'
-      header['From'].field.class.should eq Mail::FromField
+      expect(header['From'].field.class).to eq Mail::FromField
     end
   end
 
@@ -416,12 +416,12 @@ describe Mail::Header do
     
     it "should unfold a header" do
       header = Mail::Header.new("To: Mikel,\r\n Lindsaar, Bob")
-      header['To'].value.should eq 'Mikel, Lindsaar, Bob'
+      expect(header['To'].value).to eq 'Mikel, Lindsaar, Bob'
     end
     
     it "should remove multiple spaces during unfolding a header" do
       header = Mail::Header.new("To: Mikel,\r\n   Lindsaar,     Bob")
-      header['To'].value.should eq 'Mikel, Lindsaar, Bob'
+      expect(header['To'].value).to eq 'Mikel, Lindsaar, Bob'
     end
     
     it "should handle a crazy long folded header" do
@@ -433,7 +433,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\r\n"))
-      header['Received'].value.should eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      expect(header['Received'].value).to eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
     end
     
     it "should convert all lonesome LFs to CRLF" do
@@ -445,7 +445,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\n"))
-      header['Received'].value.should eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      expect(header['Received'].value).to eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
     end
     
     it "should convert all lonesome CRs to CRLF" do
@@ -457,7 +457,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\r"))
-      header['Received'].value.should eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      expect(header['Received'].value).to eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
     end
     
   end
@@ -465,12 +465,12 @@ HERE
   describe "error handling" do
     it "should collect up any of its fields' errors" do
       header = Mail::Header.new("Content-Transfer-Encoding: vl@d\r\nReply-To: a b b")
-      header.errors.should_not be_blank
-      header.errors.size.should eq 2
-      header.errors[0][0].should eq 'Reply-To'
-      header.errors[0][1].should eq 'a b b'
-      header.errors[1][0].should eq 'Content-Transfer-Encoding'
-      header.errors[1][1].should eq 'vl@d'
+      expect(header.errors).not_to be_blank
+      expect(header.errors.size).to eq 2
+      expect(header.errors[0][0]).to eq 'Reply-To'
+      expect(header.errors[0][1]).to eq 'a b b'
+      expect(header.errors[1][0]).to eq 'Content-Transfer-Encoding'
+      expect(header.errors[1][1]).to eq 'vl@d'
     end
   end
 
@@ -480,7 +480,7 @@ HERE
         header = Mail::Header.new
         header[field] = "Thu, 05 Jun 2008 10:53:29 -0700"
         header[field] = "Mon, 15 Nov 2010 11:05:29 -1100"
-        header[field].value.should eq "Mon, 15 Nov 2010 11:05:29 -1100"
+        expect(header[field].value).to eq "Mon, 15 Nov 2010 11:05:29 -1100"
       end
     end
   
@@ -489,7 +489,7 @@ HERE
         header = Mail::Header.new
         header[field] = "mikel@test.lindsaar.net"
         header[field] = "ada@test.lindsaar.net"
-        header[field].value.should eq "ada@test.lindsaar.net"
+        expect(header[field].value).to eq "ada@test.lindsaar.net"
       end
     end
 
@@ -497,7 +497,7 @@ HERE
       header = Mail::Header.new(
         "Content-Type: multipart/alternative\nContent-Type: text/plain\n"
       )
-      header['content-type'].should_not be_kind_of(Array)
+      expect(header['content-type']).not_to be_kind_of(Array)
     end
     
     it "should add additional fields that can appear more than once" do
@@ -505,7 +505,7 @@ HERE
         header = Mail::Header.new
         header[field] = "1234"
         header[field] = "5678"
-        header[field].map { |x| x.value }.should eq ["1234", "5678"]
+        expect(header[field].map { |x| x.value }).to eq ["1234", "5678"]
       end
     end
     
@@ -513,9 +513,9 @@ HERE
       header = Mail::Header.new
       header.fields = ['X-Mail-SPAM: 15', 'X-Mail-SPAM: 20']
       header['X-Mail-SPAM'] = '10000'
-      header['X-Mail-SPAM'].map { |x| x.value }.should eq ['15', '20', '10000']
+      expect(header['X-Mail-SPAM'].map { |x| x.value }).to eq ['15', '20', '10000']
       header['X-Mail-SPAM'] = nil
-      header['X-Mail-SPAM'].should eq nil
+      expect(header['X-Mail-SPAM']).to eq nil
     end
   end
 
@@ -533,18 +533,18 @@ TRACEHEADER
     end
     
     it "should instantiate one trace field object per header" do
-      @traced_header.fields.length.should eq 5
+      expect(@traced_header.fields.length).to eq 5
     end
     
     it "should add a new received header after the other received headers if they exist" do
       @traced_header['To'] = "Mikel"
       @traced_header['Received'] = "from agw2 by xxx.xxxx.xxx; Sun, 8 May 2005 12:30:13 -0500"
-      @traced_header.fields[0].addresses.should eq ['xxx@xxxx.xxxtest']
-      @traced_header.fields[1].info.should eq 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>'
-      @traced_header.fields[2].info.should eq 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id j48HUC213279 for <xxx@xxxx.xxx>'
-      @traced_header.fields[3].info.should eq 'from conversion-xxx.xxxx.xxx.net by xxx.xxxx.xxx id <0IG600901LQ64I@xxx.xxxx.xxx> for <xxx@xxxx.xxx>'
-      @traced_header.fields[5].info.should eq "from agw2 by xxx.xxxx.xxx"
-      @traced_header.fields[6].field.class.should eq Mail::ToField
+      expect(@traced_header.fields[0].addresses).to eq ['xxx@xxxx.xxxtest']
+      expect(@traced_header.fields[1].info).to eq 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>'
+      expect(@traced_header.fields[2].info).to eq 'from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id j48HUC213279 for <xxx@xxxx.xxx>'
+      expect(@traced_header.fields[3].info).to eq 'from conversion-xxx.xxxx.xxx.net by xxx.xxxx.xxx id <0IG600901LQ64I@xxx.xxxx.xxx> for <xxx@xxxx.xxx>'
+      expect(@traced_header.fields[5].info).to eq "from agw2 by xxx.xxxx.xxx"
+      expect(@traced_header.fields[6].field.class).to eq Mail::ToField
     end
     
   end
@@ -555,75 +555,75 @@ TRACEHEADER
       result = "From: bob <bob@test.lindsaar.net>\r\nTo: Mikel Lindsaar <mikel@test.lindsaar.net>\r\nSubject: This is a long badly formatted field\r\n"
       if result.respond_to?(:encode!)
         result.encode!(Encoding::US_ASCII)
-        encoded.encoding.should eq Encoding::US_ASCII if encoded.respond_to?(:encoding)
+        expect(encoded.encoding).to eq Encoding::US_ASCII if encoded.respond_to?(:encoding)
       end
-      encoded.should eq result
+      expect(encoded).to eq result
     end
 
     if '1.9'.respond_to?(:force_encoding)
       it "should blow up on encoding mismatches" do
         junk = "Subject: \xAF".force_encoding(Encoding::ASCII_8BIT)
         header = Mail::Header.new(junk, 'utf-8')
-        doing { header.encoded }.should raise_error
+        expect(doing { header.encoded }).to raise_error
       end
     end
   end
   
   describe "detecting required fields" do
     it "should not say it has a message id if it doesn't" do
-      Mail::Header.new.should_not be_has_message_id
+      expect(Mail::Header.new).not_to be_has_message_id
     end
 
     it "should say it has a message id if it does" do
-      Mail::Header.new('Message-ID: 1234').should be_has_message_id
+      expect(Mail::Header.new('Message-ID: 1234')).to be_has_message_id
     end
 
     it "should not say it has a date if it doesn't" do
-      Mail::Header.new.should_not be_has_date
+      expect(Mail::Header.new).not_to be_has_date
     end
 
     it "should say it has a date id if it does" do
-      Mail::Header.new('Date: Mon, 24 Nov 1997 14:22:01 -0800').should be_has_date
+      expect(Mail::Header.new('Date: Mon, 24 Nov 1997 14:22:01 -0800')).to be_has_date
     end
 
     it "should not say it has a mime-version if it doesn't" do
-      Mail::Header.new.should_not be_has_mime_version
+      expect(Mail::Header.new).not_to be_has_mime_version
     end
 
     it "should say it has a date id if it does" do
-      Mail::Header.new('Mime-Version: 1.0').should be_has_mime_version
+      expect(Mail::Header.new('Mime-Version: 1.0')).to be_has_mime_version
     end
   end
   
   describe "mime version handling" do
     it "should return the mime version of the email" do
       header = Mail::Header.new("Mime-Version: 1.0")
-      header['mime-version'].value.should eq '1.0'
+      expect(header['mime-version'].value).to eq '1.0'
     end
     
     it "should return nil if no mime-version header field" do
       header = Mail::Header.new('To: bob')
-      header['mime_version'].should eq nil
+      expect(header['mime_version']).to eq nil
     end
     
     it "should return the transfer-encoding of the email" do
       header = Mail::Header.new("Content-Transfer-Encoding: Base64")
-      header['content-transfer-encoding'].value.should eq 'Base64'
+      expect(header['content-transfer-encoding'].value).to eq 'Base64'
     end
     
     it "should return nil if no transfer-encoding header field" do
       header = Mail::Header.new
-      header['content-transfer-encoding'].should eq nil
+      expect(header['content-transfer-encoding']).to eq nil
     end
     
     it "should return the content-description of the email" do
       header = Mail::Header.new("Content-Description: This is a description")
-      header['Content-Description'].value.should eq 'This is a description'
+      expect(header['Content-Description'].value).to eq 'This is a description'
     end
     
     it "should return nil if no content-description header field" do
       header = Mail::Header.new
-      header['Content-Description'].should eq nil
+      expect(header['Content-Description']).to eq nil
     end
     
   end
@@ -631,7 +631,7 @@ TRACEHEADER
   describe "configuration option .maximum_amount" do
 
     it "should be 1000 by default" do
-      Mail::Header.maximum_amount.should == 1000
+      expect(Mail::Header.maximum_amount).to eq(1000)
     end
 
     it "should limit amount of parsed headers" do
@@ -641,7 +641,7 @@ TRACEHEADER
         begin
           $VERBOSE, old_verbose = nil, $VERBOSE
           header = Mail::Header.new("X-SubscriberID: 345\n" * 11)
-          header.fields.size.should == 10
+          expect(header.fields.size).to eq(10)
         ensure
           $VERBOSE = old_verbose
         end

--- a/spec/mail/mail_spec.rb
+++ b/spec/mail/mail_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper'
 describe "mail" do
   
   it "should be able to be instantiated" do
-    doing { Mail }.should_not raise_error
+    expect(doing { Mail }).not_to raise_error
   end
   
   it "should be able to make a new email" do
-    Mail.new.class.should eq Mail::Message
+    expect(Mail.new.class).to eq Mail::Message
   end
   
   it "should accept headers and body" do
@@ -19,16 +19,16 @@ describe "mail" do
       subject 'Hello there Mikel'
       body    'This is a body of text'
     end
-    message.from.should      eq ['mikel@me.com']
-    message.to.should        eq ['mikel@you.com']
-    message.subject.should   eq 'Hello there Mikel'
-    message.body.to_s.should eq 'This is a body of text'
+    expect(message.from).to      eq ['mikel@me.com']
+    expect(message.to).to        eq ['mikel@you.com']
+    expect(message.subject).to   eq 'Hello there Mikel'
+    expect(message.body.to_s).to eq 'This is a body of text'
   end
 
   it "should read a file" do
     wrap_method = Mail.read(fixture('emails', 'plain_emails', 'raw_email.eml')).to_s
     file_method = Mail.new(File.open(fixture('emails', 'plain_emails', 'raw_email.eml'), 'rb', &:read)).to_s
-    wrap_method.should eq file_method
+    expect(wrap_method).to eq file_method
   end
 
 end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -10,23 +10,23 @@ describe Mail::Message do
   describe "initialization" do
 
     it "should instantiate empty" do
-      Mail::Message.new.class.should eq Mail::Message
+      expect(Mail::Message.new.class).to eq Mail::Message
     end
 
     it "should return a basic email" do
       mail = Mail.new
       mail = Mail.new(mail.to_s)
-      mail.date.should_not be_blank
-      mail.message_id.should_not be_blank
-      mail.mime_version.should eq "1.0"
-      mail.content_type.should eq "text/plain"
-      mail.content_transfer_encoding.should eq "7bit"
-      mail.subject.should be_blank
-      mail.body.should be_blank
+      expect(mail.date).not_to be_blank
+      expect(mail.message_id).not_to be_blank
+      expect(mail.mime_version).to eq "1.0"
+      expect(mail.content_type).to eq "text/plain"
+      expect(mail.content_transfer_encoding).to eq "7bit"
+      expect(mail.subject).to be_blank
+      expect(mail.body).to be_blank
     end
 
     it "should instantiate with a string" do
-      Mail::Message.new(basic_email).class.should eq Mail::Message
+      expect(Mail::Message.new(basic_email).class).to eq Mail::Message
     end
 
     it "should allow us to pass it a block" do
@@ -34,31 +34,31 @@ describe Mail::Message do
         from 'mikel@me.com'
         to 'lindsaar@you.com'
       end
-      mail.from.should eq ['mikel@me.com']
-      mail.to.should eq ['lindsaar@you.com']
+      expect(mail.from).to eq ['mikel@me.com']
+      expect(mail.to).to eq ['lindsaar@you.com']
     end
 
     it "should initialize a body and header class even if called with nothing to begin with" do
       mail = Mail::Message.new
-      mail.header.class.should eq Mail::Header
-      mail.body.class.should eq Mail::Body
+      expect(mail.header.class).to eq Mail::Header
+      expect(mail.body.class).to eq Mail::Body
     end
 
     it "should not report basic emails as bounced" do
-      Mail::Message.new.should_not be_bounced
+      expect(Mail::Message.new).not_to be_bounced
     end
 
     it "should be able to parse a basic email" do
-      doing { Mail.read(fixture('emails', 'plain_emails', 'basic_email.eml')) }.should_not raise_error
+      expect(doing { Mail.read(fixture('emails', 'plain_emails', 'basic_email.eml')) }).not_to raise_error
     end
 
     it "should be able to parse an email with @ in display name" do
       message = Mail.read(fixture('emails', 'plain_emails', 'raw_email_with_at_display_name.eml'))
-      message.to.should eq ["smith@gmail.com", "raasdnil@gmail.com", "tom@gmail.com"]
+      expect(message.to).to eq ["smith@gmail.com", "raasdnil@gmail.com", "tom@gmail.com"]
     end
 
     it "should be able to parse an email with only blank lines as body" do
-      doing { Mail.read(fixture('emails', 'error_emails', 'missing_body.eml')) }.should_not raise_error
+      expect(doing { Mail.read(fixture('emails', 'error_emails', 'missing_body.eml')) }).not_to raise_error
     end
 
     it "should be able to parse an email with a funky date header" do
@@ -77,7 +77,7 @@ describe Mail::Message do
     it "should be able to parse every email example we have without raising an exception" do
       emails = Dir.glob( fixture('emails/**/*') ).delete_if { |f| File.directory?(f) }
 
-      STDERR.stub!(:puts) # Don't want to get noisy about any warnings
+      allow(STDERR).to receive(:puts) # Don't want to get noisy about any warnings
       errors = false
       expected_failures = []
       emails.each do |email|
@@ -91,7 +91,7 @@ describe Mail::Message do
           end
         end
       end
-      errors.should be_false
+      expect(errors).to be_false
     end
 
     it "should be able to parse a large email without raising an exception" do
@@ -99,34 +99,34 @@ describe Mail::Message do
       m.add_file(:filename => "attachment.data", :content => "a" * (8 * 1024 * 1024))
       raw_email = "From jamis_buck@byu.edu Mon May  2 16:07:05 2005\r\n#{m.to_s}"
 
-      doing { Mail::Message.new(raw_email) }.should_not raise_error
+      expect(doing { Mail::Message.new(raw_email) }).not_to raise_error
     end
 
     it "should not raise a warning on having non US-ASCII characters in the header (should just handle it)" do
-      STDERR.should_not_receive(:puts)
+      expect(STDERR).not_to receive(:puts)
       Mail.read(fixture('emails', 'plain_emails', 'raw_email_string_in_date_field.eml'))
     end
 
     it "should raise a warning (and keep parsing) on having an incorrectly formatted header" do
-      STDERR.should_receive(:puts).with("WARNING: Could not parse (and so ignoring) 'quite Delivered-To: xxx@xxx.xxx'")
+      expect(STDERR).to receive(:puts).with("WARNING: Could not parse (and so ignoring) 'quite Delivered-To: xxx@xxx.xxx'")
       Mail.read(fixture('emails', 'plain_emails', 'raw_email_incorrect_header.eml')).to_s
     end
 
     it "should read in an email message and basically parse it" do
       mail = Mail.read(fixture('emails', 'plain_emails', 'basic_email.eml'))
-      mail.to.should eq ["raasdnil@gmail.com"]
+      expect(mail.to).to eq ["raasdnil@gmail.com"]
     end
 
     it "should not fail parsing message with caps in content_type" do
       mail = Mail.read(fixture('emails', 'plain_emails', 'mix_caps_content_type.eml'))
-      mail.content_type.should eq 'text/plain; charset=iso-8859-1'
-      mail.main_type.should eq 'text'
-      mail.sub_type.should eq 'plain'
+      expect(mail.content_type).to eq 'text/plain; charset=iso-8859-1'
+      expect(mail.main_type).to eq 'text'
+      expect(mail.sub_type).to eq 'plain'
     end
 
     it "should be able to pass an empty reply-to header" do
       mail = Mail.read(fixture('emails', 'error_emails', 'empty_in_reply_to.eml'))
-      mail.in_reply_to.should be_blank
+      expect(mail.in_reply_to).to be_blank
     end
 
     describe "YAML serialization" do
@@ -146,31 +146,31 @@ describe Mail::Message do
       it "should serialize the basic information to YAML" do
         yaml = @yaml_mail.to_yaml
         yaml_output = YAML.load(yaml)
-        yaml_output['headers']['To'].should       eq "someone@somewhere.com"
-        yaml_output['headers']['Cc'].should       eq "someoneelse@somewhere.com"
-        yaml_output['headers']['Subject'].should  eq "subject"
-        yaml_output['headers']['Bcc'].should      eq "someonesecret@somewhere.com"
-        yaml_output['@body_raw'].should           eq "body"
-        yaml_output['@delivery_method'].should_not be_blank
+        expect(yaml_output['headers']['To']).to       eq "someone@somewhere.com"
+        expect(yaml_output['headers']['Cc']).to       eq "someoneelse@somewhere.com"
+        expect(yaml_output['headers']['Subject']).to  eq "subject"
+        expect(yaml_output['headers']['Bcc']).to      eq "someonesecret@somewhere.com"
+        expect(yaml_output['@body_raw']).to           eq "body"
+        expect(yaml_output['@delivery_method']).not_to be_blank
       end
 
       it "should deserialize after serializing" do
         deserialized = Mail::Message.from_yaml(@yaml_mail.to_yaml)
-        deserialized.should eq @yaml_mail
-        deserialized.delivery_method.settings.should eq @smtp_settings
+        expect(deserialized).to eq @yaml_mail
+        expect(deserialized.delivery_method.settings).to eq @smtp_settings
       end
 
       it "should serialize a Message with a custom delivery_handler" do
         @yaml_mail.delivery_handler = DeliveryAgent
         yaml = @yaml_mail.to_yaml
         yaml_output = YAML.load(yaml)
-        yaml_output['delivery_handler'].should eq "DeliveryAgent"
+        expect(yaml_output['delivery_handler']).to eq "DeliveryAgent"
       end
 
       it "should load a serialized delivery handler" do
         @yaml_mail.delivery_handler = DeliveryAgent
         deserialized = Mail::Message.from_yaml(@yaml_mail.to_yaml)
-        deserialized.delivery_handler.should eq DeliveryAgent
+        expect(deserialized.delivery_handler).to eq DeliveryAgent
       end
 
       it "should not deserialize a delivery_handler that does not exist" do
@@ -178,90 +178,90 @@ describe Mail::Message do
         yaml_hash = YAML.load(yaml)
         yaml_hash['delivery_handler'] = "NotARealClass"
         deserialized = Mail::Message.from_yaml(yaml_hash.to_yaml)
-        deserialized.delivery_handler.should be_nil
+        expect(deserialized.delivery_handler).to be_nil
       end
 
       it "should handle multipart mail" do
         @yaml_mail.add_part Mail::Part.new(:content_type => 'text/html', :body => '<b>body</b>')
         deserialized = Mail::Message.from_yaml(@yaml_mail.to_yaml)
-        deserialized.should be_multipart
-        deserialized.parts.each {|part| part.should be_a(Mail::Part)}
-        deserialized.parts.map(&:body).should == ['body', '<b>body</b>']
+        expect(deserialized).to be_multipart
+        deserialized.parts.each {|part| expect(part).to be_a(Mail::Part)}
+        expect(deserialized.parts.map(&:body)).to eq(['body', '<b>body</b>'])
       end
     end
 
     describe "splitting" do
       it "should split the body from the header" do
         message = Mail::Message.new("To: Example <example@cirw.in>\r\n\r\nHello there\r\n")
-        message.decoded.should == "Hello there\n"
+        expect(message.decoded).to eq("Hello there\n")
       end
 
       it "should split when the body starts with a space" do
         message = Mail::Message.new("To: Example <example@cirw.in>\r\n\r\n Hello there\r\n")
-        message.decoded.should == " Hello there\n"
+        expect(message.decoded).to eq(" Hello there\n")
       end
 
       it "should split if the body starts with an empty line" do
         message = Mail::Message.new("To: Example <example@cirw.in>\r\n\r\n\r\nHello there\r\n")
-        message.decoded.should == "\nHello there\n"
+        expect(message.decoded).to eq("\nHello there\n")
       end
 
       it "should split if the body starts with a blank line" do
         message = Mail::Message.new("To: Example <example@cirw.in>\r\n\r\n\t\r\nHello there\r\n")
-        message.decoded.should == "\t\nHello there\n"
+        expect(message.decoded).to eq("\t\nHello there\n")
       end
 
       it 'should split after headers that contain "\r\n "' do
         message = Mail::Message.new("To: Example\r\n <example@cirw.in>\r\n\r\n Hello there\r\n")
-        message.decoded.should == " Hello there\n"
+        expect(message.decoded).to eq(" Hello there\n")
       end
 
       it 'should split only once if there are "\r\n\r\n"s in the body' do
         message = Mail::Message.new("To: Example <example@cirw.in>\r\n\r\nHello\r\n\r\nthere\r\n")
-        message.decoded.should == "Hello\n\nthere\n"
+        expect(message.decoded).to eq("Hello\n\nthere\n")
       end
 
       # N.B. this is not in any RFCs
       it "should split on a line with whitespace on it" do
         message = Mail::Message.new("To: Example <example@cirw.in>\r\n \r\nHello there\r\n")
-        message.decoded.should == "Hello there\n"
+        expect(message.decoded).to eq("Hello there\n")
       end
     end
   end
 
   describe "envelope line handling" do
     it "should respond to 'envelope from'" do
-      Mail::Message.new.should respond_to(:envelope_from)
+      expect(Mail::Message.new).to respond_to(:envelope_from)
     end
 
     it "should strip off the envelope from field if present" do
       message = Mail.read(fixture('emails', 'plain_emails', 'raw_email.eml'))
-      message.envelope_from.should eq "jamis_buck@byu.edu"
-      message.envelope_date.should eq ::DateTime.parse("Mon May  2 16:07:05 2005")
+      expect(message.envelope_from).to eq "jamis_buck@byu.edu"
+      expect(message.envelope_date).to eq ::DateTime.parse("Mon May  2 16:07:05 2005")
     end
 
     it "should strip off the envelope from field if present" do
       message = Mail.read(fixture('emails', 'plain_emails', 'raw_email.eml'))
-      message.raw_envelope.should eq "jamis_buck@byu.edu Mon May  2 16:07:05 2005"
-      message.from.should eq ["jamis@37signals.com"]
+      expect(message.raw_envelope).to eq "jamis_buck@byu.edu Mon May  2 16:07:05 2005"
+      expect(message.from).to eq ["jamis@37signals.com"]
     end
 
     it "should not cause any problems if there is no envelope from present" do
       message = Mail.read(fixture('emails', 'plain_emails', 'basic_email.eml'))
-      message.from.should eq ["test@lindsaar.net"]
+      expect(message.from).to eq ["test@lindsaar.net"]
     end
 
     it "should ignore a plain text body that starts with ^From" do
       m = Mail::Message.new("From: mikel@test.lindsaar.net\r\n\r\nThis is a way to break mail by putting\r\nFrom at the start of a body\r\nor elsewhere.")
-      m.from.should_not be_nil
-      m.from.should eq ['mikel@test.lindsaar.net']
+      expect(m.from).not_to be_nil
+      expect(m.from).to eq ['mikel@test.lindsaar.net']
     end
 
     it "should handle a multipart message that has ^From in it" do
       m = Mail.read(fixture('emails', 'error_emails', 'cant_parse_from.eml'))
-      m.from.should_not be_nil
-      m.from.should eq ["News@InsideApple.Apple.com"]
-      m.should be_multipart
+      expect(m.from).not_to be_nil
+      expect(m.from).to eq ["News@InsideApple.Apple.com"]
+      expect(m).to be_multipart
     end
 
   end
@@ -270,49 +270,49 @@ describe Mail::Message do
 
     it "should accept some email text to parse and return an email" do
       mail = Mail::Message.new(basic_email)
-      mail.class.should eq Mail::Message
+      expect(mail.class).to eq Mail::Message
     end
 
     it "should set a raw source instance variable to equal the passed in message" do
       mail = Mail::Message.new(basic_email)
-      mail.raw_source.should eq basic_email
+      expect(mail.raw_source).to eq basic_email
     end
 
     it "should set the raw source instance variable to '' if no message is passed in" do
       mail = Mail::Message.new
-      mail.raw_source.should eq ""
+      expect(mail.raw_source).to eq ""
     end
 
     it "should give the header class the header to parse" do
       header = Mail::Header.new("To: mikel\r\nFrom: bob\r\nSubject: Hello!")
-      Mail::Header.should_receive(:new).with("To: mikel\r\nFrom: bob\r\nSubject: Hello!", 'UTF-8').and_return(header)
+      expect(Mail::Header).to receive(:new).with("To: mikel\r\nFrom: bob\r\nSubject: Hello!", 'UTF-8').and_return(header)
       Mail::Message.new(basic_email)
     end
 
     it "should give the header class the header to parse even if there is no body" do
       header = Mail::Header.new("To: mikel\r\nFrom: bob\r\nSubject: Hello!")
-      Mail::Header.should_receive(:new).with("To: mikel\r\nFrom: bob\r\nSubject: Hello!", 'UTF-8').and_return(header)
+      expect(Mail::Header).to receive(:new).with("To: mikel\r\nFrom: bob\r\nSubject: Hello!", 'UTF-8').and_return(header)
       Mail::Message.new("To: mikel\r\nFrom: bob\r\nSubject: Hello!")
     end
 
     it "should give the body class the body to parse" do
       body = Mail::Body.new("email message")
-      Mail::Body.should_receive(:new).with("email message\r\n").and_return(body)
+      expect(Mail::Body).to receive(:new).with("email message\r\n").and_return(body)
       mail = Mail::Message.new(basic_email)
       mail.body #body calculates now lazy so need to ask for it
     end
 
     it "should still ask the body for a new instance even though these is nothing to parse, yet" do
       body = Mail::Body.new('')
-      Mail::Body.should_receive(:new).and_return(body)
+      expect(Mail::Body).to receive(:new).and_return(body)
       Mail::Message.new("To: mikel\r\nFrom: bob\r\nSubject: Hello!")
     end
 
     it "should give the header the part before the line without spaces and the body the part without" do
       header = Mail::Header.new("To: mikel")
       body = Mail::Body.new("G'Day!")
-      Mail::Header.should_receive(:new).with("To: mikel", 'UTF-8').and_return(header)
-      Mail::Body.should_receive(:new).with("G'Day!").and_return(body)
+      expect(Mail::Header).to receive(:new).with("To: mikel", 'UTF-8').and_return(header)
+      expect(Mail::Body).to receive(:new).with("G'Day!").and_return(body)
       mail = Mail::Message.new("To: mikel\r\n\r\nG'Day!")
       mail.body #body calculates now lazy so need to ask for it
     end
@@ -320,31 +320,31 @@ describe Mail::Message do
     it "should give allow for whitespace on the gap line between header and body" do
       header = Mail::Header.new("To: mikel")
       body = Mail::Body.new("G'Day!")
-      Mail::Header.should_receive(:new).with("To: mikel", 'UTF-8').and_return(header)
-      Mail::Body.should_receive(:new).with("G'Day!").and_return(body)
+      expect(Mail::Header).to receive(:new).with("To: mikel", 'UTF-8').and_return(header)
+      expect(Mail::Body).to receive(:new).with("G'Day!").and_return(body)
       mail = Mail::Message.new("To: mikel\r\n   		  \r\nG'Day!")
       mail.body #body calculates now lazy so need to ask for it
     end
 
     it "should allow for whitespace at the start of the email" do
       mail = Mail.new("\r\n\r\nFrom: mikel\r\n\r\nThis is the body")
-      mail.body.to_s.should eq 'This is the body'
-      mail.from.should eq ['mikel']
+      expect(mail.body.to_s).to eq 'This is the body'
+      expect(mail.from).to eq ['mikel']
     end
 
     it "should read in an email message with the word 'From' in it multiple times and parse it" do
       mail = Mail.read(fixture('emails', 'mime_emails', 'two_from_in_message.eml'))
-      mail.to.should_not be_nil
-      mail.to.should eq ["tester2@test.com"]
+      expect(mail.to).not_to be_nil
+      expect(mail.to).to eq ["tester2@test.com"]
     end
 
     it "should parse non-UTF8 sources" do
       raw_message = File.read(fixture('emails', 'multi_charset', 'japanese_shiftjis.eml'))
       original_encoding = raw_message.encoding if raw_message.respond_to?(:encoding)
       mail = Mail.new(raw_message)
-      mail.to.should eq ["raasdnil@gmail.com"]
-      mail.decoded.should eq "すみません。\n\n"
-      raw_message.encoding.should eq original_encoding if raw_message.respond_to?(:encoding)
+      expect(mail.to).to eq ["raasdnil@gmail.com"]
+      expect(mail.decoded).to eq "すみません。\n\n"
+      expect(raw_message.encoding).to eq original_encoding if raw_message.respond_to?(:encoding)
     end
   end
 
@@ -357,21 +357,21 @@ describe Mail::Message do
       end
 
       it "should allow you to grab field objects if you really want to" do
-        @mail.header_fields.class.should eq Mail::FieldList
+        expect(@mail.header_fields.class).to eq Mail::FieldList
       end
 
       it "should give you back the fields in the header" do
         @mail['bar'] = 'abcd'
-        @mail.header_fields.length.should eq 1
+        expect(@mail.header_fields.length).to eq 1
         @mail['foo'] = '4321'
-        @mail.header_fields.length.should eq 2
+        expect(@mail.header_fields.length).to eq 2
       end
 
       it "should delete a field if it is set to nil" do
         @mail['foo'] = '4321'
-        @mail.header_fields.length.should eq 1
+        expect(@mail.header_fields.length).to eq 1
         @mail['foo'] = nil
-        @mail.header_fields.length.should eq 0
+        expect(@mail.header_fields.length).to eq 0
       end
 
     end
@@ -384,32 +384,32 @@ describe Mail::Message do
 
       it "should return the to field" do
         @mail.to = "mikel"
-        @mail.to.should eq ["mikel"]
+        expect(@mail.to).to eq ["mikel"]
       end
 
       it "should return the from field" do
         @mail.from = "bob"
-        @mail.from.should eq ["bob"]
+        expect(@mail.from).to eq ["bob"]
       end
 
       it "should return the subject" do
         @mail.subject = "Hello!"
-        @mail.subject.should eq "Hello!"
+        expect(@mail.subject).to eq "Hello!"
       end
 
       it "should return the body decoded with to_s" do
         @mail.body "email message\r\n"
-        @mail.body.to_s.should eq "email message\n"
+        expect(@mail.body.to_s).to eq "email message\n"
       end
 
       it "should return the body encoded if asked for" do
         @mail.body "email message\r\n"
-        @mail.body.encoded.should eq "email message\r\n"
+        expect(@mail.body.encoded).to eq "email message\r\n"
       end
 
       it "should return the body decoded if asked for" do
         @mail.body "email message\r\n"
-        @mail.body.decoded.should eq "email message\n"
+        expect(@mail.body.decoded).to eq "email message\n"
       end
     end
 
@@ -421,32 +421,32 @@ describe Mail::Message do
 
       it "should return the to field" do
         @mail.to "mikel"
-        @mail.to.should eq ["mikel"]
+        expect(@mail.to).to eq ["mikel"]
       end
 
       it "should return the from field" do
         @mail.from "bob"
-        @mail.from.should eq ["bob"]
+        expect(@mail.from).to eq ["bob"]
       end
 
       it "should return the subject" do
         @mail.subject "Hello!"
-        @mail.subject.should eq "Hello!"
+        expect(@mail.subject).to eq "Hello!"
       end
 
       it "should return the body decoded with to_s" do
         @mail.body "email message\r\n"
-        @mail.body.to_s.should eq "email message\n"
+        expect(@mail.body.to_s).to eq "email message\n"
       end
 
       it "should return the body encoded if asked for" do
         @mail.body "email message\r\n"
-        @mail.body.encoded.should eq "email message\r\n"
+        expect(@mail.body.encoded).to eq "email message\r\n"
       end
 
       it "should return the body decoded if asked for" do
         @mail.body "email message\r\n"
-        @mail.body.decoded.should eq "email message\n"
+        expect(@mail.body.decoded).to eq "email message\n"
       end
     end
 
@@ -457,17 +457,17 @@ describe Mail::Message do
       end
 
       it "should allow you to set them" do
-        doing {@mail['foo'] = 1234}.should_not raise_error
+        expect(doing {@mail['foo'] = 1234}).not_to raise_error
       end
 
       it "should allow you to read arbitrary headers" do
         @mail['foo'] = 1234
-        @mail['foo'].value.to_s.should eq '1234'
+        expect(@mail['foo'].value.to_s).to eq '1234'
       end
 
       it "should instantiate a new Header" do
         @mail['foo'] = 1234
-        @mail.header_fields.first.class.should eq Mail::Field
+        expect(@mail.header_fields.first.class).to eq Mail::Field
       end
     end
 
@@ -475,19 +475,19 @@ describe Mail::Message do
 
       it "should allow you to replace a from field" do
         mail = Mail.new
-        mail.from.should eq nil
+        expect(mail.from).to eq nil
         mail.from = 'mikel@test.lindsaar.net'
-        mail.from.should eq ['mikel@test.lindsaar.net']
+        expect(mail.from).to eq ['mikel@test.lindsaar.net']
         mail.from = 'bob@test.lindsaar.net'
-        mail.from.should eq ['bob@test.lindsaar.net']
+        expect(mail.from).to eq ['bob@test.lindsaar.net']
       end
 
       it "should maintain the class of the field" do
         mail = Mail.new
         mail.from = 'mikel@test.lindsaar.net'
-        mail[:from].field.class.should eq Mail::FromField
+        expect(mail[:from].field.class).to eq Mail::FromField
         mail.from = 'bob@test.lindsaar.net'
-        mail[:from].field.class.should eq Mail::FromField
+        expect(mail[:from].field.class).to eq Mail::FromField
       end
     end
 
@@ -525,34 +525,34 @@ describe Mail::Message do
           body          'This is a body of text'
         end
 
-        message.bcc.should           eq ['mikel@bcc.lindsaar.net']
-        message.cc.should            eq ['mikel@cc.lindsaar.net']
-        message.comments.should      eq 'this is a comment'
-        message.date.should          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          eq ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   eq '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      eq ["test", "of the new mail", "system"]
-        message.message_id.should    eq '1234@message_id.lindsaar.net'
-        message.received.date_time.should      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    eq '1234@references.lindsaar.net'
-        message.reply_to.should      eq ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    eq ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     eq ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   eq ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should eq '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should eq ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     eq ['mikel@resent-to.lindsaar.net']
-        message.sender.should        eq 'mikel@sender.lindsaar.net'
-        message.subject.should       eq 'Hello there Mikel'
-        message.to.should            eq ['mikel@to.lindsaar.net']
-        message.content_type.should              eq 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should eq '7bit'
-        message.content_description.should       eq 'This is a test'
-        message.content_disposition.should       eq 'attachment; filename=File'
-        message.content_id.should                eq '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              eq '1.0'
-        message.body.to_s.should          eq 'This is a body of text'
+        expect(message.bcc).to           eq ['mikel@bcc.lindsaar.net']
+        expect(message.cc).to            eq ['mikel@cc.lindsaar.net']
+        expect(message.comments).to      eq 'this is a comment'
+        expect(message.date).to          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        expect(message.from).to          eq ['mikel@from.lindsaar.net']
+        expect(message.in_reply_to).to   eq '1234@in_reply_to.lindsaar.net'
+        expect(message.keywords).to      eq ["test", "of the new mail", "system"]
+        expect(message.message_id).to    eq '1234@message_id.lindsaar.net'
+        expect(message.received.date_time).to      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        expect(message.references).to    eq '1234@references.lindsaar.net'
+        expect(message.reply_to).to      eq ['mikel@reply-to.lindsaar.net']
+        expect(message.resent_bcc).to    eq ['mikel@resent-bcc.lindsaar.net']
+        expect(message.resent_cc).to     eq ['mikel@resent-cc.lindsaar.net']
+        expect(message.resent_date).to   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        expect(message.resent_from).to   eq ['mikel@resent-from.lindsaar.net']
+        expect(message.resent_message_id).to eq '1234@resent_message_id.lindsaar.net'
+        expect(message.resent_sender).to eq ['mikel@resent-sender.lindsaar.net']
+        expect(message.resent_to).to     eq ['mikel@resent-to.lindsaar.net']
+        expect(message.sender).to        eq 'mikel@sender.lindsaar.net'
+        expect(message.subject).to       eq 'Hello there Mikel'
+        expect(message.to).to            eq ['mikel@to.lindsaar.net']
+        expect(message.content_type).to              eq 'text/plain; charset=UTF-8'
+        expect(message.content_transfer_encoding).to eq '7bit'
+        expect(message.content_description).to       eq 'This is a test'
+        expect(message.content_disposition).to       eq 'attachment; filename=File'
+        expect(message.content_id).to                eq '<1234@message_id.lindsaar.net>'
+        expect(message.mime_version).to              eq '1.0'
+        expect(message.body.to_s).to          eq 'This is a body of text'
       end
 
       it "should accept them in assignment form" do
@@ -586,34 +586,34 @@ describe Mail::Message do
         message.mime_version =  '1.0'
         message.body =          'This is a body of text'
 
-        message.bcc.should           eq ['mikel@bcc.lindsaar.net']
-        message.cc.should            eq ['mikel@cc.lindsaar.net']
-        message.comments.should      eq 'this is a comment'
-        message.date.should          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          eq ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   eq '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      eq ["test", "of the new mail", "system"]
-        message.message_id.should    eq '1234@message_id.lindsaar.net'
-        message.received.date_time.should      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    eq '1234@references.lindsaar.net'
-        message.reply_to.should      eq ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    eq ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     eq ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   eq ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should eq '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should eq ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     eq ['mikel@resent-to.lindsaar.net']
-        message.sender.should        eq 'mikel@sender.lindsaar.net'
-        message.subject.should       eq 'Hello there Mikel'
-        message.to.should            eq ['mikel@to.lindsaar.net']
-        message.content_type.should              eq 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should eq '7bit'
-        message.content_description.should       eq 'This is a test'
-        message.content_disposition.should       eq 'attachment; filename=File'
-        message.content_id.should                eq '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              eq '1.0'
-        message.body.to_s.should          eq 'This is a body of text'
+        expect(message.bcc).to           eq ['mikel@bcc.lindsaar.net']
+        expect(message.cc).to            eq ['mikel@cc.lindsaar.net']
+        expect(message.comments).to      eq 'this is a comment'
+        expect(message.date).to          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        expect(message.from).to          eq ['mikel@from.lindsaar.net']
+        expect(message.in_reply_to).to   eq '1234@in_reply_to.lindsaar.net'
+        expect(message.keywords).to      eq ["test", "of the new mail", "system"]
+        expect(message.message_id).to    eq '1234@message_id.lindsaar.net'
+        expect(message.received.date_time).to      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        expect(message.references).to    eq '1234@references.lindsaar.net'
+        expect(message.reply_to).to      eq ['mikel@reply-to.lindsaar.net']
+        expect(message.resent_bcc).to    eq ['mikel@resent-bcc.lindsaar.net']
+        expect(message.resent_cc).to     eq ['mikel@resent-cc.lindsaar.net']
+        expect(message.resent_date).to   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        expect(message.resent_from).to   eq ['mikel@resent-from.lindsaar.net']
+        expect(message.resent_message_id).to eq '1234@resent_message_id.lindsaar.net'
+        expect(message.resent_sender).to eq ['mikel@resent-sender.lindsaar.net']
+        expect(message.resent_to).to     eq ['mikel@resent-to.lindsaar.net']
+        expect(message.sender).to        eq 'mikel@sender.lindsaar.net'
+        expect(message.subject).to       eq 'Hello there Mikel'
+        expect(message.to).to            eq ['mikel@to.lindsaar.net']
+        expect(message.content_type).to              eq 'text/plain; charset=UTF-8'
+        expect(message.content_transfer_encoding).to eq '7bit'
+        expect(message.content_description).to       eq 'This is a test'
+        expect(message.content_disposition).to       eq 'attachment; filename=File'
+        expect(message.content_id).to                eq '<1234@message_id.lindsaar.net>'
+        expect(message.mime_version).to              eq '1.0'
+        expect(message.body.to_s).to          eq 'This is a body of text'
       end
 
       it "should accept them in key, value form as symbols" do
@@ -647,34 +647,34 @@ describe Mail::Message do
         message[:mime_version]=  '1.0'
         message[:body] =          'This is a body of text'
 
-        message.bcc.should           eq ['mikel@bcc.lindsaar.net']
-        message.cc.should            eq ['mikel@cc.lindsaar.net']
-        message.comments.should      eq 'this is a comment'
-        message.date.should          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          eq ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   eq '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      eq ["test", "of the new mail", "system"]
-        message.message_id.should    eq '1234@message_id.lindsaar.net'
-        message.received.date_time.should      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    eq '1234@references.lindsaar.net'
-        message.reply_to.should      eq ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    eq ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     eq ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   eq ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should eq '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should eq ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     eq ['mikel@resent-to.lindsaar.net']
-        message.sender.should        eq 'mikel@sender.lindsaar.net'
-        message.subject.should       eq 'Hello there Mikel'
-        message.to.should            eq ['mikel@to.lindsaar.net']
-        message.content_type.should              eq 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should eq '7bit'
-        message.content_description.should       eq 'This is a test'
-        message.content_disposition.should       eq 'attachment; filename=File'
-        message.content_id.should                eq '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              eq '1.0'
-        message.body.to_s.should          eq 'This is a body of text'
+        expect(message.bcc).to           eq ['mikel@bcc.lindsaar.net']
+        expect(message.cc).to            eq ['mikel@cc.lindsaar.net']
+        expect(message.comments).to      eq 'this is a comment'
+        expect(message.date).to          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        expect(message.from).to          eq ['mikel@from.lindsaar.net']
+        expect(message.in_reply_to).to   eq '1234@in_reply_to.lindsaar.net'
+        expect(message.keywords).to      eq ["test", "of the new mail", "system"]
+        expect(message.message_id).to    eq '1234@message_id.lindsaar.net'
+        expect(message.received.date_time).to      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        expect(message.references).to    eq '1234@references.lindsaar.net'
+        expect(message.reply_to).to      eq ['mikel@reply-to.lindsaar.net']
+        expect(message.resent_bcc).to    eq ['mikel@resent-bcc.lindsaar.net']
+        expect(message.resent_cc).to     eq ['mikel@resent-cc.lindsaar.net']
+        expect(message.resent_date).to   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        expect(message.resent_from).to   eq ['mikel@resent-from.lindsaar.net']
+        expect(message.resent_message_id).to eq '1234@resent_message_id.lindsaar.net'
+        expect(message.resent_sender).to eq ['mikel@resent-sender.lindsaar.net']
+        expect(message.resent_to).to     eq ['mikel@resent-to.lindsaar.net']
+        expect(message.sender).to        eq 'mikel@sender.lindsaar.net'
+        expect(message.subject).to       eq 'Hello there Mikel'
+        expect(message.to).to            eq ['mikel@to.lindsaar.net']
+        expect(message.content_type).to              eq 'text/plain; charset=UTF-8'
+        expect(message.content_transfer_encoding).to eq '7bit'
+        expect(message.content_description).to       eq 'This is a test'
+        expect(message.content_disposition).to       eq 'attachment; filename=File'
+        expect(message.content_id).to                eq '<1234@message_id.lindsaar.net>'
+        expect(message.mime_version).to              eq '1.0'
+        expect(message.body.to_s).to          eq 'This is a body of text'
       end
 
       it "should accept them in key, value form as strings" do
@@ -708,34 +708,34 @@ describe Mail::Message do
         message['mime_version'] =  '1.0'
         message['body'] =          'This is a body of text'
 
-        message.bcc.should           eq ['mikel@bcc.lindsaar.net']
-        message.cc.should            eq ['mikel@cc.lindsaar.net']
-        message.comments.should      eq 'this is a comment'
-        message.date.should          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          eq ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   eq '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      eq ["test", "of the new mail", "system"]
-        message.message_id.should    eq '1234@message_id.lindsaar.net'
-        message.received.date_time.should      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    eq '1234@references.lindsaar.net'
-        message.reply_to.should      eq ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    eq ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     eq ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   eq ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should eq '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should eq ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     eq ['mikel@resent-to.lindsaar.net']
-        message.sender.should        eq 'mikel@sender.lindsaar.net'
-        message.subject.should       eq 'Hello there Mikel'
-        message.to.should            eq ['mikel@to.lindsaar.net']
-        message.content_type.should              eq 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should eq '7bit'
-        message.content_description.should       eq 'This is a test'
-        message.content_disposition.should       eq 'attachment; filename=File'
-        message.content_id.should                eq '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              eq '1.0'
-        message.body.to_s.should          eq 'This is a body of text'
+        expect(message.bcc).to           eq ['mikel@bcc.lindsaar.net']
+        expect(message.cc).to            eq ['mikel@cc.lindsaar.net']
+        expect(message.comments).to      eq 'this is a comment'
+        expect(message.date).to          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        expect(message.from).to          eq ['mikel@from.lindsaar.net']
+        expect(message.in_reply_to).to   eq '1234@in_reply_to.lindsaar.net'
+        expect(message.keywords).to      eq ["test", "of the new mail", "system"]
+        expect(message.message_id).to    eq '1234@message_id.lindsaar.net'
+        expect(message.received.date_time).to      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        expect(message.references).to    eq '1234@references.lindsaar.net'
+        expect(message.reply_to).to      eq ['mikel@reply-to.lindsaar.net']
+        expect(message.resent_bcc).to    eq ['mikel@resent-bcc.lindsaar.net']
+        expect(message.resent_cc).to     eq ['mikel@resent-cc.lindsaar.net']
+        expect(message.resent_date).to   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        expect(message.resent_from).to   eq ['mikel@resent-from.lindsaar.net']
+        expect(message.resent_message_id).to eq '1234@resent_message_id.lindsaar.net'
+        expect(message.resent_sender).to eq ['mikel@resent-sender.lindsaar.net']
+        expect(message.resent_to).to     eq ['mikel@resent-to.lindsaar.net']
+        expect(message.sender).to        eq 'mikel@sender.lindsaar.net'
+        expect(message.subject).to       eq 'Hello there Mikel'
+        expect(message.to).to            eq ['mikel@to.lindsaar.net']
+        expect(message.content_type).to              eq 'text/plain; charset=UTF-8'
+        expect(message.content_transfer_encoding).to eq '7bit'
+        expect(message.content_description).to       eq 'This is a test'
+        expect(message.content_disposition).to       eq 'attachment; filename=File'
+        expect(message.content_id).to                eq '<1234@message_id.lindsaar.net>'
+        expect(message.mime_version).to              eq '1.0'
+        expect(message.body.to_s).to          eq 'This is a body of text'
       end
 
       it "should accept them as a hash with symbols" do
@@ -770,34 +770,34 @@ describe Mail::Message do
           :body =>          'This is a body of text'
         })
 
-        message.bcc.should           eq ['mikel@bcc.lindsaar.net']
-        message.cc.should            eq ['mikel@cc.lindsaar.net']
-        message.comments.should      eq 'this is a comment'
-        message.date.should          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          eq ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   eq '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      eq ["test", "of the new mail", "system"]
-        message.message_id.should    eq '1234@message_id.lindsaar.net'
-        message.received.date_time.should      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    eq '1234@references.lindsaar.net'
-        message.reply_to.should      eq ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    eq ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     eq ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   eq ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should eq '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should eq ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     eq ['mikel@resent-to.lindsaar.net']
-        message.sender.should        eq 'mikel@sender.lindsaar.net'
-        message.subject.should       eq 'Hello there Mikel'
-        message.to.should            eq ['mikel@to.lindsaar.net']
-        message.content_type.should              eq 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should eq '7bit'
-        message.content_description.should       eq 'This is a test'
-        message.content_disposition.should       eq 'attachment; filename=File'
-        message.content_id.should                eq '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              eq '1.0'
-        message.body.to_s.should          eq 'This is a body of text'
+        expect(message.bcc).to           eq ['mikel@bcc.lindsaar.net']
+        expect(message.cc).to            eq ['mikel@cc.lindsaar.net']
+        expect(message.comments).to      eq 'this is a comment'
+        expect(message.date).to          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        expect(message.from).to          eq ['mikel@from.lindsaar.net']
+        expect(message.in_reply_to).to   eq '1234@in_reply_to.lindsaar.net'
+        expect(message.keywords).to      eq ["test", "of the new mail", "system"]
+        expect(message.message_id).to    eq '1234@message_id.lindsaar.net'
+        expect(message.received.date_time).to      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        expect(message.references).to    eq '1234@references.lindsaar.net'
+        expect(message.reply_to).to      eq ['mikel@reply-to.lindsaar.net']
+        expect(message.resent_bcc).to    eq ['mikel@resent-bcc.lindsaar.net']
+        expect(message.resent_cc).to     eq ['mikel@resent-cc.lindsaar.net']
+        expect(message.resent_date).to   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        expect(message.resent_from).to   eq ['mikel@resent-from.lindsaar.net']
+        expect(message.resent_message_id).to eq '1234@resent_message_id.lindsaar.net'
+        expect(message.resent_sender).to eq ['mikel@resent-sender.lindsaar.net']
+        expect(message.resent_to).to     eq ['mikel@resent-to.lindsaar.net']
+        expect(message.sender).to        eq 'mikel@sender.lindsaar.net'
+        expect(message.subject).to       eq 'Hello there Mikel'
+        expect(message.to).to            eq ['mikel@to.lindsaar.net']
+        expect(message.content_type).to              eq 'text/plain; charset=UTF-8'
+        expect(message.content_transfer_encoding).to eq '7bit'
+        expect(message.content_description).to       eq 'This is a test'
+        expect(message.content_disposition).to       eq 'attachment; filename=File'
+        expect(message.content_id).to                eq '<1234@message_id.lindsaar.net>'
+        expect(message.mime_version).to              eq '1.0'
+        expect(message.body.to_s).to          eq 'This is a body of text'
       end
 
       it "should accept them as a hash with strings" do
@@ -832,46 +832,46 @@ describe Mail::Message do
           'body' =>          'This is a body of text'
         })
 
-        message.bcc.should           eq ['mikel@bcc.lindsaar.net']
-        message.cc.should            eq ['mikel@cc.lindsaar.net']
-        message.comments.should      eq 'this is a comment'
-        message.date.should          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
-        message.from.should          eq ['mikel@from.lindsaar.net']
-        message.in_reply_to.should   eq '1234@in_reply_to.lindsaar.net'
-        message.keywords.should      eq ["test", "of the new mail", "system"]
-        message.message_id.should    eq '1234@message_id.lindsaar.net'
-        message.received.date_time.should      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
-        message.references.should    eq '1234@references.lindsaar.net'
-        message.reply_to.should      eq ['mikel@reply-to.lindsaar.net']
-        message.resent_bcc.should    eq ['mikel@resent-bcc.lindsaar.net']
-        message.resent_cc.should     eq ['mikel@resent-cc.lindsaar.net']
-        message.resent_date.should   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
-        message.resent_from.should   eq ['mikel@resent-from.lindsaar.net']
-        message.resent_message_id.should eq '1234@resent_message_id.lindsaar.net'
-        message.resent_sender.should eq ['mikel@resent-sender.lindsaar.net']
-        message.resent_to.should     eq ['mikel@resent-to.lindsaar.net']
-        message.sender.should        eq 'mikel@sender.lindsaar.net'
-        message.subject.should       eq 'Hello there Mikel'
-        message.to.should            eq ['mikel@to.lindsaar.net']
-        message.content_type.should              eq 'text/plain; charset=UTF-8'
-        message.content_transfer_encoding.should eq '7bit'
-        message.content_description.should       eq 'This is a test'
-        message.content_disposition.should       eq 'attachment; filename=File'
-        message.content_id.should                eq '<1234@message_id.lindsaar.net>'
-        message.mime_version.should              eq '1.0'
-        message.body.to_s.should          eq 'This is a body of text'
+        expect(message.bcc).to           eq ['mikel@bcc.lindsaar.net']
+        expect(message.cc).to            eq ['mikel@cc.lindsaar.net']
+        expect(message.comments).to      eq 'this is a comment'
+        expect(message.date).to          eq DateTime.parse('12 Aug 2009 00:00:01 GMT')
+        expect(message.from).to          eq ['mikel@from.lindsaar.net']
+        expect(message.in_reply_to).to   eq '1234@in_reply_to.lindsaar.net'
+        expect(message.keywords).to      eq ["test", "of the new mail", "system"]
+        expect(message.message_id).to    eq '1234@message_id.lindsaar.net'
+        expect(message.received.date_time).to      eq DateTime.parse('12 Aug 2009 00:00:02 GMT')
+        expect(message.references).to    eq '1234@references.lindsaar.net'
+        expect(message.reply_to).to      eq ['mikel@reply-to.lindsaar.net']
+        expect(message.resent_bcc).to    eq ['mikel@resent-bcc.lindsaar.net']
+        expect(message.resent_cc).to     eq ['mikel@resent-cc.lindsaar.net']
+        expect(message.resent_date).to   eq DateTime.parse('12 Aug 2009 00:00:03 GMT')
+        expect(message.resent_from).to   eq ['mikel@resent-from.lindsaar.net']
+        expect(message.resent_message_id).to eq '1234@resent_message_id.lindsaar.net'
+        expect(message.resent_sender).to eq ['mikel@resent-sender.lindsaar.net']
+        expect(message.resent_to).to     eq ['mikel@resent-to.lindsaar.net']
+        expect(message.sender).to        eq 'mikel@sender.lindsaar.net'
+        expect(message.subject).to       eq 'Hello there Mikel'
+        expect(message.to).to            eq ['mikel@to.lindsaar.net']
+        expect(message.content_type).to              eq 'text/plain; charset=UTF-8'
+        expect(message.content_transfer_encoding).to eq '7bit'
+        expect(message.content_description).to       eq 'This is a test'
+        expect(message.content_disposition).to       eq 'attachment; filename=File'
+        expect(message.content_id).to                eq '<1234@message_id.lindsaar.net>'
+        expect(message.mime_version).to              eq '1.0'
+        expect(message.body.to_s).to          eq 'This is a body of text'
       end
 
       it "should let you set custom headers with a :headers => {hash}" do
         message = Mail.new(:headers => {'custom-header' => 'mikel'})
-        message['custom-header'].decoded.should eq 'mikel'
+        expect(message['custom-header'].decoded).to eq 'mikel'
       end
 
       it "should assign the body to a part on creation" do
         message = Mail.new do
           part({:content_type=>"multipart/alternative", :content_disposition=>"inline", :body=>"Nothing to see here."})
         end
-        message.parts.first.body.decoded.should eq "Nothing to see here."
+        expect(message.parts.first.body.decoded).to eq "Nothing to see here."
       end
 
       it "should not overwrite bodies on creation" do
@@ -880,27 +880,27 @@ describe Mail::Message do
             p.part :content_type => "text/html", :body => "<b>test</b> HTML<br/>"
           end
         end
-        message.parts.first.parts[0].body.decoded.should eq "Nothing to see here."
-        message.parts.first.parts[1].body.decoded.should eq "<b>test</b> HTML<br/>"
-        message.encoded.should match %r{Nothing to see here\.}
-        message.encoded.should match %r{<b>test</b> HTML<br/>}
+        expect(message.parts.first.parts[0].body.decoded).to eq "Nothing to see here."
+        expect(message.parts.first.parts[1].body.decoded).to eq "<b>test</b> HTML<br/>"
+        expect(message.encoded).to match %r{Nothing to see here\.}
+        expect(message.encoded).to match %r{<b>test</b> HTML<br/>}
       end
 
       it "should allow you to init on an array of addresses from a hash" do
         mail = Mail.new(:to => ['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>'])
-        mail.to.should eq ['test1@lindsaar.net', 'test2@lindsaar.net']
+        expect(mail.to).to eq ['test1@lindsaar.net', 'test2@lindsaar.net']
       end
 
       it "should allow you to init on an array of addresses directly" do
         mail = Mail.new
         mail.to = ['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>']
-        mail.to.should eq ['test1@lindsaar.net', 'test2@lindsaar.net']
+        expect(mail.to).to eq ['test1@lindsaar.net', 'test2@lindsaar.net']
       end
 
       it "should allow you to init on an array of addresses directly" do
         mail = Mail.new
         mail[:to] = ['test1@lindsaar.net', 'Mikel <test2@lindsaar.net>']
-        mail.to.should eq ['test1@lindsaar.net', 'test2@lindsaar.net']
+        expect(mail.to).to eq ['test1@lindsaar.net', 'test2@lindsaar.net']
       end
 
     end
@@ -919,7 +919,7 @@ describe Mail::Message do
             subject 'This is a test email'
                body 'This is a body of the email'
           end
-          mail.should_not be_has_message_id
+          expect(mail).not_to be_has_message_id
         end
 
         it "should preserve any message id that you pass it if add_message_id is called explicitly" do
@@ -930,7 +930,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_message_id("<ThisIsANonUniqueMessageId@me.com>")
-          mail.to_s.should =~ /Message-ID: <ThisIsANonUniqueMessageId@me.com>\r\n/
+          expect(mail.to_s).to match(/Message-ID: <ThisIsANonUniqueMessageId@me.com>\r\n/)
         end
 
         it "should generate a random message ID if nothing is passed to add_message_id" do
@@ -941,7 +941,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_message_id
-          mail.to_s.should =~ /Message-ID: <[\w]+@#{::Socket.gethostname}.mail>\r\n/
+          expect(mail.to_s).to match(/Message-ID: <[\w]+@#{::Socket.gethostname}.mail>\r\n/)
         end
 
         it "should make an email and inject a message ID if none was set if told to_s" do
@@ -951,7 +951,7 @@ describe Mail::Message do
             subject 'This is a test email'
                body 'This is a body of the email'
           end
-          (mail.to_s =~ /Message-ID: <.+@.+.mail>/i).should_not be_nil
+          expect(mail.to_s =~ /Message-ID: <.+@.+.mail>/i).not_to be_nil
         end
 
         it "should add the message id to the message permanently once sent to_s" do
@@ -962,13 +962,13 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.to_s
-          mail.should be_has_message_id
+          expect(mail).to be_has_message_id
         end
 
         it "should add a body part if it is missing" do
           mail = Mail.new
           mail.to_s
-          mail.body.class.should eq Mail::Body
+          expect(mail.body.class).to eq Mail::Body
         end
       end
 
@@ -980,7 +980,7 @@ describe Mail::Message do
             subject 'This is a test email'
                body 'This is a body of the email'
           end
-          mail.should_not be_has_date
+          expect(mail).not_to be_has_date
         end
 
         it "should preserve any date that you pass it if add_date is called explicitly" do
@@ -991,7 +991,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_date("Mon, 24 Nov 1997 14:22:01 -0800")
-          mail.to_s.should =~ /Date: Mon, 24 Nov 1997 14:22:01 -0800/
+          expect(mail.to_s).to match(/Date: Mon, 24 Nov 1997 14:22:01 -0800/)
         end
 
         it "should generate a current date if nothing is passed to add_date" do
@@ -1002,7 +1002,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_date
-          mail.to_s.should =~ /Date: \w{3}, [\s\d]\d \w{3} \d{4} \d{2}:\d{2}:\d{2} [-+]?\d{4}\r\n/
+          expect(mail.to_s).to match(/Date: \w{3}, [\s\d]\d \w{3} \d{4} \d{2}:\d{2}:\d{2} [-+]?\d{4}\r\n/)
         end
 
         it "should make an email and inject a date if none was set if told to_s" do
@@ -1012,7 +1012,7 @@ describe Mail::Message do
             subject 'This is a test email'
                body 'This is a body of the email'
           end
-          mail.to_s.should =~ /Date: \w{3}, [\s\d]\d \w{3} \d{4} \d{2}:\d{2}:\d{2} [-+]?\d{4}\r\n/
+          expect(mail.to_s).to match(/Date: \w{3}, [\s\d]\d \w{3} \d{4} \d{2}:\d{2}:\d{2} [-+]?\d{4}\r\n/)
         end
 
         it "should add the date to the message permanently once sent to_s" do
@@ -1023,7 +1023,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.to_s
-          mail.should be_has_date
+          expect(mail).to be_has_date
         end
       end
 
@@ -1039,7 +1039,7 @@ describe Mail::Message do
             subject 'This is a test email'
                body 'This is a body of the email'
           end
-          mail.should_not be_has_mime_version
+          expect(mail).not_to be_has_mime_version
         end
 
         it "should preserve any mime version that you pass it if add_mime_version is called explicitly" do
@@ -1050,7 +1050,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_mime_version("3.0 (This is an unreal version number)")
-          mail.to_s.should =~ /Mime-Version: 3.0\r\n/
+          expect(mail.to_s).to match(/Mime-Version: 3.0\r\n/)
         end
 
         it "should generate a mime version if nothing is passed to add_date" do
@@ -1061,7 +1061,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_mime_version
-          mail.to_s.should =~ /Mime-Version: 1.0\r\n/
+          expect(mail.to_s).to match(/Mime-Version: 1.0\r\n/)
         end
 
         it "should make an email and inject a mime_version if none was set if told to_s" do
@@ -1071,7 +1071,7 @@ describe Mail::Message do
             subject 'This is a test email'
                body 'This is a body of the email'
           end
-          mail.to_s.should =~ /Mime-Version: 1.0\r\n/
+          expect(mail.to_s).to match(/Mime-Version: 1.0\r\n/)
         end
 
         it "should add the mime version to the message permanently once sent to_s" do
@@ -1082,7 +1082,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.to_s
-          mail.should be_has_mime_version
+          expect(mail).to be_has_mime_version
         end
       end
 
@@ -1090,29 +1090,29 @@ describe Mail::Message do
 
         it "should say if it has a content type" do
           mail = Mail.new('Content-Type: text/plain')
-          mail.should be_has_content_type
+          expect(mail).to be_has_content_type
         end
 
         it "should say if it does not have a content type" do
           mail = Mail.new
-          mail.should_not be_has_content_type
+          expect(mail).not_to be_has_content_type
         end
 
         it "should say if it has a charset" do
           mail = Mail.new('Content-Type: text/plain; charset=US-ASCII')
-          mail.should be_has_charset
+          expect(mail).to be_has_charset
         end
 
         it "should say if it has a charset" do
           mail = Mail.new('Content-Type: text/plain')
-          mail.should_not be_has_charset
+          expect(mail).not_to be_has_charset
         end
 
         it "should not raise a warning if there is no charset defined and only US-ASCII chars" do
           body = "This is plain text US-ASCII"
           mail = Mail.new
           mail.body = body
-          STDERR.should_not_receive(:puts)
+          expect(STDERR).not_to receive(:puts)
           mail.to_s
         end
 
@@ -1136,7 +1136,7 @@ describe Mail::Message do
           mail = Mail.new
           mail.body = body
           mail.content_transfer_encoding = "8bit"
-          STDERR.should_receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
+          expect(STDERR).to receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
           mail.to_s =~ %r{Content-Type: text/plain; charset=UTF-8}
         end
 
@@ -1146,7 +1146,7 @@ describe Mail::Message do
           mail.body = body
           mail.content_type = "text/plain"
           mail.content_transfer_encoding = "8bit"
-          STDERR.should_receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
+          expect(STDERR).to receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
           mail.to_s =~ %r{Content-Type: text/plain; charset=UTF-8}
         end
 
@@ -1156,27 +1156,27 @@ describe Mail::Message do
           mail.body = body
           mail.content_transfer_encoding = "8bit"
           mail.content_type = "text/plain; charset=UTF-8"
-          STDERR.should_not_receive(:puts)
+          expect(STDERR).not_to receive(:puts)
           mail.to_s
         end
 
         it "should be able to set a content type with an array and hash" do
           mail = Mail.new
           mail.content_type = ["text", "plain", { :charset => 'US-ASCII' }]
-          mail[:content_type].encoded.should eq %Q[Content-Type: text/plain;\r\n\scharset=US-ASCII\r\n]
-          mail.content_type_parameters.should eql({"charset" => "US-ASCII"})
+          expect(mail[:content_type].encoded).to eq %Q[Content-Type: text/plain;\r\n\scharset=US-ASCII\r\n]
+          expect(mail.content_type_parameters).to eql({"charset" => "US-ASCII"})
         end
 
         it "should be able to set a content type with an array and hash with a non-usascii field" do
           mail = Mail.new
           mail.content_type = ["text", "plain", { :charset => 'UTF-8' }]
-          mail[:content_type].encoded.should eq %Q[Content-Type: text/plain;\r\n\scharset=UTF-8\r\n]
-          mail.content_type_parameters.should eql({"charset" => "UTF-8"})
+          expect(mail[:content_type].encoded).to eq %Q[Content-Type: text/plain;\r\n\scharset=UTF-8\r\n]
+          expect(mail.content_type_parameters).to eql({"charset" => "UTF-8"})
         end
 
         it "should allow us to specify a content type in a block" do
           mail = Mail.new { content_type ["text", "plain", { "charset" => "UTF-8" }] }
-          mail.content_type_parameters.should eql({"charset" => "UTF-8"})
+          expect(mail.content_type_parameters).to eql({"charset" => "UTF-8"})
         end
 
       end
@@ -1187,7 +1187,7 @@ describe Mail::Message do
           body = "This is plain text US-ASCII"
           mail = Mail.new
           mail.body = body
-          mail.to_s.should =~ %r{Content-Transfer-Encoding: 7bit}
+          expect(mail.to_s).to match(%r{Content-Transfer-Encoding: 7bit})
         end
 
         it "should use QP transfer encoding for 8bit text with only a few 8bit characters" do
@@ -1195,7 +1195,7 @@ describe Mail::Message do
           mail = Mail.new
           mail.charset = "UTF-8"
           mail.body = body
-          mail.to_s.should =~ %r{Content-Transfer-Encoding: quoted-printable}
+          expect(mail.to_s).to match(%r{Content-Transfer-Encoding: quoted-printable})
         end
 
         it "should use base64 transfer encoding for 8-bit text with lots of 8bit characters" do
@@ -1204,9 +1204,9 @@ describe Mail::Message do
           mail.charset = "UTF-8"
           mail.body = body
           mail.content_type = "text/plain; charset=utf-8"
-          mail.should be_has_content_type
-          mail.should be_has_charset
-          mail.to_s.should =~  %r{Content-Transfer-Encoding: base64}
+          expect(mail).to be_has_content_type
+          expect(mail).to be_has_charset
+          expect(mail.to_s).to match(%r{Content-Transfer-Encoding: base64})
         end
 
         it "should not use 8bit transfer encoding when 8bit is allowed" do
@@ -1216,7 +1216,7 @@ describe Mail::Message do
           mail.body = body
           mail.content_type = "text/plain; charset=utf-8"
           mail.transport_encoding = "8bit"
-          mail.to_s.should =~ %r{Content-Transfer-Encoding: 8bit}
+          expect(mail.to_s).to match(%r{Content-Transfer-Encoding: 8bit})
         end
 
       end
@@ -1235,10 +1235,10 @@ describe Mail::Message do
            body 'This is a body of the email'
       end
 
-      mail.to_s.should =~ /From: mikel@test.lindsaar.net\r\n/
-      mail.to_s.should =~ /To: you@test.lindsaar.net\r\n/
-      mail.to_s.should =~ /Subject: This is a test email\r\n/
-      mail.to_s.should =~ /This is a body of the email/
+      expect(mail.to_s).to match(/From: mikel@test.lindsaar.net\r\n/)
+      expect(mail.to_s).to match(/To: you@test.lindsaar.net\r\n/)
+      expect(mail.to_s).to match(/Subject: This is a test email\r\n/)
+      expect(mail.to_s).to match(/This is a body of the email/)
 
     end
 
@@ -1255,7 +1255,7 @@ describe Mail::Message do
           body '<h1>This is HTML</h1>'
         end
       end
-      doing { mail.decoded }.should raise_error(NoMethodError, 'Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.')
+      expect(doing { mail.decoded }).to raise_error(NoMethodError, 'Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.')
     end
 
     it "should return the decoded body if you call decode and the message is not multipart" do
@@ -1263,7 +1263,7 @@ describe Mail::Message do
         content_transfer_encoding 'base64'
         body "VGhlIGJvZHk=\n"
       end
-      mail.decoded.should eq "The body"
+      expect(mail.decoded).to eq "The body"
     end
 
     describe "decoding bodies" do
@@ -1272,8 +1272,8 @@ describe Mail::Message do
         mail = Mail.new do
           body "The=3Dbody"
         end
-        mail.body.decoded.should eq "The=3Dbody"
-        mail.body.encoded.should eq "The=3Dbody"
+        expect(mail.body.decoded).to eq "The=3Dbody"
+        expect(mail.body.encoded).to eq "The=3Dbody"
       end
 
       it "should change a body on decode if given an encoding type to decode" do
@@ -1281,8 +1281,8 @@ describe Mail::Message do
           content_transfer_encoding 'quoted-printable'
           body "The=3Dbody"
         end
-        mail.body.decoded.should eq "The=body"
-        mail.body.encoded.should eq "The=3Dbody=\r\n"
+        expect(mail.body.decoded).to eq "The=body"
+        expect(mail.body.encoded).to eq "The=3Dbody=\r\n"
       end
 
       it "should change a body on decode if given an encoding type to decode" do
@@ -1290,12 +1290,12 @@ describe Mail::Message do
           content_transfer_encoding 'base64'
           body "VGhlIGJvZHk=\n"
         end
-        mail.body.decoded.should eq "The body"
-        mail.body.encoded.should eq "VGhlIGJvZHk=\r\n"
+        expect(mail.body.decoded).to eq "The body"
+        expect(mail.body.encoded).to eq "VGhlIGJvZHk=\r\n"
       end
 
       it 'should not strip the raw mail source in case the trailing \r\n is meaningful' do
-        Mail.new("Content-Transfer-Encoding: quoted-printable;\r\n\r\nfoo=\r\nbar=\r\nbaz=\r\n").decoded.should eq 'foobarbaz'
+        expect(Mail.new("Content-Transfer-Encoding: quoted-printable;\r\n\r\nfoo=\r\nbar=\r\nbaz=\r\n").decoded).to eq 'foobarbaz'
       end
 
     end
@@ -1317,11 +1317,11 @@ describe Mail::Message do
     end
 
     it "should be decoded using content type charset" do
-      @message.decoded.should eq "América"
+      expect(@message.decoded).to eq "América"
     end
 
     it "should respond true to text?" do
-      @message.text?.should eq true
+      expect(@message.text?).to eq true
     end
 
   end
@@ -1332,47 +1332,47 @@ describe Mail::Message do
       before(:each) do
         # Ensure specs don't randomly fail due to messages being generated 1 second apart
         time = Time.now
-        Time.stub!(:now).and_return(time)
+        allow(Time).to receive(:now).and_return(time)
       end
 
       it "should be implemented" do
-        doing { Mail.new == Mail.new }.should_not raise_error
+        expect(doing { Mail.new == Mail.new }).not_to raise_error
       end
 
       it "should ignore the message id value if both have a nil message id" do
         m1 = Mail.new("To: mikel@test.lindsaar.net\r\nSubject: Yo!\r\n\r\nHello there")
         m2 = Mail.new("To: mikel@test.lindsaar.net\r\nSubject: Yo!\r\n\r\nHello there")
-        m1.should eq m2
+        expect(m1).to eq m2
         # confirm there are no side-effects in the comparison
-        m1.message_id.should be_nil
-        m2.message_id.should be_nil
+        expect(m1.message_id).to be_nil
+        expect(m2.message_id).to be_nil
       end
 
       it "should ignore the message id value if self has a nil message id" do
         m1 = Mail.new("To: mikel@test.lindsaar.net\r\nSubject: Yo!\r\n\r\nHello there")
         m2 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <1234@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
-        m1.should eq m2
+        expect(m1).to eq m2
         # confirm there are no side-effects in the comparison
-        m1.message_id.should be_nil
-        m2.message_id.should eq '1234@test.lindsaar.net'
+        expect(m1.message_id).to be_nil
+        expect(m2.message_id).to eq '1234@test.lindsaar.net'
       end
 
       it "should ignore the message id value if other has a nil message id" do
         m1 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <1234@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
         m2 = Mail.new("To: mikel@test.lindsaar.net\r\nSubject: Yo!\r\n\r\nHello there")
-        m1.should eq m2
+        expect(m1).to eq m2
         # confirm there are no side-effects in the comparison
-        m1.message_id.should eq '1234@test.lindsaar.net'
-        m2.message_id.should be_nil
+        expect(m1.message_id).to eq '1234@test.lindsaar.net'
+        expect(m2.message_id).to be_nil
       end
 
       it "should not be == if both emails have different Message IDs" do
         m1 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <4321@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
         m2 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <1234@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")
-        m1.should_not eq m2
+        expect(m1).not_to eq m2
         # confirm there are no side-effects in the comparison
-        m1.message_id.should eq '4321@test.lindsaar.net'
-        m2.message_id.should eq '1234@test.lindsaar.net'
+        expect(m1.message_id).to eq '4321@test.lindsaar.net'
+        expect(m2.message_id).to eq '1234@test.lindsaar.net'
       end
     end
 
@@ -1384,7 +1384,7 @@ describe Mail::Message do
       mail2 = Mail.new do
         date(now - 10) # Make mail2 10 seconds 'older'
       end
-      [mail2, mail1].sort.should eq [mail2, mail1]
+      expect([mail2, mail1].sort).to eq [mail2, mail1]
     end
 
     it "should have a destinations method" do
@@ -1393,66 +1393,66 @@ describe Mail::Message do
         cc 'bob@test.lindsaar.net'
         bcc 'sam@test.lindsaar.net'
       end
-      mail.destinations.length.should eq 3
+      expect(mail.destinations.length).to eq 3
     end
 
     it "should have a from_addrs method" do
       mail = Mail.new do
         from 'mikel@test.lindsaar.net'
       end
-      mail.from_addrs.length.should eq 1
+      expect(mail.from_addrs.length).to eq 1
     end
 
     it "should have a from_addrs method that is empty if nil" do
       mail = Mail.new do
       end
-      mail.from_addrs.length.should eq 0
+      expect(mail.from_addrs.length).to eq 0
     end
 
     it "should have a to_addrs method" do
       mail = Mail.new do
         to 'mikel@test.lindsaar.net'
       end
-      mail.to_addrs.length.should eq 1
+      expect(mail.to_addrs.length).to eq 1
     end
 
     it "should have a to_addrs method that is empty if nil" do
       mail = Mail.new do
       end
-      mail.to_addrs.length.should eq 0
+      expect(mail.to_addrs.length).to eq 0
     end
 
     it "should have a cc_addrs method" do
       mail = Mail.new do
         cc 'bob@test.lindsaar.net'
       end
-      mail.cc_addrs.length.should eq 1
+      expect(mail.cc_addrs.length).to eq 1
     end
 
     it "should have a cc_addrs method that is empty if nil" do
       mail = Mail.new do
       end
-      mail.cc_addrs.length.should eq 0
+      expect(mail.cc_addrs.length).to eq 0
     end
 
     it "should have a bcc_addrs method" do
       mail = Mail.new do
         bcc 'sam@test.lindsaar.net'
       end
-      mail.bcc_addrs.length.should eq 1
+      expect(mail.bcc_addrs.length).to eq 1
     end
 
     it "should have a bcc_addrs method that is empty if nil" do
       mail = Mail.new do
       end
-      mail.bcc_addrs.length.should eq 0
+      expect(mail.bcc_addrs.length).to eq 0
     end
 
     it "should give destinations even if some of the fields are blank" do
       mail = Mail.new do
         to 'mikel@test.lindsaar.net'
       end
-      mail.destinations.length.should eq 1
+      expect(mail.destinations.length).to eq 1
     end
 
     it "should be able to encode with only one destination" do
@@ -1479,12 +1479,12 @@ describe Mail::Message do
 
       end
 
-      mail.parts.first.should be_multipart
-      mail.parts.first.parts.length.should eq 2
-      mail.parts.first.parts[0][:content_type].string.should eq "text/plain"
-      mail.parts.first.parts[0].body.decoded.should eq "test text\nline #2"
-      mail.parts.first.parts[1][:content_type].string.should eq "text/html"
-      mail.parts.first.parts[1].body.decoded.should eq "<b>test</b> HTML<br/>\nline #2"
+      expect(mail.parts.first).to be_multipart
+      expect(mail.parts.first.parts.length).to eq 2
+      expect(mail.parts.first.parts[0][:content_type].string).to eq "text/plain"
+      expect(mail.parts.first.parts[0].body.decoded).to eq "test text\nline #2"
+      expect(mail.parts.first.parts[1][:content_type].string).to eq "text/html"
+      expect(mail.parts.first.parts[1].body.decoded).to eq "<b>test</b> HTML<br/>\nline #2"
     end
   end
 
@@ -1492,7 +1492,7 @@ describe Mail::Message do
     it "should return self after delivery" do
       mail = Mail.new
       mail.perform_deliveries = false
-      mail.deliver.should eq mail
+      expect(mail.deliver).to eq mail
     end
 
     class DeliveryAgent
@@ -1503,7 +1503,7 @@ describe Mail::Message do
     it "should pass self to a delivery agent" do
       mail = Mail.new
       mail.delivery_handler = DeliveryAgent
-      DeliveryAgent.should_receive(:deliver_mail).with(mail)
+      expect(DeliveryAgent).to receive(:deliver_mail).with(mail)
       mail.deliver
     end
 
@@ -1516,7 +1516,7 @@ describe Mail::Message do
       mail = Mail.new(:from => 'bob@example.com', :to => 'bobette@example.com')
       mail.delivery_method :test
       Mail.register_observer(ObserverAgent)
-      ObserverAgent.should_receive(:delivered_email).with(mail)
+      expect(ObserverAgent).to receive(:delivered_email).with(mail)
       mail.deliver
     end
 
@@ -1524,7 +1524,7 @@ describe Mail::Message do
       mail = Mail.new
       mail.delivery_handler = DeliveryAgent
       Mail.register_observer(ObserverAgent)
-      ObserverAgent.should_receive(:delivered_email).with(mail)
+      expect(ObserverAgent).to receive(:delivered_email).with(mail)
       mail.deliver
     end
 
@@ -1544,7 +1544,7 @@ describe Mail::Message do
       mail = Mail.new(:from => 'bob@example.com', :to => 'bobette@example.com')
       mail.delivery_method :test
       Mail.register_interceptor(InterceptorAgent)
-      InterceptorAgent.should_receive(:delivering_email).with(mail)
+      expect(InterceptorAgent).to receive(:delivering_email).with(mail)
       InterceptorAgent.intercept = true
       mail.deliver
       InterceptorAgent.intercept = false
@@ -1558,7 +1558,7 @@ describe Mail::Message do
       InterceptorAgent.intercept = true
       mail.deliver
       InterceptorAgent.intercept = false
-      mail.to.should eq ['bob@example.com']
+      expect(mail.to).to eq ['bob@example.com']
     end
 
   end
@@ -1566,12 +1566,12 @@ describe Mail::Message do
   describe "error handling" do
     it "should collect up any of its fields' errors" do
       mail = Mail.new("Content-Transfer-Encoding: vl@d\r\nReply-To: a b b\r\n")
-      mail.errors.should_not be_blank
-      mail.errors.size.should eq 2
-      mail.errors[0][0].should eq 'Reply-To'
-      mail.errors[0][1].should eq 'a b b'
-      mail.errors[1][0].should eq 'Content-Transfer-Encoding'
-      mail.errors[1][1].should eq 'vl@d'
+      expect(mail.errors).not_to be_blank
+      expect(mail.errors.size).to eq 2
+      expect(mail.errors[0][0]).to eq 'Reply-To'
+      expect(mail.errors[0][1]).to eq 'a b b'
+      expect(mail.errors[1][0]).to eq 'Content-Transfer-Encoding'
+      expect(mail.errors[1][1]).to eq 'vl@d'
     end
   end
 
@@ -1579,16 +1579,16 @@ describe Mail::Message do
     it "should handle mail[] and keep the header case" do
       mail = Mail.new
       mail['X-Foo-Bar'] = "Some custom text"
-      mail.to_s.should match(/X-Foo-Bar: Some custom text/)
+      expect(mail.to_s).to match(/X-Foo-Bar: Some custom text/)
     end
   end
 
   describe "parsing emails with non usascii in the header" do
     it "should work" do
       mail = Mail.new('From: "Foo áëô îü" <extended@example.net>')
-      mail.from.should eq ['extended@example.net']
-      mail[:from].decoded.should eq '"Foo áëô îü" <extended@example.net>'
-      mail[:from].encoded.should eq "From: =?UTF-8?B?Rm9vIMOhw6vDtCDDrsO8?= <extended@example.net>\r\n"
+      expect(mail.from).to eq ['extended@example.net']
+      expect(mail[:from].decoded).to eq '"Foo áëô îü" <extended@example.net>'
+      expect(mail[:from].encoded).to eq "From: =?UTF-8?B?Rm9vIMOhw6vDtCDDrsO8?= <extended@example.net>\r\n"
     end
   end
 
@@ -1602,23 +1602,23 @@ describe Mail::Message do
       p.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
       mail.add_part(p)
       mail.encoded
-      mail.parts[0].mime_type.should eq "multipart/alternative"
-      mail.parts[0].parts[0].mime_type.should eq "text/plain"
-      mail.parts[0].parts[1].mime_type.should eq "text/html"
-      mail.parts[1].mime_type.should eq "image/png"
+      expect(mail.parts[0].mime_type).to eq "multipart/alternative"
+      expect(mail.parts[0].parts[0].mime_type).to eq "text/plain"
+      expect(mail.parts[0].parts[1].mime_type).to eq "text/html"
+      expect(mail.parts[1].mime_type).to eq "image/png"
     end
   end
 
   describe "attachment query methods" do
     it "shouldn't die with an invalid Content-Disposition header" do
       mail = Mail.new('Content-Disposition: invalid')
-      doing { mail.attachment? }.should_not raise_error
+      expect(doing { mail.attachment? }).not_to raise_error
     end
 
     it "shouldn't die with an invalid Content-Type header" do
       mail = Mail.new('Content-Type: invalid/invalid; charset="iso-8859-1"')
       mail.attachment?
-      doing { mail.attachment? }.should_not raise_error
+      expect(doing { mail.attachment? }).not_to raise_error
     end
 
   end
@@ -1631,12 +1631,12 @@ describe Mail::Message do
       emails_with_attachments.each { |email|
         mail = Mail.read(fixture(File.join('emails', 'attachment_emails', "attachment_#{email}.eml")))
         mail_length_with_attachments = mail.to_s.length
-        mail.has_attachments?.should be_true
+        expect(mail.has_attachments?).to be_true
         mail.without_attachments!
 
         mail_length_without_attachments = mail.to_s.length
-        mail_length_without_attachments.should be < mail_length_with_attachments
-        mail.has_attachments?.should be_false
+        expect(mail_length_without_attachments).to be < mail_length_with_attachments
+        expect(mail.has_attachments?).to be_false
       }
     end
   end
@@ -1650,37 +1650,37 @@ describe Mail::Message do
       end
 
       it "should create a new message" do
-        @mail.reply.should be_a_kind_of(Mail::Message)
+        expect(@mail.reply).to be_a_kind_of(Mail::Message)
       end
 
       it "should be in-reply-to the original message" do
-        @mail.reply.in_reply_to.should eq '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
+        expect(@mail.reply.in_reply_to).to eq '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
       end
 
       it "should reference the original message" do
-        @mail.reply.references.should eq '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
+        expect(@mail.reply.references).to eq '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
       end
 
       it "should RE: the original subject" do
-        @mail.reply.subject.should eq 'RE: Testing 123'
+        expect(@mail.reply.subject).to eq 'RE: Testing 123'
       end
 
       it "should be sent to the original sender" do
-        @mail.reply.to.should eq ['test@lindsaar.net']
-        @mail.reply[:to].to_s.should eq 'Mikel Lindsaar <test@lindsaar.net>'
+        expect(@mail.reply.to).to eq ['test@lindsaar.net']
+        expect(@mail.reply[:to].to_s).to eq 'Mikel Lindsaar <test@lindsaar.net>'
       end
 
       it "should be sent from the original recipient" do
-        @mail.reply.from.should eq ['raasdnil@gmail.com']
-        @mail.reply[:from].to_s.should eq 'Mikel Lindsaar <raasdnil@gmail.com>'
+        expect(@mail.reply.from).to eq ['raasdnil@gmail.com']
+        expect(@mail.reply[:from].to_s).to eq 'Mikel Lindsaar <raasdnil@gmail.com>'
       end
 
       it "should accept args" do
-        @mail.reply(:from => 'Donald Ball <donald.ball@gmail.com>').from.should eq ['donald.ball@gmail.com']
+        expect(@mail.reply(:from => 'Donald Ball <donald.ball@gmail.com>').from).to eq ['donald.ball@gmail.com']
       end
 
       it "should accept a block" do
-        @mail.reply { from('Donald Ball <donald.ball@gmail.com>') }.from.should eq ['donald.ball@gmail.com']
+        expect(@mail.reply { from('Donald Ball <donald.ball@gmail.com>') }.from).to eq ['donald.ball@gmail.com']
       end
 
     end
@@ -1692,7 +1692,7 @@ describe Mail::Message do
       end
 
       it "should be sent to the reply-to address" do
-        @mail.reply[:to].to_s.should eq '"Mary Smith: Personal Account" <smith@home.example>'
+        expect(@mail.reply[:to].to_s).to eq '"Mary Smith: Personal Account" <smith@home.example>'
       end
 
     end
@@ -1704,7 +1704,7 @@ describe Mail::Message do
       end
 
       it "should be sent from the first to address" do
-        @mail.reply[:from].to_s.should eq 'Mary Smith <mary@x.test>'
+        expect(@mail.reply[:from].to_s).to eq 'Mary Smith <mary@x.test>'
       end
 
     end
@@ -1716,15 +1716,15 @@ describe Mail::Message do
       end
 
       it "should be in-reply-to the original message" do
-        @mail.reply.in_reply_to.should eq '473FFE27.20003@xxx.org'
+        expect(@mail.reply.in_reply_to).to eq '473FFE27.20003@xxx.org'
       end
 
       it "should append to the original's references list" do
-        @mail.reply[:references].message_ids.should eq ['473FF3B8.9020707@xxx.org', '348F04F142D69C21-291E56D292BC@xxxx.net', '473FFE27.20003@xxx.org']
+        expect(@mail.reply[:references].message_ids).to eq ['473FF3B8.9020707@xxx.org', '348F04F142D69C21-291E56D292BC@xxxx.net', '473FFE27.20003@xxx.org']
       end
 
       it "should not append another RE:" do
-        @mail.reply.subject.should eq "Re: Test reply email"
+        expect(@mail.reply.subject).to eq "Re: Test reply email"
       end
 
     end
@@ -1739,7 +1739,7 @@ describe Mail::Message do
       end
 
       it "should have a references consisting of the in-reply-to and message_id fields" do
-        @mail.reply[:references].message_ids.should eq ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
+        expect(@mail.reply[:references].message_ids).to eq ['1234@test.lindsaar.net', '5678@test.lindsaar.net']
       end
 
     end
@@ -1755,7 +1755,7 @@ describe Mail::Message do
 
       # Behavior is actually not defined in RFC2822, so we'll just leave it empty
       it "should have no references header" do
-        @mail.references.should be_nil
+        expect(@mail.references).to be_nil
       end
 
     end
@@ -1764,7 +1764,7 @@ describe Mail::Message do
 
   describe 'SMTP envelope From' do
     it 'should respond' do
-      Mail::Message.new.should respond_to(:smtp_envelope_from)
+      expect(Mail::Message.new).to respond_to(:smtp_envelope_from)
     end
 
     it 'should default to return_path, sender, or first from address' do
@@ -1773,32 +1773,32 @@ describe Mail::Message do
         sender 'sender'
         from 'from'
       end
-      message.smtp_envelope_from.should eq 'return'
+      expect(message.smtp_envelope_from).to eq 'return'
 
       message.return_path = nil
-      message.smtp_envelope_from.should eq 'sender'
+      expect(message.smtp_envelope_from).to eq 'sender'
 
       message.sender = nil
-      message.smtp_envelope_from.should eq 'from'
+      expect(message.smtp_envelope_from).to eq 'from'
     end
 
     it 'can be overridden' do
       message = Mail::Message.new { return_path 'return' }
 
       message.smtp_envelope_from = 'envelope_from'
-      message.smtp_envelope_from.should eq 'envelope_from'
+      expect(message.smtp_envelope_from).to eq 'envelope_from'
 
       message.smtp_envelope_from = 'declared_from'
-      message.smtp_envelope_from.should eq 'declared_from'
+      expect(message.smtp_envelope_from).to eq 'declared_from'
 
       message.smtp_envelope_from = nil
-      message.smtp_envelope_from.should eq 'return'
+      expect(message.smtp_envelope_from).to eq 'return'
     end
   end
 
   describe 'SMTP envelope To' do
     it 'should respond' do
-      Mail::Message.new.should respond_to(:smtp_envelope_to)
+      expect(Mail::Message.new).to respond_to(:smtp_envelope_to)
     end
 
     it 'should default to destinations' do
@@ -1807,20 +1807,20 @@ describe Mail::Message do
         cc 'cc'
         bcc 'bcc'
       end
-      message.smtp_envelope_to.should eq message.destinations
+      expect(message.smtp_envelope_to).to eq message.destinations
     end
 
     it 'can be overridden' do
       message = Mail::Message.new { to 'to' }
 
       message.smtp_envelope_to = 'envelope_to'
-      message.smtp_envelope_to.should eq %w(envelope_to)
+      expect(message.smtp_envelope_to).to eq %w(envelope_to)
 
       message.smtp_envelope_to = 'declared_to'
-      message.smtp_envelope_to.should eq %w(declared_to)
+      expect(message.smtp_envelope_to).to eq %w(declared_to)
 
       message.smtp_envelope_to = nil
-      message.smtp_envelope_to.should eq %w(to)
+      expect(message.smtp_envelope_to).to eq %w(to)
     end
   end
 

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -7,105 +7,105 @@ describe "MIME Emails" do
 
       it "should read a mime version from an email" do
         mail = Mail.new("Mime-Version: 1.0")
-        mail.mime_version.should eq '1.0'
+        expect(mail.mime_version).to eq '1.0'
       end
 
       it "should return nil if the email has no mime version" do
         mail = Mail.new("To: bob")
-        mail.mime_version.should eq nil
+        expect(mail.mime_version).to eq nil
       end
 
       it "should read the content-transfer-encoding" do
         mail = Mail.new("Content-Transfer-Encoding: quoted-printable")
-        mail.content_transfer_encoding.should eq 'quoted-printable'
+        expect(mail.content_transfer_encoding).to eq 'quoted-printable'
       end
 
       it "should read the content-description" do
         mail = Mail.new("Content-Description: This is a description")
-        mail.content_description.should eq 'This is a description'
+        expect(mail.content_description).to eq 'This is a description'
       end
 
       it "should return the content-type" do
         mail = Mail.new("Content-Type: text/plain")
-        mail.mime_type.should eq 'text/plain'
+        expect(mail.mime_type).to eq 'text/plain'
       end
 
       it "should return the charset" do
         mail = Mail.new("Content-Type: text/plain; charset=utf-8")
-        mail.charset.should eq 'utf-8'
+        expect(mail.charset).to eq 'utf-8'
       end
 
       it "should allow you to set the charset" do
         mail = Mail.new
         mail.charset = 'utf-8'
-        mail.charset.should eq 'utf-8'
+        expect(mail.charset).to eq 'utf-8'
       end
 
       it "should return the main content-type" do
         mail = Mail.new("Content-Type: text/plain")
-        mail.main_type.should eq 'text'
+        expect(mail.main_type).to eq 'text'
       end
 
       it "should return the sub content-type" do
         mail = Mail.new("Content-Type: text/plain")
-        mail.sub_type.should eq 'plain'
+        expect(mail.sub_type).to eq 'plain'
       end
 
       it "should return the content-type parameters" do
         mail = Mail.new("Content-Type: text/plain; charset=US-ASCII; format=flowed")
-        mail.content_type_parameters.should eql({"charset" => 'US-ASCII', "format" => 'flowed'})
+        expect(mail.content_type_parameters).to eql({"charset" => 'US-ASCII', "format" => 'flowed'})
       end
 
       it "should recognize a multipart email" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email7.eml'))
-        mail.should be_multipart
+        expect(mail).to be_multipart
       end
 
       it "should recognize a non multipart email" do
         mail = Mail.read(fixture('emails', 'plain_emails', 'basic_email.eml'))
-        mail.should_not be_multipart
+        expect(mail).not_to be_multipart
       end
 
       it "should not report the email as :attachment?" do
         mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_pdf.eml')))
-        mail.attachment?.should eq false
+        expect(mail.attachment?).to eq false
       end
 
       it "should report the email as :attachment?" do
         mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_only_email.eml')))
-        mail.attachment?.should eq true
+        expect(mail.attachment?).to eq true
       end
 
       it "should recognize an attachment part" do
         mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_pdf.eml')))
-        mail.should_not be_attachment
-        mail.parts[0].attachment?.should eq false
-        mail.parts[1].attachment?.should eq true
+        expect(mail).not_to be_attachment
+        expect(mail.parts[0].attachment?).to eq false
+        expect(mail.parts[1].attachment?).to eq true
       end
 
       it "should give how may (top level) parts there are" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email7.eml'))
-        mail.parts.length.should eq 2
+        expect(mail.parts.length).to eq 2
       end
 
       it "should give the content_type of each part" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email11.eml'))
-        mail.mime_type.should eq 'multipart/alternative'
-        mail.parts[0].mime_type.should eq 'text/plain'
-        mail.parts[1].mime_type.should eq 'text/enriched'
+        expect(mail.mime_type).to eq 'multipart/alternative'
+        expect(mail.parts[0].mime_type).to eq 'text/plain'
+        expect(mail.parts[1].mime_type).to eq 'text/enriched'
       end
 
       it "should report the mail :has_attachments?" do
         mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_pdf.eml')))
-        mail.should be_has_attachments
+        expect(mail).to be_has_attachments
       end
 
       it "should only split on exact boundary matches" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'email_with_similar_boundaries.eml'))
-        mail.parts.size.should eq 2
-        mail.parts.first.parts.size.should eq 2
-        mail.boundary.should eq "----=_NextPart_476c4fde88e507bb8028170e8cf47c73"
-        mail.parts.first.boundary.should eq "----=_NextPart_476c4fde88e507bb8028170e8cf47c73_alt"
+        expect(mail.parts.size).to eq 2
+        expect(mail.parts.first.parts.size).to eq 2
+        expect(mail.boundary).to eq "----=_NextPart_476c4fde88e507bb8028170e8cf47c73"
+        expect(mail.parts.first.boundary).to eq "----=_NextPart_476c4fde88e507bb8028170e8cf47c73_alt"
       end
     end
 
@@ -115,13 +115,13 @@ describe "MIME Emails" do
           part('This is a part')
           part('This is another part')
         end
-        mail.boundary.should_not be_nil
+        expect(mail.boundary).not_to be_nil
       end
 
       it "should not add a boundary for a message that is only an attachment" do
         mail = Mail.new
         mail.attachments['test.png'] = "2938492384923849"
-        mail.boundary.should be_nil
+        expect(mail.boundary).to be_nil
       end
     end
 
@@ -129,62 +129,62 @@ describe "MIME Emails" do
 
       it "should know what its boundary is if it is a multipart document" do
         mail = Mail.new('Content-Type: multipart/mixed; boundary="--==Boundary"')
-        mail.boundary.should eq "--==Boundary"
+        expect(mail.boundary).to eq "--==Boundary"
       end
 
       it "should return nil if there is no content-type defined" do
         mail = Mail.new
-        mail.boundary.should eq nil
+        expect(mail.boundary).to eq nil
       end
 
       it "should assign the text part and allow you to reference" do
         mail = Mail.new
         text_mail = Mail.new("This is Text")
         mail.text_part = text_mail
-        mail.text_part.should eq text_mail
+        expect(mail.text_part).to eq text_mail
       end
 
       it "should not assign a nil text part" do
         mail = Mail.new
         mail.text_part = nil
-        mail.text_part.should be_nil
+        expect(mail.text_part).to be_nil
       end
 
       it "should assign the html part and allow you to reference" do
         mail = Mail.new
         html_mail = Mail.new("<b>This is HTML</b>")
         mail.html_part = html_mail
-        mail.html_part.should eq html_mail
+        expect(mail.html_part).to eq html_mail
       end
 
       it "should not assign a nil html part" do
         mail = Mail.new
         mail.html_part = nil
-        mail.html_part.should be_nil
+        expect(mail.html_part).to be_nil
       end
 
       it "should set default content type on assigned text and html parts" do
         mail = Mail.new
         mail.text_part = Mail.new
-        mail.text_part.content_type.should eq 'text/plain'
+        expect(mail.text_part.content_type).to eq 'text/plain'
         mail.html_part = Mail.new
-        mail.html_part.content_type.should eq 'text/html'
+        expect(mail.html_part.content_type).to eq 'text/html'
       end
 
       it "should set default content type on declared text and html parts" do
         mail = Mail.new
         mail.text_part { }
-        mail.text_part.content_type.should eq 'text/plain'
+        expect(mail.text_part.content_type).to eq 'text/plain'
         mail.html_part { }
-        mail.html_part.content_type.should eq 'text/html'
+        expect(mail.html_part.content_type).to eq 'text/html'
       end
 
       it "should not override content type" do
         mail = Mail.new
         mail.text_part { content_type 'text/plain+foo' }
-        mail.text_part.content_type.should eq 'text/plain+foo'
+        expect(mail.text_part.content_type).to eq 'text/plain+foo'
         mail.html_part { content_type 'text/html+foo' }
-        mail.html_part.content_type.should eq 'text/html+foo'
+        expect(mail.html_part.content_type).to eq 'text/html+foo'
       end
 
       it "should add the html part and text part" do
@@ -196,33 +196,33 @@ describe "MIME Emails" do
           content_type "text/html; charset=US-ASCII"
           body "<b>This is HTML</b>"
         end
-        mail.parts.length.should eq 2
-        mail.parts.first.class.should eq Mail::Part
-        mail.parts.last.class.should eq Mail::Part
+        expect(mail.parts.length).to eq 2
+        expect(mail.parts.first.class).to eq Mail::Part
+        expect(mail.parts.last.class).to eq Mail::Part
       end
 
       it "should remove the html part and back out of multipart/alternative if set to nil" do
         mail = Mail.new
         mail.text_part = Mail::Part.new
         mail.html_part = Mail::Part.new
-        mail.parts.length.should eq 2
+        expect(mail.parts.length).to eq 2
 
         mail.html_part = nil
-        mail.parts.length.should eq 1
-        mail.boundary.should be_nil
-        mail.content_type.should be_nil
+        expect(mail.parts.length).to eq 1
+        expect(mail.boundary).to be_nil
+        expect(mail.content_type).to be_nil
       end
 
       it "should remove the text part and back out of multipart/alternative if set to nil" do
         mail = Mail.new
         mail.text_part = Mail::Part.new
         mail.html_part = Mail::Part.new
-        mail.parts.length.should eq 2
+        expect(mail.parts.length).to eq 2
 
         mail.text_part = nil
-        mail.parts.length.should eq 1
-        mail.boundary.should be_nil
-        mail.content_type.should be_nil
+        expect(mail.parts.length).to eq 1
+        expect(mail.boundary).to be_nil
+        expect(mail.content_type).to be_nil
       end
 
       it "should set the content type to multipart/alternative if you assign html and text parts" do
@@ -234,26 +234,26 @@ describe "MIME Emails" do
           content_type "text/html; charset=US-ASCII"
           body "<b>This is HTML</b>"
         end
-        mail.to_s.should =~ %r|Content-Type: multipart/alternative;\s+boundary="#{mail.boundary}"|
+        expect(mail.to_s).to match(%r|Content-Type: multipart/alternative;\s+boundary="#{mail.boundary}"|)
       end
 
       it "should set the content type to multipart/alternative if you declare html and text parts" do
         mail = Mail.new
         mail.text_part { }
         mail.html_part { }
-        mail.to_s.should =~ %r|Content-Type: multipart/alternative;\s+boundary="#{mail.boundary}"|
+        expect(mail.to_s).to match(%r|Content-Type: multipart/alternative;\s+boundary="#{mail.boundary}"|)
       end
 
       it "should not set the content type to multipart/alternative if you declare an html part but not a text part" do
         mail = Mail.new
         mail.html_part { }
-        mail.to_s.should_not =~ %r|Content-Type: multipart/alternative;\s+boundary="#{mail.boundary}"|
+        expect(mail.to_s).not_to match(%r|Content-Type: multipart/alternative;\s+boundary="#{mail.boundary}"|)
       end
 
       it "should not set the content type to multipart/alternative if you declare a text part but not an html part" do
         mail = Mail.new
         mail.text_part { }
-        mail.to_s.should_not =~ %r|Content-Type: multipart/alternative;\s+boundary="#{mail.boundary}"|
+        expect(mail.to_s).not_to match(%r|Content-Type: multipart/alternative;\s+boundary="#{mail.boundary}"|)
       end
 
       it "should add the end boundary tag" do
@@ -265,7 +265,7 @@ describe "MIME Emails" do
           content_type "text/html; charset=US-ASCII"
           body "<b>This is HTML</b>"
         end
-        mail.to_s.should =~ %r|#{mail.boundary}--|
+        expect(mail.to_s).to match(%r|#{mail.boundary}--|)
       end
 
       it "should not put message-ids into parts" do
@@ -278,8 +278,8 @@ describe "MIME Emails" do
           body "<b>This is HTML</b>"
         end
         mail.to_s
-        mail.parts.first.message_id.should be_nil
-        mail.parts.last.message_id.should be_nil
+        expect(mail.parts.first.message_id).to be_nil
+        expect(mail.parts.last.message_id).to be_nil
       end
 
       it "should create a multipart/alternative email through a block" do
@@ -295,20 +295,20 @@ describe "MIME Emails" do
             body '<h1>This is HTML</h1>'
           end
         end
-        mail.should be_multipart
-        mail.parts.length.should eq 2
-        mail.text_part.class.should eq Mail::Part
-        mail.text_part.body.to_s.should eq 'This is plain text'
-        mail.html_part.class.should eq Mail::Part
-        mail.html_part.body.to_s.should eq '<h1>This is HTML</h1>'
+        expect(mail).to be_multipart
+        expect(mail.parts.length).to eq 2
+        expect(mail.text_part.class).to eq Mail::Part
+        expect(mail.text_part.body.to_s).to eq 'This is plain text'
+        expect(mail.html_part.class).to eq Mail::Part
+        expect(mail.html_part.body.to_s).to eq '<h1>This is HTML</h1>'
       end
 
       it "should detect an html_part in an existing email" do
         m = Mail.new(:content_type => 'multipart/alternative')
         m.add_part(Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT'))
         m.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
-        m.text_part.body.decoded.should eq 'PLAIN TEXT'
-        m.html_part.body.decoded.should eq 'HTML TEXT'
+        expect(m.text_part.body.decoded).to eq 'PLAIN TEXT'
+        expect(m.html_part.body.decoded).to eq 'HTML TEXT'
       end
 
       it "should detect a text_part in an existing email with plain text attachment" do
@@ -316,8 +316,8 @@ describe "MIME Emails" do
         m.add_file(fixture('attachments', 'てすと.txt'))
         m.add_part(Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT'))
         m.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
-        m.text_part.body.decoded.should eq 'PLAIN TEXT'
-        m.html_part.body.decoded.should eq 'HTML TEXT'
+        expect(m.text_part.body.decoded).to eq 'PLAIN TEXT'
+        expect(m.html_part.body.decoded).to eq 'HTML TEXT'
       end
 
       it "should detect an html_part in a multi level mime email" do
@@ -328,8 +328,8 @@ describe "MIME Emails" do
         p.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
         m.add_part(p)
         m.add_part(a)
-        m.text_part.body.decoded.should eq 'PLAIN TEXT'
-        m.html_part.body.decoded.should eq 'HTML TEXT'
+        expect(m.text_part.body.decoded).to eq 'PLAIN TEXT'
+        expect(m.html_part.body.decoded).to eq 'HTML TEXT'
       end
 
       it "should only the first part on a stupidly overly complex email" do
@@ -352,8 +352,8 @@ describe "MIME Emails" do
         d.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN 3 TEXT'))
         b.add_part(d)
 
-        m.text_part.body.decoded.should eq 'PLAIN TEXT'
-        m.html_part.body.decoded.should eq 'HTML TEXT'
+        expect(m.text_part.body.decoded).to eq 'PLAIN TEXT'
+        expect(m.html_part.body.decoded).to eq 'HTML TEXT'
       end
 
     end
@@ -362,15 +362,15 @@ describe "MIME Emails" do
 
       it "should return an array of attachments" do
         mail = Mail.read(fixture('emails', 'attachment_emails', 'attachment_content_disposition.eml'))
-        mail.attachments.length.should eq 1
-        mail.attachments.first.filename.should eq 'hello.rb'
+        expect(mail.attachments.length).to eq 1
+        expect(mail.attachments.first.filename).to eq 'hello.rb'
       end
 
       it "should return an array of attachments" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email_with_nested_attachment.eml'))
-        mail.attachments.length.should eq 2
-        mail.attachments[0].filename.should eq 'byo-ror-cover.png'
-        mail.attachments[1].filename.should eq 'smime.p7s'
+        expect(mail.attachments.length).to eq 2
+        expect(mail.attachments[0].filename).to eq 'byo-ror-cover.png'
+        expect(mail.attachments[1].filename).to eq 'smime.p7s'
       end
 
     end
@@ -381,32 +381,32 @@ describe "MIME Emails" do
         mail = Mail::Message.new
         mail.text_part { body("log message goes here") }
         mail.add_file(fixture('attachments', 'test.png'))
-        mail.mime_type.should eq 'multipart/mixed'
+        expect(mail.mime_type).to eq 'multipart/mixed'
       end
 
       it "should set to multipart/mixed if you add an attachment and then a text part" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'test.png'))
         mail.text_part { body("log message goes here") }
-        mail.mime_type.should eq 'multipart/mixed'
+        expect(mail.mime_type).to eq 'multipart/mixed'
       end
 
       it "should add a part given a filename" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'test.png'))
-        mail.parts.length.should eq 1 # First part is an empty text body
+        expect(mail.parts.length).to eq 1 # First part is an empty text body
       end
 
       it "should give the part the right content type" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'test.png'))
-        mail.parts.first[:content_type].content_type.should eq 'image/png'
+        expect(mail.parts.first[:content_type].content_type).to eq 'image/png'
       end
 
       it "should return attachment objects" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'test.png'))
-        mail.attachments.first.class.should eq Mail::Part
+        expect(mail.attachments.first.class).to eq Mail::Part
       end
 
       it "should be return an aray of attachments" do
@@ -419,8 +419,8 @@ describe "MIME Emails" do
           add_file fixture('attachments', 'test.pdf')
           add_file fixture('attachments', 'test.zip')
         end
-        mail.attachments.length.should eq 4
-        mail.attachments.each { |a| a.class.should eq Mail::Part }
+        expect(mail.attachments.length).to eq 4
+        mail.attachments.each { |a| expect(a.class).to eq Mail::Part }
       end
 
       it "should return the filename of each attachment" do
@@ -433,10 +433,10 @@ describe "MIME Emails" do
           add_file fixture('attachments', 'test.pdf')
           add_file fixture('attachments', 'test.zip')
         end
-        mail.attachments[0].filename.should eq 'test.png'
-        mail.attachments[1].filename.should eq 'test.jpg'
-        mail.attachments[2].filename.should eq 'test.pdf'
-        mail.attachments[3].filename.should eq 'test.zip'
+        expect(mail.attachments[0].filename).to eq 'test.png'
+        expect(mail.attachments[1].filename).to eq 'test.jpg'
+        expect(mail.attachments[2].filename).to eq 'test.pdf'
+        expect(mail.attachments[3].filename).to eq 'test.zip'
       end
 
       it "should return the type/subtype of each attachment" do
@@ -449,10 +449,10 @@ describe "MIME Emails" do
           add_file fixture('attachments', 'test.pdf')
           add_file fixture('attachments', 'test.zip')
         end
-        mail.attachments[0].mime_type.should eq 'image/png'
-        mail.attachments[1].mime_type.should eq 'image/jpeg'
-        mail.attachments[2].mime_type.should eq 'application/pdf'
-        mail.attachments[3].mime_type.should eq 'application/zip'
+        expect(mail.attachments[0].mime_type).to eq 'image/png'
+        expect(mail.attachments[1].mime_type).to eq 'image/jpeg'
+        expect(mail.attachments[2].mime_type).to eq 'application/pdf'
+        expect(mail.attachments[3].mime_type).to eq 'application/zip'
       end
 
       it "should return the content of each attachment" do
@@ -468,21 +468,21 @@ describe "MIME Emails" do
         if RUBY_VERSION >= '1.9'
           tripped = mail.attachments[0].decoded
           original = File.open(fixture('attachments', 'test.png'), 'rb', &:read)
-          tripped.should eq original
+          expect(tripped).to eq original
           tripped = mail.attachments[1].decoded
           original = File.open(fixture('attachments', 'test.jpg'), 'rb', &:read)
-          tripped.should eq original
+          expect(tripped).to eq original
           tripped = mail.attachments[2].decoded
           original = File.open(fixture('attachments', 'test.pdf'), 'rb', &:read)
-          tripped.should eq original
+          expect(tripped).to eq original
           tripped = mail.attachments[3].decoded
           original = File.open(fixture('attachments', 'test.zip'), 'rb', &:read)
-          tripped.should eq original
+          expect(tripped).to eq original
         else
-          mail.attachments[0].decoded.should eq File.read(fixture('attachments', 'test.png'))
-          mail.attachments[1].decoded.should eq File.read(fixture('attachments', 'test.jpg'))
-          mail.attachments[2].decoded.should eq File.read(fixture('attachments', 'test.pdf'))
-          mail.attachments[3].decoded.should eq File.read(fixture('attachments', 'test.zip'))
+          expect(mail.attachments[0].decoded).to eq File.read(fixture('attachments', 'test.png'))
+          expect(mail.attachments[1].decoded).to eq File.read(fixture('attachments', 'test.jpg'))
+          expect(mail.attachments[2].decoded).to eq File.read(fixture('attachments', 'test.pdf'))
+          expect(mail.attachments[3].decoded).to eq File.read(fixture('attachments', 'test.zip'))
         end
       end
 
@@ -497,9 +497,9 @@ describe "MIME Emails" do
         if RUBY_VERSION >= '1.9'
           tripped = mail.attachments[0].decoded
           original = File.open(fixture('attachments', 'test.png'), 'rb', &:read)
-          tripped.should eq original
+          expect(tripped).to eq original
         else
-          mail.attachments[0].decoded.should eq File.open(fixture('attachments', 'test.png'), 'rb', &:read)
+          expect(mail.attachments[0].decoded).to eq File.open(fixture('attachments', 'test.png'), 'rb', &:read)
         end
       end
 
@@ -511,10 +511,10 @@ describe "MIME Emails" do
           body    "Attached"
           add_file fixture('attachments', 'test.png')
         end
-        m.attachments.length.should eq 1
-        m.parts.length.should eq 2
-        m.parts[0].body.should eq "Attached"
-        m.parts[1].filename.should eq "test.png"
+        expect(m.attachments.length).to eq 1
+        expect(m.parts.length).to eq 2
+        expect(m.parts[0].body).to eq "Attached"
+        expect(m.parts[1].filename).to eq "test.png"
       end
 
       it "should allow you to add a body as text part if you have added a file" do
@@ -525,9 +525,9 @@ describe "MIME Emails" do
           add_file fixture('attachments', 'test.png')
           body    "Attached"
         end
-        m.parts.length.should eq 2
-        m.parts.first[:content_type].content_type.should eq 'image/png'
-        m.parts.last[:content_type].content_type.should eq 'text/plain'
+        expect(m.parts.length).to eq 2
+        expect(m.parts.first[:content_type].content_type).to eq 'image/png'
+        expect(m.parts.last[:content_type].content_type).to eq 'text/plain'
       end
 
       it "should allow you to add a body as text part if you have added a file and not truncate after newlines - issue 208" do
@@ -539,10 +539,10 @@ describe "MIME Emails" do
           body    "First Line\n\nSecond Line\n\nThird Line\n\n"
           #Note: trailing \n\n is stripped off by Mail::Part initialization
         end
-        m.parts.length.should eq 2
-        m.parts.first[:content_type].content_type.should eq 'image/png'
-        m.parts.last[:content_type].content_type.should eq 'text/plain'
-        m.parts.last.to_s.should match(/^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/)
+        expect(m.parts.length).to eq 2
+        expect(m.parts.first[:content_type].content_type).to eq 'image/png'
+        expect(m.parts.last[:content_type].content_type).to eq 'text/plain'
+        expect(m.parts.last.to_s).to match(/^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/)
       end
 
       it "should not raise a warning if there is a charset defined and there are non ascii chars in the body" do
@@ -551,7 +551,7 @@ describe "MIME Emails" do
         mail.body = body
         mail.charset = 'UTF-8'
         mail.add_file fixture('attachments', 'test.png')
-        STDERR.should_not_receive(:puts)
+        expect(STDERR).not_to receive(:puts)
         mail.to_s
       end
 

--- a/spec/mail/multibyte_spec.rb
+++ b/spec/mail/multibyte_spec.rb
@@ -6,12 +6,12 @@ describe "multibyte/chars" do
 
   it "should upcase" do
     chars = Chars.new('Laurent, où sont les tests ?')
-    chars.upcase.should == "LAURENT, OÙ SONT LES TESTS ?"
+    expect(chars.upcase).to eq("LAURENT, OÙ SONT LES TESTS ?")
   end
 
   it "should downcase" do
     chars = Chars.new('VĚDA A VÝZKUM')
-    chars.downcase.should == "věda a výzkum"
+    expect(chars.downcase).to eq("věda a výzkum")
   end
 end
 

--- a/spec/mail/multipart_report_spec.rb
+++ b/spec/mail/multipart_report_spec.rb
@@ -5,39 +5,39 @@ describe "multipart/report emails" do
   
   it "should know if it is a multipart report type" do
     mail = Mail.read(fixture('emails', 'multipart_report_emails', 'report_422.eml'))
-    mail.should be_multipart_report
+    expect(mail).to be_multipart_report
   end
   
   describe "delivery-status reports" do
     
     it "should know if it is a deliver-status report" do
       mail = Mail.read(fixture('emails', 'multipart_report_emails', 'report_422.eml'))
-      mail.should be_delivery_status_report
+      expect(mail).to be_delivery_status_report
     end
 
     it "should find its message/delivery-status part" do
       mail = Mail.read(fixture('emails', 'multipart_report_emails', 'report_422.eml'))
-      mail.delivery_status_part.should_not be_nil
+      expect(mail.delivery_status_part).not_to be_nil
     end
     
     it "should handle a report that has a human readable message/delivery-status" do
       mail = Mail.read(fixture('emails', 'multipart_report_emails', 'multipart_report_multiple_status.eml'))
-      mail.should be_bounced
+      expect(mail).to be_bounced
     end
 
     describe "multipart reports with more than one address" do
       it "should not crash" do
         mail1 = Mail.read(fixture('emails', 'multipart_report_emails', 'multi_address_bounce1.eml'))
         mail2 = Mail.read(fixture('emails', 'multipart_report_emails', 'multi_address_bounce2.eml'))
-        doing { mail1.bounced? }.should_not raise_error
-        doing { mail2.bounced? }.should_not raise_error
+        expect(doing { mail1.bounced? }).not_to raise_error
+        expect(doing { mail2.bounced? }).not_to raise_error
       end
 
       it "should not know that a multi address email was bounced" do
         mail1 = Mail.read(fixture('emails', 'multipart_report_emails', 'multi_address_bounce1.eml'))
         mail2 = Mail.read(fixture('emails', 'multipart_report_emails', 'multi_address_bounce2.eml'))
-        mail1.should be_bounced
-        mail2.should be_bounced
+        expect(mail1).to be_bounced
+        expect(mail2).to be_bounced
       end
     end
 
@@ -48,31 +48,31 @@ describe "multipart/report emails" do
       end
       
       it "should be bounced" do
-        @mail.should_not be_bounced
+        expect(@mail).not_to be_bounced
       end
       
       it "should say action 'delayed'" do
-        @mail.action.should eq 'delayed'
+        expect(@mail.action).to eq 'delayed'
       end
       
       it "should give a final recipient" do
-        @mail.final_recipient.should eq 'RFC822; fraser@oooooooo.com.au'
+        expect(@mail.final_recipient).to eq 'RFC822; fraser@oooooooo.com.au'
       end
       
       it "should give an error code" do
-        @mail.error_status.should eq '4.2.2'
+        expect(@mail.error_status).to eq '4.2.2'
       end
       
       it "should give a diagostic code" do
-        @mail.diagnostic_code.should eq 'SMTP; 452 4.2.2 <fraser@oooooooo.com.au>... Mailbox full'
+        expect(@mail.diagnostic_code).to eq 'SMTP; 452 4.2.2 <fraser@oooooooo.com.au>... Mailbox full'
       end
       
       it "should give a remote-mta" do
-        @mail.remote_mta.should eq 'DNS; mail.oooooooo.com.au'
+        expect(@mail.remote_mta).to eq 'DNS; mail.oooooooo.com.au'
       end
       
       it "should be retryable" do
-        @mail.should be_retryable
+        expect(@mail).to be_retryable
       end
     end
 
@@ -83,31 +83,31 @@ describe "multipart/report emails" do
       end
       
       it "should be bounced" do
-        @mail.should be_bounced
+        expect(@mail).to be_bounced
       end
       
       it "should say action 'failed'" do
-        @mail.action.should eq 'failed'
+        expect(@mail.action).to eq 'failed'
       end
       
       it "should give a final recipient" do
-        @mail.final_recipient.should eq 'RFC822; edwin@zzzzzzz.com'
+        expect(@mail.final_recipient).to eq 'RFC822; edwin@zzzzzzz.com'
       end
       
       it "should give an error code" do
-        @mail.error_status.should eq '5.3.0'
+        expect(@mail.error_status).to eq '5.3.0'
       end
       
       it "should give a diagostic code" do
-        @mail.diagnostic_code.should eq 'SMTP; 553 5.3.0 <edwin@zzzzzzz.com>... Unknown E-Mail Address'
+        expect(@mail.diagnostic_code).to eq 'SMTP; 553 5.3.0 <edwin@zzzzzzz.com>... Unknown E-Mail Address'
       end
       
       it "should give a remote-mta" do
-        @mail.remote_mta.should eq 'DNS; mail.zzzzzz.com'
+        expect(@mail.remote_mta).to eq 'DNS; mail.zzzzzz.com'
       end
       
       it "should be retryable" do
-        @mail.should_not be_retryable
+        expect(@mail).not_to be_retryable
       end
     end
 

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -27,7 +27,7 @@ describe "exim delivery agent" do
       subject 'invalid RFC2822'
     end
     
-    Mail::Exim.should_receive(:call).with('/usr/sbin/exim', 
+    expect(Mail::Exim).to receive(:call).with('/usr/sbin/exim', 
                                           '-i -t -f "roger@test.lindsaar.net" --', 
                                           '"marcel@test.lindsaar.net" "bob@test.lindsaar.net"', 
                                           mail.encoded)
@@ -51,7 +51,7 @@ describe "exim delivery agent" do
         body "body"
       end
       
-      Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
+      expect(Mail::Exim).to receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "return@test.lindsaar.net" --', 
                                                 '"to@test.lindsaar.net"', 
                                                 mail.encoded)
@@ -74,7 +74,7 @@ describe "exim delivery agent" do
         body "body"
       end
 
-      Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
+      expect(Mail::Exim).to receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "sender@test.lindsaar.net" --', 
                                                 '"to@test.lindsaar.net"', 
                                                 mail.encoded)
@@ -95,7 +95,7 @@ describe "exim delivery agent" do
         body "body"
       end
 
-      Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
+      expect(Mail::Exim).to receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "from@test.lindsaar.net" --', 
                                                 '"to@test.lindsaar.net"', 
                                                 mail.encoded)
@@ -115,7 +115,7 @@ describe "exim delivery agent" do
         body 'body'
       end
 
-      Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
+      expect(Mail::Exim).to receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "\"from+suffix test\"@test.lindsaar.net" --',
                                                 '"to@test.lindsaar.net"',
                                                 mail.encoded)
@@ -132,7 +132,7 @@ describe "exim delivery agent" do
         from 'from@test.lindsaar.net'
       end
 
-      Mail::Exim.should_receive(:call).with('/usr/sbin/exim',
+      expect(Mail::Exim).to receive(:call).with('/usr/sbin/exim',
                                                 '-i -t -f "from@test.lindsaar.net" --',
                                                 '"-hyphen@test.lindsaar.net"',
                                                 mail.encoded)
@@ -151,7 +151,7 @@ describe "exim delivery agent" do
       subject 'invalid RFC2822'
     end
     
-    Mail::Exim.should_receive(:call).with('/usr/sbin/exim', 
+    expect(Mail::Exim).to receive(:call).with('/usr/sbin/exim', 
                                               ' -f "from@test.lindsaar.net" --',
                                               '"marcel@test.lindsaar.net" "bob@test.lindsaar.net"', 
                                               mail.encoded)
@@ -169,7 +169,7 @@ describe "exim delivery agent" do
       subject 'invalid RFC2822'
     end
     
-    Mail::Exim.should_receive(:call).with('/usr/sbin/exim', 
+    expect(Mail::Exim).to receive(:call).with('/usr/sbin/exim', 
                                               " -f \"\\\"foo\\\\\\\"\\;touch /tmp/PWNED\\;\\\\\\\"\\\"@blah.com\" --",
                                               '"marcel@test.lindsaar.net"', 
                                               mail.encoded)
@@ -180,25 +180,25 @@ describe "exim delivery agent" do
     Mail.defaults do
       delivery_method :test
     end
-    lambda do
+    expect do
       Mail.deliver do
         to "to@somemail.com"
         subject "Email with no sender"
         body "body"
       end
-    end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+    end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
   end
 
   it "should raise an error if no recipient if defined" do
     Mail.defaults do
       delivery_method :test
     end
-    lambda do
+    expect do
       Mail.deliver do
         from "from@somemail.com"
         subject "Email with no recipient"
         body "body"
       end
-    end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+    end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
   end
 end

--- a/spec/mail/network/delivery_methods/file_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/file_delivery_spec.rb
@@ -15,14 +15,14 @@ describe "SMTP Delivery Method" do
                                :enable_starttls_auto => true  }
     end
   end
-  
+
   after(:each) do
     files = Dir.glob(File.join(Mail.delivery_method.settings[:location], '*'))
     files.each do |file|
       File.delete(file)
     end
   end
-  
+
   describe "general usage" do
     tmpdir = File.expand_path('../../../../tmp/mail', __FILE__)
 
@@ -30,15 +30,15 @@ describe "SMTP Delivery Method" do
       Mail.defaults do
         delivery_method :file, :location => tmpdir
       end
-      
+
       mail = Mail.deliver do
         from    'roger@moore.com'
         to      'marcel@amont.com'
         subject 'invalid RFC2822'
       end
-      
+
       delivery = File.join(Mail.delivery_method.settings[:location], 'marcel@amont.com')
-      
+
       File.read(delivery).should eq mail.encoded
     end
 
@@ -46,16 +46,16 @@ describe "SMTP Delivery Method" do
       Mail.defaults do
         delivery_method :file, :location => tmpdir
       end
-      
+
       mail = Mail.deliver do
         from    'roger@moore.com'
         to      'marcel@amont.com, bob@me.com'
         subject 'invalid RFC2822'
       end
-      
+
       delivery_one = File.join(Mail.delivery_method.settings[:location], 'marcel@amont.com')
       delivery_two = File.join(Mail.delivery_method.settings[:location], 'bob@me.com')
-      
+
       File.read(delivery_one).should eq mail.encoded
       File.read(delivery_two).should eq mail.encoded
     end
@@ -64,21 +64,21 @@ describe "SMTP Delivery Method" do
       Mail.defaults do
         delivery_method :file, :location => tmpdir
       end
-      
+
       Mail.deliver do
         from    'roger@moore.com'
         to      '"Long, stupid email address" <mikel@test.lindsaar.net>'
         subject 'invalid RFC2822'
       end
       delivery = File.join(Mail.delivery_method.settings[:location], 'mikel@test.lindsaar.net')
-      File.exists?(delivery).should be_true
+      File.exist?(delivery).should be_true
     end
 
     it "should use the base name of the file name to prevent file system traversal" do
       Mail.defaults do
         delivery_method :file, :location => tmpdir
       end
-      
+
       Mail.deliver do
         from    'roger@moore.com'
         to      '../../../../../../../../../../../tmp/pwn'
@@ -86,7 +86,7 @@ describe "SMTP Delivery Method" do
       end
 
       delivery = File.join(Mail.delivery_method.settings[:location], 'pwn')
-      File.exists?(delivery).should be_true
+      File.exist?(delivery).should be_true
     end
 
     it "should raise an error if no sender is defined" do
@@ -118,5 +118,5 @@ describe "SMTP Delivery Method" do
     end
 
   end
-  
+
 end

--- a/spec/mail/network/delivery_methods/file_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/file_delivery_spec.rb
@@ -39,7 +39,7 @@ describe "SMTP Delivery Method" do
 
       delivery = File.join(Mail.delivery_method.settings[:location], 'marcel@amont.com')
 
-      File.read(delivery).should eq mail.encoded
+      expect(File.read(delivery)).to eq mail.encoded
     end
 
     it "should send multiple emails to multiple files" do
@@ -56,8 +56,8 @@ describe "SMTP Delivery Method" do
       delivery_one = File.join(Mail.delivery_method.settings[:location], 'marcel@amont.com')
       delivery_two = File.join(Mail.delivery_method.settings[:location], 'bob@me.com')
 
-      File.read(delivery_one).should eq mail.encoded
-      File.read(delivery_two).should eq mail.encoded
+      expect(File.read(delivery_one)).to eq mail.encoded
+      expect(File.read(delivery_two)).to eq mail.encoded
     end
 
     it "should only create files based on the addr_spec of the destination" do
@@ -71,7 +71,7 @@ describe "SMTP Delivery Method" do
         subject 'invalid RFC2822'
       end
       delivery = File.join(Mail.delivery_method.settings[:location], 'mikel@test.lindsaar.net')
-      File.exist?(delivery).should be_true
+      expect(File.exist?(delivery)).to be_true
     end
 
     it "should use the base name of the file name to prevent file system traversal" do
@@ -86,7 +86,7 @@ describe "SMTP Delivery Method" do
       end
 
       delivery = File.join(Mail.delivery_method.settings[:location], 'pwn')
-      File.exist?(delivery).should be_true
+      expect(File.exist?(delivery)).to be_true
     end
 
     it "should raise an error if no sender is defined" do
@@ -94,13 +94,13 @@ describe "SMTP Delivery Method" do
         delivery_method :file, :location => tmpdir
       end
 
-      lambda do
+      expect do
         Mail.deliver do
           to "to@somemail.com"
           subject "Email with no sender"
           body "body"
         end
-      end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+      end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
     end
 
     it "should raise an error if no recipient if defined" do
@@ -108,13 +108,13 @@ describe "SMTP Delivery Method" do
         delivery_method :file, :location => tmpdir
       end
 
-      lambda do
+      expect do
         Mail.deliver do
           from "from@somemail.com"
           subject "Email with no recipient"
           body "body"
         end
-      end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+      end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
     end
 
   end

--- a/spec/mail/network/delivery_methods/sendmail_spec.rb
+++ b/spec/mail/network/delivery_methods/sendmail_spec.rb
@@ -27,7 +27,7 @@ describe "sendmail delivery agent" do
       subject 'invalid RFC2822'
     end
     
-    Mail::Sendmail.should_receive(:call).with('/usr/sbin/sendmail', 
+    expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/sendmail', 
                                               '-i -f "roger@test.lindsaar.net" --',
                                               '"marcel@test.lindsaar.net" "bob@test.lindsaar.net"', 
                                               mail.encoded)
@@ -45,7 +45,7 @@ describe "sendmail delivery agent" do
       subject 'invalid RFC2822'
     end
 
-    Mail::Sendmail.should_receive(:popen).with('/usr/sbin/sendmail -i -f "roger@test.lindsaar.net" -- "marcel@test.lindsaar.net" "bob@test.lindsaar.net"')
+    expect(Mail::Sendmail).to receive(:popen).with('/usr/sbin/sendmail -i -f "roger@test.lindsaar.net" -- "marcel@test.lindsaar.net" "bob@test.lindsaar.net"')
 
     mail.deliver!
   end
@@ -67,7 +67,7 @@ describe "sendmail delivery agent" do
         smtp_envelope_from 'smtp_from@test.lindsaar.net'
       end
 
-      Mail::Sendmail.should_receive(:call).with('/usr/sbin/sendmail',
+      expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/sendmail',
                                                 '-i -f "smtp_from@test.lindsaar.net" --',
                                                 '"to@test.lindsaar.net"', 
                                                 mail.encoded)
@@ -89,7 +89,7 @@ describe "sendmail delivery agent" do
         body 'body'
       end
 
-      Mail::Sendmail.should_receive(:call).with('/usr/sbin/sendmail',
+      expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/sendmail',
                                                 '-i -f "\"from+suffix test\"@test.lindsaar.net" --',
                                                 '"to@test.lindsaar.net"',
                                                 mail.encoded)
@@ -114,7 +114,7 @@ describe "sendmail delivery agent" do
         smtp_envelope_to 'smtp_to@test.lindsaar.net'
       end
 
-      Mail::Sendmail.should_receive(:call).with('/usr/sbin/sendmail',
+      expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/sendmail',
                                                 '-i -f "from@test.lindsaar.net" --',
                                                 '"smtp_to@test.lindsaar.net"',
                                                 mail.encoded)
@@ -134,7 +134,7 @@ describe "sendmail delivery agent" do
         body 'body'
       end
 
-      Mail::Sendmail.should_receive(:call).with('/usr/sbin/sendmail',
+      expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/sendmail',
                                                 '-i -f "from@test.lindsaar.net" --',
                                                 '"\"to+suffix test\"@test.lindsaar.net"',
                                                 mail.encoded)
@@ -151,7 +151,7 @@ describe "sendmail delivery agent" do
         from 'from@test.lindsaar.net'
       end
 
-      Mail::Sendmail.should_receive(:call).with('/usr/sbin/sendmail',
+      expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/sendmail',
                                                 '-i -f "from@test.lindsaar.net" --',
                                                 '"-hyphen@test.lindsaar.net"',
                                                 mail.encoded)
@@ -170,7 +170,7 @@ describe "sendmail delivery agent" do
       subject 'invalid RFC2822'
     end
     
-    Mail::Sendmail.should_receive(:call).with('/usr/sbin/sendmail', 
+    expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/sendmail', 
                                               ' -f "from@test.lindsaar.net" --',
                                               '"marcel@test.lindsaar.net" "bob@test.lindsaar.net"', 
                                               mail.encoded)
@@ -188,7 +188,7 @@ describe "sendmail delivery agent" do
       subject 'invalid RFC2822'
     end
     
-    Mail::Sendmail.should_receive(:call).with('/usr/sbin/sendmail', 
+    expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/sendmail', 
                                               " -f \"\\\"foo\\\\\\\"\\;touch /tmp/PWNED\\;\\\\\\\"\\\"@blah.com\" --",
                                               %("\\\"foo\\\\\\\"\\;touch /tmp/PWNED\\;\\\\\\\"\\\"@blah.com"), 
                                               mail.encoded)
@@ -199,25 +199,25 @@ describe "sendmail delivery agent" do
     Mail.defaults do
       delivery_method :test
     end
-    lambda do
+    expect do
       Mail.deliver do
         to "to@somemail.com"
         subject "Email with no sender"
         body "body"
       end
-    end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+    end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
   end
 
   it "should raise an error if no recipient if defined" do
     Mail.defaults do
       delivery_method :test
     end
-    lambda do
+    expect do
       Mail.deliver do
         from "from@somemail.com"
         subject "Email with no recipient"
         body "body"
       end
-    end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+    end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
   end
 end

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -24,9 +24,9 @@ describe "SMTP Delivery Method" do
       smtp_envelope_to 'smtp_to'
     end
 
-    MockSMTP.deliveries[0][0].should eq mail.encoded
-    MockSMTP.deliveries[0][1].should eq 'smtp_from'
-    MockSMTP.deliveries[0][2].should eq %w(smtp_to)
+    expect(MockSMTP.deliveries[0][0]).to eq mail.encoded
+    expect(MockSMTP.deliveries[0][1]).to eq 'smtp_from'
+    expect(MockSMTP.deliveries[0][2]).to eq %w(smtp_to)
   end
 
   it "should be able to return actual SMTP protocol response" do
@@ -42,7 +42,7 @@ describe "SMTP Delivery Method" do
     end
 
     response = mail.deliver!
-    response.should eq 'OK'
+    expect(response).to eq 'OK'
 
   end
 
@@ -53,13 +53,13 @@ describe "SMTP Delivery Method" do
       delivery_method :smtp_connection, :connection => smtp, :port => 587, :return_response => true
     end
 
-    lambda do
+    expect do
       Mail.deliver do
         to "to@somemail.com"
         subject "Email with no sender"
         body "body"
       end
-    end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+    end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
   end
 
   it "should raise an error if no recipient if defined" do
@@ -68,12 +68,12 @@ describe "SMTP Delivery Method" do
       delivery_method :smtp_connection, :connection => smtp, :port => 587, :return_response => true
     end
 
-    lambda do
+    expect do
       Mail.deliver do
         from "from@somemail.com"
         subject "Email with no recipient"
         body "body"
       end
-    end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+    end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
   end
 end

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -34,9 +34,9 @@ describe "SMTP Delivery Method" do
         smtp_envelope_to 'smtp_to'
       end
 
-      MockSMTP.deliveries[0][0].should eq mail.encoded
-      MockSMTP.deliveries[0][1].should eq 'smtp_from'
-      MockSMTP.deliveries[0][2].should eq %w(smtp_to)
+      expect(MockSMTP.deliveries[0][0]).to eq mail.encoded
+      expect(MockSMTP.deliveries[0][1]).to eq 'smtp_from'
+      expect(MockSMTP.deliveries[0][2]).to eq %w(smtp_to)
     end
 
     it "should be able to send itself" do
@@ -48,9 +48,9 @@ describe "SMTP Delivery Method" do
 
       mail.deliver!
 
-      MockSMTP.deliveries[0][0].should eq mail.encoded
-      MockSMTP.deliveries[0][1].should eq mail.from[0]
-      MockSMTP.deliveries[0][2].should eq mail.destinations
+      expect(MockSMTP.deliveries[0][0]).to eq mail.encoded
+      expect(MockSMTP.deliveries[0][1]).to eq mail.from[0]
+      expect(MockSMTP.deliveries[0][2]).to eq mail.destinations
     end
     
     it "should be able to return actual SMTP protocol response" do
@@ -65,7 +65,7 @@ describe "SMTP Delivery Method" do
       end
       
       response = mail.deliver!
-      response.should eq 'OK'
+      expect(response).to eq 'OK'
       
     end
   end
@@ -91,7 +91,7 @@ describe "SMTP Delivery Method" do
         subject 'invalid RFC2822'
       end
 
-      doing { mail.deliver! }.should_not raise_error(TypeError)
+      expect(doing { mail.deliver! }).not_to raise_error
     end
     
     it "should ignore OpenSSL::SSL::VERIFY_NONE if it is 0" do
@@ -108,7 +108,7 @@ describe "SMTP Delivery Method" do
         subject 'invalid RFC2822'
       end
 
-      doing { mail.deliver! }.should_not raise_error(TypeError)
+      expect(doing { mail.deliver! }).not_to raise_error
     end
   end
   
@@ -132,7 +132,7 @@ describe "SMTP Delivery Method" do
         subject 'invalid RFC2822'
       end
 
-      doing { mail.deliver! }.should_not raise_error(TypeError)
+      expect(doing { mail.deliver! }).not_to raise_error
     end
     
     it "should ignore OpenSSL::SSL::VERIFY_NONE if it is 0" do
@@ -149,7 +149,7 @@ describe "SMTP Delivery Method" do
         subject 'invalid RFC2822'
       end
 
-      doing { mail.deliver! }.should_not raise_error(TypeError)
+      expect(doing { mail.deliver! }).not_to raise_error
     end
   end
 
@@ -165,28 +165,28 @@ describe "SMTP Delivery Method" do
         smtp_envelope_to "smtp_to@someemail.com"
         smtp_envelope_from "smtp_from@someemail.com"
       end
-      MockSMTP.deliveries[0][1].should eq 'smtp_from@someemail.com'
-      MockSMTP.deliveries[0][2].should eq %w(smtp_to@someemail.com)
+      expect(MockSMTP.deliveries[0][1]).to eq 'smtp_from@someemail.com'
+      expect(MockSMTP.deliveries[0][2]).to eq %w(smtp_to@someemail.com)
     end
 
     it "should raise if there is no envelope From address" do
-      lambda do
+      expect do
         Mail.deliver do
           to "to@somemail.com"
           subject "Email with no sender"
           body "body"
         end
-      end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+      end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
     end
 
     it "should raise an error if no recipient if defined" do
-      lambda do
+      expect do
         Mail.deliver do
           from "from@somemail.com"
           subject "Email with no recipient"
           body "body"
         end
-      end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+      end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
     end
   end
 

--- a/spec/mail/network/delivery_methods/test_mailer_spec.rb
+++ b/spec/mail/network/delivery_methods/test_mailer_spec.rb
@@ -20,7 +20,7 @@ describe "Mail::TestMailer" do
     Mail.defaults do
       delivery_method :test
     end
-    Mail::TestMailer.deliveries.should be_empty
+    expect(Mail::TestMailer.deliveries).to be_empty
   end
 
   it "should deliver an email to the Mail::TestMailer.deliveries array" do
@@ -34,8 +34,8 @@ describe "Mail::TestMailer" do
       body 'hello'
     end
     mail.deliver
-    Mail::TestMailer.deliveries.length.should eq 1
-    Mail::TestMailer.deliveries.first.should eq mail
+    expect(Mail::TestMailer.deliveries.length).to eq 1
+    expect(Mail::TestMailer.deliveries.first).to eq mail
   end
 
   it "should clear the deliveries when told to" do
@@ -49,38 +49,38 @@ describe "Mail::TestMailer" do
       body 'hello'
     end
     mail.deliver
-    Mail::TestMailer.deliveries.length.should eq 1
+    expect(Mail::TestMailer.deliveries.length).to eq 1
     Mail::TestMailer.deliveries.clear
-    Mail::TestMailer.deliveries.should be_empty
+    expect(Mail::TestMailer.deliveries).to be_empty
   end
 
   it "should raise an error if no sender is defined" do
     Mail.defaults do
       delivery_method :test
     end
-    lambda do
+    expect do
       Mail.deliver do
         to "to@somemail.com"
         subject "Email with no sender"
         body "body"
       end
-    end.should raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+    end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
   end
 
   it "should raise an error if no recipient if defined" do
     Mail.defaults do
       delivery_method :test
     end
-    lambda do
+    expect do
       Mail.deliver do
         from "from@somemail.com"
         subject "Email with no recipient"
         body "body"
       end
-    end.should raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+    end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
   end
 
   it "should save settings passed to initialize" do
-    Mail::TestMailer.new(:setting => true).settings.should include(:setting => true)
+    expect(Mail::TestMailer.new(:setting => true).settings).to include(:setting => true)
   end
 end

--- a/spec/mail/network/retriever_methods/imap_spec.rb
+++ b/spec/mail/network/retriever_methods/imap_spec.rb
@@ -15,101 +15,101 @@ describe "IMAP Retriever" do
 
   describe "find with and without block" do
     it "should find all emails with a given block" do
-      MockIMAP.should be_disconnected
+      expect(MockIMAP).to be_disconnected
 
       messages = []
       Mail.all do |message|
         messages << message
       end
-      messages.map { |m| m.raw_source }.sort.should eq MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
+      expect(messages.map { |m| m.raw_source }.sort).to eq MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
 
-      MockIMAP.should be_disconnected
+      expect(MockIMAP).to be_disconnected
     end
     it "should get all emails without a given block" do
-      MockIMAP.should be_disconnected
+      expect(MockIMAP).to be_disconnected
 
       messages = Mail.all
-      messages.map { |m| m.raw_source }.sort.should eq MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
+      expect(messages.map { |m| m.raw_source }.sort).to eq MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
 
-      MockIMAP.should be_disconnected
+      expect(MockIMAP).to be_disconnected
     end
     it "should get all emails and yield the imap, uid, and email when given a block of arity 3" do
-      MockIMAP.should be_disconnected
+      expect(MockIMAP).to be_disconnected
 
       messages = []
       uids = []
       Mail.all do |message, imap, uid|
-        MockIMAP.should === imap
+        expect(MockIMAP).to be === imap
         messages << message
         uids << uid
       end
-      messages.map { |m| m.raw_source }.sort.should eq MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
-      uids.sort.should eq MockIMAP.examples.map { |m| m.number }.sort
+      expect(messages.map { |m| m.raw_source }.sort).to eq MockIMAP.examples.map { |m| m.attr['RFC822']}.sort
+      expect(uids.sort).to eq MockIMAP.examples.map { |m| m.number }.sort
 
-      MockIMAP.should be_disconnected
+      expect(MockIMAP).to be_disconnected
     end
   end
 
   describe "find and options" do
     it "should handle the :count option" do
       messages = Mail.find(:count => :all, :what => :last, :order => :asc)
-      messages.map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822'] }
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }
 
       message = Mail.find(:count => 1, :what => :last)
-      message.raw_source.should eq MockIMAP.examples.last.attr['RFC822']
+      expect(message.raw_source).to eq MockIMAP.examples.last.attr['RFC822']
 
       messages = Mail.find(:count => 2, :what => :last, :order => :asc)
-      messages[0..1].map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[-2..-1]
+      expect(messages[0..1].map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[-2..-1]
     end
     it "should handle the :what option" do
       messages = Mail.find(:count => :all, :what => :last)
-      messages.map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822'] }
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }
 
       messages = Mail.find(:count => 2, :what => :first, :order => :asc)
-      messages.map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[0..1]
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[0..1]
     end
     it "should handle the :order option" do
       messages = Mail.find(:order => :desc, :count => 5, :what => :last)
-      messages.map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[-5..-1].reverse
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[-5..-1].reverse
 
       messages = Mail.find(:order => :asc, :count => 5, :what => :last)
-      messages.map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[-5..-1]
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[-5..-1]
     end
     it "should handle the :mailbox option" do
       Mail.find(:mailbox => 'SOME-RANDOM-MAILBOX')
 
-      MockIMAP.mailbox.should eq 'SOME-RANDOM-MAILBOX'
+      expect(MockIMAP.mailbox).to eq 'SOME-RANDOM-MAILBOX'
     end
     it "should handle the :uid option" do
       messages = Mail.find(:uid => 1)
 
-      messages[0].raw_source.should eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[1]
+      expect(messages[0].raw_source).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }[1]
     end
     it "should find the last 10 messages by default" do
       messages = Mail.find
 
-      messages.size.should eq 10
+      expect(messages.size).to eq 10
     end
     it "should search the mailbox 'INBOX' by default" do
       Mail.find
 
-      MockIMAP.mailbox.should eq 'INBOX'
+      expect(MockIMAP.mailbox).to eq 'INBOX'
     end
 
     it "should handle the delete_after_find_option" do
       Mail.find(:delete_after_find => false)
-      MockIMAP.examples.size.should eq 20
+      expect(MockIMAP.examples.size).to eq 20
 
       Mail.find(:delete_after_find => true)
-      MockIMAP.examples.size.should eq 10
+      expect(MockIMAP.examples.size).to eq 10
 
       Mail.find(:delete_after_find => true) { |message| }
-      MockIMAP.examples.size.should eq 10
+      expect(MockIMAP.examples.size).to eq 10
     end
 
     it "should handle the find_and_delete method" do
       Mail.find_and_delete(:count => 15)
-      MockIMAP.examples.size.should eq 5
+      expect(MockIMAP.examples.size).to eq 5
     end
     
   end
@@ -118,13 +118,13 @@ describe "IMAP Retriever" do
     it "should find the last received messages" do
       messages = Mail.last(:count => 5)
 
-      messages.should be_instance_of(Array)
-      messages.map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822']}[-5..-1]
+      expect(messages).to be_instance_of(Array)
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822']}[-5..-1]
     end
     it "should find the last received message" do
       message = Mail.last
 
-      message.raw_source.should eq MockIMAP.examples.last.attr['RFC822']
+      expect(message.raw_source).to eq MockIMAP.examples.last.attr['RFC822']
     end
   end
 
@@ -132,13 +132,13 @@ describe "IMAP Retriever" do
     it "should find the first received messages" do
       messages = Mail.first(:count => 5)
 
-      messages.should be_instance_of(Array)
-      messages.map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822']}[0..4]
+      expect(messages).to be_instance_of(Array)
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822']}[0..4]
     end
     it "should find the first received message" do
       message = Mail.first
 
-      message.raw_source.should eq MockIMAP.examples.first.attr['RFC822']
+      expect(message.raw_source).to eq MockIMAP.examples.first.attr['RFC822']
     end
   end
 
@@ -146,8 +146,8 @@ describe "IMAP Retriever" do
     it "should find all messages" do
       messages = Mail.all
 
-      messages.size.should eq MockIMAP.examples.size
-      messages.map { |m| m.raw_source }.should eq MockIMAP.examples.map { |m| m.attr['RFC822'] }
+      expect(messages.size).to eq MockIMAP.examples.size
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }
     end
   end
 
@@ -155,20 +155,20 @@ describe "IMAP Retriever" do
     it "should delete all messages" do
       Mail.all
 
-      Net::IMAP.should_receive(:encode_utf7).once
+      expect(Net::IMAP).to receive(:encode_utf7).once
       Mail.delete_all
 
-      MockIMAP.examples.size.should eq 0
+      expect(MockIMAP.examples.size).to eq 0
     end
   end 
 
   describe "connection" do
     it "should raise an Error if no block is given" do
-      lambda { Mail.connection { |m| raise ArgumentError.new } }.should raise_error
+      expect { Mail.connection { |m| raise ArgumentError.new } }.to raise_error
     end
     it "should yield the connection object to the given block" do
       Mail.connection do |connection|
-        connection.should be_an_instance_of(MockIMAP)
+        expect(connection).to be_an_instance_of(MockIMAP)
       end
     end
   end
@@ -178,17 +178,17 @@ describe "IMAP Retriever" do
       retrievable = Mail::IMAP.new({})
       options = retrievable.send(:validate_options, {})
 
-      options[:count].should_not be_blank
-      options[:count].should eq 10
+      expect(options[:count]).not_to be_blank
+      expect(options[:count]).to eq 10
 
-      options[:order].should_not be_blank
-      options[:order].should eq :asc
+      expect(options[:order]).not_to be_blank
+      expect(options[:order]).to eq :asc
 
-      options[:what].should_not be_blank
-      options[:what].should eq :first
+      expect(options[:what]).not_to be_blank
+      expect(options[:what]).to eq :first
 
-      options[:mailbox].should_not be_blank
-      options[:mailbox].should eq 'INBOX'
+      expect(options[:mailbox]).not_to be_blank
+      expect(options[:mailbox]).to eq 'INBOX'
     end
     it "should not replace given configuration" do
       retrievable = Mail::IMAP.new({})
@@ -199,55 +199,55 @@ describe "IMAP Retriever" do
         :what => :first
       })
 
-      options[:count].should_not be_blank
-      options[:count].should eq 2
+      expect(options[:count]).not_to be_blank
+      expect(options[:count]).to eq 2
 
-      options[:order].should_not be_blank
-      options[:order].should eq :asc
+      expect(options[:order]).not_to be_blank
+      expect(options[:order]).to eq :asc
 
-      options[:what].should_not be_blank
-      options[:what].should eq :first
+      expect(options[:what]).not_to be_blank
+      expect(options[:what]).to eq :first
 
-      options[:mailbox].should_not be_blank
-      options[:mailbox].should eq 'some/mail/box'
+      expect(options[:mailbox]).not_to be_blank
+      expect(options[:mailbox]).to eq 'some/mail/box'
     end
     it "should ensure utf7 conversion for mailbox names" do
       retrievable = Mail::IMAP.new({})
 
-      Net::IMAP.stub!(:encode_utf7 => 'UTF7_STRING')
+      Net::IMAP.stub(:encode_utf7 => 'UTF7_STRING')
       options = retrievable.send(:validate_options, {
         :mailbox => 'UTF8_STRING'
       })
-      options[:mailbox].should eq 'UTF7_STRING'
+      expect(options[:mailbox]).to eq 'UTF7_STRING'
     end
   end
 
   describe "error handling" do
     it "should finish the IMAP connection if an exception is raised" do 
-      MockIMAP.should be_disconnected
+      expect(MockIMAP).to be_disconnected
 
-      lambda { Mail.all { |m| raise ArgumentError.new } }.should raise_error
+      expect { Mail.all { |m| raise ArgumentError.new } }.to raise_error
 
-      MockIMAP.should be_disconnected
+      expect(MockIMAP).to be_disconnected
     end
   end
   
   describe "authentication mechanism" do
     before(:each) do
       @imap = MockIMAP.new
-      MockIMAP.stub!(:new).and_return(@imap)
+      allow(MockIMAP).to receive(:new).and_return(@imap)
     end
     it "should be login by default" do
-      @imap.should_not_receive(:authenticate)
-      @imap.should_receive(:login).with('foo', 'secret')
+      expect(@imap).not_to receive(:authenticate)
+      expect(@imap).to receive(:login).with('foo', 'secret')
       Mail.defaults do
         retriever_method :imap, {:user_name => 'foo', :password => 'secret'}
       end
       Mail.find
     end
     it "should be changeable" do
-      @imap.should_receive(:authenticate).with('CRAM-MD5', 'foo', 'secret')
-      @imap.should_not_receive(:login)
+      expect(@imap).to receive(:authenticate).with('CRAM-MD5', 'foo', 'secret')
+      expect(@imap).not_to receive(:login)
       Mail.defaults do
         retriever_method :imap, {:authentication => 'CRAM-MD5', :user_name => 'foo', :password => 'secret'}
       end

--- a/spec/mail/network/retriever_methods/pop3_spec.rb
+++ b/spec/mail/network/retriever_methods/pop3_spec.rb
@@ -18,27 +18,27 @@ describe "POP3 Retriever" do
   describe "find with and without block" do
   
     it "should find all emails with a given block" do
-      MockPOP3.should_not be_started
+      expect(MockPOP3).not_to be_started
       
       messages = []
       Mail.all do |message|
         messages << message
       end
       
-      messages.map { |m| m.raw_source }.sort.should eq MockPOP3.popmails.map { |p| p.pop }.sort
-      MockPOP3.should_not be_started
+      expect(messages.map { |m| m.raw_source }.sort).to eq MockPOP3.popmails.map { |p| p.pop }.sort
+      expect(MockPOP3).not_to be_started
     end
     
     it "should get all emails without a given block" do
-      MockPOP3.should_not be_started
+      expect(MockPOP3).not_to be_started
       
       messages = []
       Mail.all do |message|
         messages << message
       end
       
-      messages.map { |m| m.raw_source }.sort.should eq MockPOP3.popmails.map { |p| p.pop }.sort
-      MockPOP3.should_not be_started
+      expect(messages.map { |m| m.raw_source }.sort).to eq MockPOP3.popmails.map { |p| p.pop }.sort
+      expect(MockPOP3).not_to be_started
     end
   
   end
@@ -47,54 +47,54 @@ describe "POP3 Retriever" do
     
     it "should handle the :count option" do
       messages = Mail.find(:count => :all, :what => :last, :order => :asc)
-      messages.map { |m| m.raw_source }.sort.should eq MockPOP3.popmails.map { |p| p.pop }
+      expect(messages.map { |m| m.raw_source }.sort).to eq MockPOP3.popmails.map { |p| p.pop }
       
       message = Mail.find(:count => 1, :what => :last)
-      message.raw_source.should eq MockPOP3.popmails.map { |p| p.pop }.last
+      expect(message.raw_source).to eq MockPOP3.popmails.map { |p| p.pop }.last
       
       messages = Mail.find(:count => 2, :what => :last, :order => :asc)
-      messages[0..1].collect {|m| m.raw_source}.should eq MockPOP3.popmails.map { |p| p.pop }[-2..-1]
+      expect(messages[0..1].collect {|m| m.raw_source}).to eq MockPOP3.popmails.map { |p| p.pop }[-2..-1]
     end
     
     it "should handle the :what option" do
       messages = Mail.find(:count => :all, :what => :last)
-      messages.map { |m| m.raw_source }.sort.should eq MockPOP3.popmails.map { |p| p.pop }
+      expect(messages.map { |m| m.raw_source }.sort).to eq MockPOP3.popmails.map { |p| p.pop }
       
       messages = Mail.find(:count => 2, :what => :first, :order => :asc)
-      messages.map { |m| m.raw_source }.should eq MockPOP3.popmails.map { |p| p.pop }[0..1]
+      expect(messages.map { |m| m.raw_source }).to eq MockPOP3.popmails.map { |p| p.pop }[0..1]
     end
     
     it "should handle the :order option" do
       messages = Mail.find(:order => :desc, :count => 5, :what => :last)
-      messages.map { |m| m.raw_source }.should eq MockPOP3.popmails.map { |p| p.pop }[-5..-1].reverse
+      expect(messages.map { |m| m.raw_source }).to eq MockPOP3.popmails.map { |p| p.pop }[-5..-1].reverse
       
       messages = Mail.find(:order => :asc, :count => 5, :what => :last)
-      messages.map { |m| m.raw_source }.should eq MockPOP3.popmails.map { |p| p.pop }[-5..-1]
+      expect(messages.map { |m| m.raw_source }).to eq MockPOP3.popmails.map { |p| p.pop }[-5..-1]
     end
     
     it "should find the last 10 messages by default" do
       messages = Mail.find
       
-      messages.size.should eq 10
+      expect(messages.size).to eq 10
     end
 
     it "should handle the delete_after_find option" do
       Mail.find(:delete_after_find => false)
-      MockPOP3.popmails.each { |message| message.should_not be_deleted }
+      MockPOP3.popmails.each { |message| expect(message).not_to be_deleted }
 
       Mail.find(:delete_after_find => true)
-      MockPOP3.popmails.first(10).each { |message| message.should be_deleted }
-      MockPOP3.popmails.last(10).each { |message| message.should_not be_deleted }
+      MockPOP3.popmails.first(10).each { |message| expect(message).to be_deleted }
+      MockPOP3.popmails.last(10).each { |message| expect(message).not_to be_deleted }
 
       Mail.find(:delete_after_find => true) { |message| }
-      MockPOP3.popmails.first(10).each { |message| message.should be_deleted }
-      MockPOP3.popmails.last(10).each { |message| message.should_not be_deleted }
+      MockPOP3.popmails.first(10).each { |message| expect(message).to be_deleted }
+      MockPOP3.popmails.last(10).each { |message| expect(message).not_to be_deleted }
     end
 
     it "should handle the find_and_delete method" do
       Mail.find_and_delete(:count => 15)
-      MockPOP3.popmails.first(15).each { |message| message.should be_deleted }
-      MockPOP3.popmails.last(5).each { |message| message.should_not be_deleted }
+      MockPOP3.popmails.first(15).each { |message| expect(message).to be_deleted }
+      MockPOP3.popmails.last(5).each { |message| expect(message).not_to be_deleted }
     end
     
   end
@@ -104,15 +104,15 @@ describe "POP3 Retriever" do
     it "should find the last received messages" do
       messages = Mail.last(:count => 5)
       
-      messages.should be_instance_of(Array)
-      messages.map { |m| m.raw_source }.should eq MockPOP3.popmails.map { |p| p.pop }[-5..-1]
+      expect(messages).to be_instance_of(Array)
+      expect(messages.map { |m| m.raw_source }).to eq MockPOP3.popmails.map { |p| p.pop }[-5..-1]
     end
     
     it "should find the last received message" do
       message = Mail.last
       
-      message.should be_instance_of(Mail::Message)
-      message.raw_source.should eq MockPOP3.popmails.last.pop
+      expect(message).to be_instance_of(Mail::Message)
+      expect(message.raw_source).to eq MockPOP3.popmails.last.pop
     end
     
   end
@@ -122,15 +122,15 @@ describe "POP3 Retriever" do
     it "should find the first received messages" do
       messages = Mail.first(:count => 5)
       
-      messages.should be_instance_of(Array)
-      messages.map { |m| m.raw_source }.should eq MockPOP3.popmails.map { |p| p.pop }[0..4]
+      expect(messages).to be_instance_of(Array)
+      expect(messages.map { |m| m.raw_source }).to eq MockPOP3.popmails.map { |p| p.pop }[0..4]
     end
     
     it "should find the first received message" do
       message = Mail.first
       
-      message.should be_instance_of(Mail::Message)
-      message.raw_source.should eq MockPOP3.popmails.first.pop
+      expect(message).to be_instance_of(Mail::Message)
+      expect(message.raw_source).to eq MockPOP3.popmails.first.pop
     end
     
   end
@@ -140,8 +140,8 @@ describe "POP3 Retriever" do
     it "should find all messages" do
       messages = Mail.all
       
-      messages.size.should eq MockPOP3.popmails.size
-      messages.map { |m| m.raw_source }.should eq MockPOP3.popmails.map { |p| p.pop }
+      expect(messages.size).to eq MockPOP3.popmails.size
+      expect(messages.map { |m| m.raw_source }).to eq MockPOP3.popmails.map { |p| p.pop }
     end
     
   end
@@ -151,17 +151,17 @@ describe "POP3 Retriever" do
       Mail.all
       Mail.delete_all
     
-      MockPOP3.popmails.size.should eq 0
+      expect(MockPOP3.popmails.size).to eq 0
     end
   end
   
   describe "connection" do
     it "should raise an Error if no block is given" do
-      lambda { Mail.connection { |m| raise ArgumentError.new } }.should raise_error
+      expect { Mail.connection { |m| raise ArgumentError.new } }.to raise_error
     end
     it "should yield the connection object to the given block" do
       Mail.connection do |connection|
-        connection.should be_an_instance_of(MockPOP3)
+        expect(connection).to be_an_instance_of(MockPOP3)
       end
     end
   end
@@ -172,14 +172,14 @@ describe "POP3 Retriever" do
       retrievable = Mail::POP3.new({})
       options = retrievable.send(:validate_options, {})
       
-      options[:count].should_not be_blank
-      options[:count].should eq 10
+      expect(options[:count]).not_to be_blank
+      expect(options[:count]).to eq 10
       
-      options[:order].should_not be_blank
-      options[:order].should eq :asc
+      expect(options[:order]).not_to be_blank
+      expect(options[:order]).to eq :asc
       
-      options[:what].should_not be_blank
-      options[:what].should eq :first
+      expect(options[:what]).not_to be_blank
+      expect(options[:what]).to eq :first
     end
     
     it "should not replace given configuration" do
@@ -190,14 +190,14 @@ describe "POP3 Retriever" do
         :what => :first
       })
       
-      options[:count].should_not be_blank
-      options[:count].should eq 2
+      expect(options[:count]).not_to be_blank
+      expect(options[:count]).to eq 2
       
-      options[:order].should_not be_blank
-      options[:order].should eq :asc
+      expect(options[:order]).not_to be_blank
+      expect(options[:order]).to eq :asc
       
-      options[:what].should_not be_blank
-      options[:what].should eq :first
+      expect(options[:what]).not_to be_blank
+      expect(options[:what]).to eq :first
     end
     
   end
@@ -205,13 +205,13 @@ describe "POP3 Retriever" do
   describe "error handling" do
   
     it "should finish the POP3 connection is an exception is raised" do
-      MockPOP3.should_not be_started
+      expect(MockPOP3).not_to be_started
       
-      doing do
+      expect(doing do
         Mail.all { |m| raise ArgumentError.new }
-      end.should raise_error
+      end).to raise_error
       
-      MockPOP3.should_not be_started
+      expect(MockPOP3).not_to be_started
     end
     
   end

--- a/spec/mail/network/retriever_methods/test_retriever_spec.rb
+++ b/spec/mail/network/retriever_methods/test_retriever_spec.rb
@@ -9,7 +9,7 @@ describe "Test Retriever" do
   end
 
   it "should have no emails initially" do
-    Mail.all.should be_empty
+    expect(Mail.all).to be_empty
   end
 
   describe "all" do
@@ -19,13 +19,13 @@ describe "Test Retriever" do
     end
 
     it "should return all emails without a block" do
-      Mail.all.should eq @emails
+      expect(Mail.all).to eq @emails
     end
 
     it "should return all emails with a block" do
       messages = []
       Mail.all { |message| messages << message }
-      messages.should eq @emails
+      expect(messages).to eq @emails
     end
 
   end
@@ -37,51 +37,51 @@ describe "Test Retriever" do
     end
 
     it "should handle the :count option" do
-      Mail.find(:count => :all).should eq @emails
-      Mail.find(:count => 1).should eq @emails.first
-      Mail.find(:count => 5).should eq @emails[0, 5]
+      expect(Mail.find(:count => :all)).to eq @emails
+      expect(Mail.find(:count => 1)).to eq @emails.first
+      expect(Mail.find(:count => 5)).to eq @emails[0, 5]
     end
 
     it "should handle the :order option" do
-      Mail.find(:order => :asc).should eq @emails
-      Mail.find(:order => :desc).should eq @emails.reverse
+      expect(Mail.find(:order => :asc)).to eq @emails
+      expect(Mail.find(:order => :desc)).to eq @emails.reverse
     end
 
     it "should handle the :what option" do
-      Mail.find(:what => :first).should eq @emails
-      Mail.find(:what => :first, :count => 5).should eq @emails[0, 5]
-      Mail.find(:what => :last).should eq @emails
-      Mail.find(:what => :last, :count => 5).should eq @emails[10, 5]
+      expect(Mail.find(:what => :first)).to eq @emails
+      expect(Mail.find(:what => :first, :count => 5)).to eq @emails[0, 5]
+      expect(Mail.find(:what => :last)).to eq @emails
+      expect(Mail.find(:what => :last, :count => 5)).to eq @emails[10, 5]
     end
 
     it "should handle the both of :what and :order option with :count => 1" do
-      Mail.find(:count => 1, :what => :last, :order => :asc).should eq @emails.last
-      Mail.find(:count => 1, :what => :first, :order => :desc).should eq @emails.first
+      expect(Mail.find(:count => 1, :what => :last, :order => :asc)).to eq @emails.last
+      expect(Mail.find(:count => 1, :what => :first, :order => :desc)).to eq @emails.first
     end
 
     it "should handle the :delete_after_find option" do
-      Mail.find(:delete_after_find => false).should eq @emails
-      Mail.find(:delete_after_find => false).should eq @emails
-      Mail.find(:delete_after_find => true).should eq @emails
-      Mail.find(:delete_after_find => false).should be_empty
+      expect(Mail.find(:delete_after_find => false)).to eq @emails
+      expect(Mail.find(:delete_after_find => false)).to eq @emails
+      expect(Mail.find(:delete_after_find => true)).to eq @emails
+      expect(Mail.find(:delete_after_find => false)).to be_empty
     end
 
     it "should handle the both of :delete_after_find and :count option" do
       expect do
-        Mail.find(:count => 5, :delete_after_find => true).should have(5).items
+        expect(Mail.find(:count => 5, :delete_after_find => true).size).to eq(5)
       end.to change { Mail.all.size }.by(-5)
       expect do
-        Mail.find(:count => 5, :delete_after_find => true).should have(5).items
+        expect(Mail.find(:count => 5, :delete_after_find => true).size).to eq(5)
       end.to change { Mail.all.size }.by(-5)
     end
 
     it "should handle the both of :count and :delete_after_find option" do
       15.times do |idx|
         expect do
-          Mail.find(:count => 1, :delete_after_find => true).should eq @emails[idx]
+          expect(Mail.find(:count => 1, :delete_after_find => true)).to eq @emails[idx]
         end.to change { Mail.all.size }.by(-1)
       end
-      Mail.find(:count => 1, :delete_after_find => true).should be_empty
+      expect(Mail.find(:count => 1, :delete_after_find => true)).to be_empty
     end
 
     it "should handle the :delete_after_find option with messages marked not for delete" do
@@ -94,7 +94,7 @@ describe "Test Retriever" do
         end
         i += 1
       end
-      Mail.all.should eq messages
+      expect(Mail.all).to eq messages
     end
 
   end

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -32,12 +32,12 @@ describe "Mail" do
       Mail.defaults do
         delivery_method :smtp
       end
-      Mail.delivery_method.class.should eq Mail::SMTP
+      expect(Mail.delivery_method.class).to eq Mail::SMTP
     end
 
     it "should default to settings for smtp" do
-      Mail.delivery_method.class.should eq Mail::SMTP
-      Mail.delivery_method.settings.should eql({:address              => "localhost",
+      expect(Mail.delivery_method.class).to eq Mail::SMTP
+      expect(Mail.delivery_method.settings).to eql({:address              => "localhost",
                                                 :port                 => 25,
                                                 :domain               => 'localhost.localdomain',
                                                 :user_name            => nil,
@@ -53,12 +53,12 @@ describe "Mail" do
       Mail.defaults do
         retriever_method :pop3
       end
-      Mail.retriever_method.class.should eq Mail::POP3
+      expect(Mail.retriever_method.class).to eq Mail::POP3
     end
 
     it "should default to settings for pop3" do
-      Mail.retriever_method.class.should eq Mail::POP3
-      Mail.retriever_method.settings.should eql({:address              => "localhost",
+      expect(Mail.retriever_method.class).to eq Mail::POP3
+      expect(Mail.retriever_method.settings).to eql({:address              => "localhost",
                                                  :port                 => 110,
                                                  :user_name            => nil,
                                                  :password             => nil,
@@ -70,50 +70,50 @@ describe "Mail" do
       Mail.defaults do
         delivery_method :smtp, :port => 999
       end
-      Mail.delivery_method.settings[:address].should eq 'localhost'
-      Mail.delivery_method.settings[:port].should eq 999
+      expect(Mail.delivery_method.settings[:address]).to eq 'localhost'
+      expect(Mail.delivery_method.settings[:port]).to eq 999
     end
 
     it "should allow us to overwrite anything we need on POP3" do
       Mail.defaults do
         retriever_method :pop3, :address => 'foo.bar.com'
       end
-      Mail.retriever_method.settings[:address].should eq 'foo.bar.com'
-      Mail.retriever_method.settings[:port].should eq 110
+      expect(Mail.retriever_method.settings[:address]).to eq 'foo.bar.com'
+      expect(Mail.retriever_method.settings[:port]).to eq 110
     end
 
     it "should allow you to pass in your own delivery method" do
       Mail.defaults do
         delivery_method MyDelivery
       end
-      Mail.delivery_method.class.should eq MyDelivery
+      expect(Mail.delivery_method.class).to eq MyDelivery
     end
 
     it "should ask the custom delivery agent for its settings" do
-      mock_my_delivery = mock(MyDelivery)
-      mock_my_delivery.should_receive(:settings).and_return({:these_are => :settings})
-      MyDelivery.should_receive(:new).and_return(mock_my_delivery)
+      mock_my_delivery = double(MyDelivery)
+      expect(mock_my_delivery).to receive(:settings).and_return({:these_are => :settings})
+      expect(MyDelivery).to receive(:new).and_return(mock_my_delivery)
       Mail.defaults do
         delivery_method MyDelivery
       end
-      Mail.delivery_method.settings.should eql({:these_are => :settings})
+      expect(Mail.delivery_method.settings).to eql({:these_are => :settings})
     end
 
     it "should allow you to pass in your own retriever method" do
       Mail.defaults do
         retriever_method MyRetriever
       end
-      Mail.retriever_method.class.should eq MyRetriever
+      expect(Mail.retriever_method.class).to eq MyRetriever
     end
 
     it "should ask the custom retriever agent for its settings" do
-      mock_my_retriever = mock(MyRetriever)
-      mock_my_retriever.should_receive(:settings).and_return({:these_are => :settings})
-      MyRetriever.should_receive(:new).and_return(mock_my_retriever)
+      mock_my_retriever = double(MyRetriever)
+      expect(mock_my_retriever).to receive(:settings).and_return({:these_are => :settings})
+      expect(MyRetriever).to receive(:new).and_return(mock_my_retriever)
       Mail.defaults do
         retriever_method MyRetriever
       end
-      Mail.retriever_method.settings.should eql({:these_are => :settings})
+      expect(Mail.retriever_method.settings).to eql({:these_are => :settings})
     end
 
   end
@@ -122,39 +122,39 @@ describe "Mail" do
 
     it "should copy the defaults defined by Mail.defaults" do
       mail = Mail.new
-      mail.delivery_method.class.should eq Mail::SMTP
+      expect(mail.delivery_method.class).to eq Mail::SMTP
     end
 
     it "should be able to change the delivery_method" do
       mail = Mail.new
       mail.delivery_method :file
-      mail.delivery_method.class.should eq Mail::FileDelivery
+      expect(mail.delivery_method.class).to eq Mail::FileDelivery
     end
 
     it "should be able to change the delivery_method and pass in settings" do
       mail = Mail.new
       tmpdir = File.expand_path('../../../tmp/mail', __FILE__)
       mail.delivery_method :file, :location => tmpdir
-      mail.delivery_method.class.should eq Mail::FileDelivery
-      mail.delivery_method.settings.should eql({:location => tmpdir})
+      expect(mail.delivery_method.class).to eq Mail::FileDelivery
+      expect(mail.delivery_method.settings).to eql({:location => tmpdir})
     end
 
     it "should not change the default when it changes the delivery_method" do
       mail1 = Mail.new
       mail2 = Mail.new
       mail1.delivery_method :file
-      Mail.delivery_method.class.should eq Mail::SMTP
-      mail1.delivery_method.class.should eq Mail::FileDelivery
-      mail2.delivery_method.class.should eq Mail::SMTP
+      expect(Mail.delivery_method.class).to eq Mail::SMTP
+      expect(mail1.delivery_method.class).to eq Mail::FileDelivery
+      expect(mail2.delivery_method.class).to eq Mail::SMTP
     end
 
     it "should not change the default settings when it changes the delivery_method settings" do
       mail1 = Mail.new
       mail2 = Mail.new
       mail1.delivery_method :smtp, :address => 'my.own.address'
-      Mail.delivery_method.settings[:address].should eq 'localhost'
-      mail1.delivery_method.settings[:address].should eq 'my.own.address'
-      mail2.delivery_method.settings[:address].should eq 'localhost'
+      expect(Mail.delivery_method.settings[:address]).to eq 'localhost'
+      expect(mail1.delivery_method.settings[:address]).to eq 'my.own.address'
+      expect(mail2.delivery_method.settings[:address]).to eq 'localhost'
     end
 
   end
@@ -163,9 +163,9 @@ describe "Mail" do
     it "should retrieve all emails via POP3" do
       messages = Mail.all
 
-      messages.should_not be_empty
+      expect(messages).not_to be_empty
       for message in messages
-        message.should be_instance_of(Mail::Message)
+        expect(message).to be_instance_of(Mail::Message)
       end
     end
   end
@@ -186,9 +186,9 @@ describe "Mail" do
         # add_file 'New Header Image', '/somefile.png'
       end
 
-      MockSMTP.deliveries[0][0].should eq message.encoded
-      MockSMTP.deliveries[0][1].should eq "mikel@test.lindsaar.net"
-      MockSMTP.deliveries[0][2].should eq ["ada@test.lindsaar.net"]
+      expect(MockSMTP.deliveries[0][0]).to eq message.encoded
+      expect(MockSMTP.deliveries[0][1]).to eq "mikel@test.lindsaar.net"
+      expect(MockSMTP.deliveries[0][2]).to eq ["ada@test.lindsaar.net"]
     end
 
     it "should deliver itself" do
@@ -202,9 +202,9 @@ describe "Mail" do
 
       message.deliver!
 
-      MockSMTP.deliveries[0][0].should eq message.encoded
-      MockSMTP.deliveries[0][1].should eq "mikel@test.lindsaar.net"
-      MockSMTP.deliveries[0][2].should eq ["ada@test.lindsaar.net"]
+      expect(MockSMTP.deliveries[0][0]).to eq message.encoded
+      expect(MockSMTP.deliveries[0][1]).to eq "mikel@test.lindsaar.net"
+      expect(MockSMTP.deliveries[0][2]).to eq ["ada@test.lindsaar.net"]
     end
 
   end
@@ -246,48 +246,48 @@ describe "Mail" do
 
     describe "adding to Mail.deliveries" do
       it "should add itself to the deliveries collection on mail on delivery" do
-        doing { @message.deliver }.should change(Mail::TestMailer.deliveries, :size).by(1)
+        expect(doing { @message.deliver }).to change(Mail::TestMailer.deliveries, :size).by(1)
       end
     end
 
     describe "perform_deliveries" do
       it "should call deliver! on the delivery method by default" do
         delivery_agent = MyDeliveryMethod.new
-        @message.should_receive(:delivery_method).and_return(delivery_agent)
-        delivery_agent.should_receive(:deliver!).with(@message)
+        expect(@message).to receive(:delivery_method).and_return(delivery_agent)
+        expect(delivery_agent).to receive(:deliver!).with(@message)
         @message.deliver
       end
 
       it "should not call deliver if perform deliveries is set to false" do
         @message.perform_deliveries = false
         delivery_agent = MyDeliveryMethod.new
-        @message.should_not_receive(:delivery_method)
-        delivery_agent.should_not_receive(:deliver!)
+        expect(@message).not_to receive(:delivery_method)
+        expect(delivery_agent).not_to receive(:deliver!)
         @message.deliver
       end
 
       it "should add to the deliveries array if perform_deliveries is true" do
         @message.perform_deliveries = true
-        doing { @message.deliver }.should change(Mail::TestMailer.deliveries, :size).by(1)
+        expect(doing { @message.deliver }).to change(Mail::TestMailer.deliveries, :size).by(1)
       end
 
       it "should not add to the deliveries array if perform_deliveries is false" do
         @message.perform_deliveries = false
-        doing { @message.deliver }.should_not change(Mail::TestMailer.deliveries, :size)
+        expect(doing { @message.deliver }).not_to change(Mail::TestMailer.deliveries, :size)
       end
     end
 
     describe "observers" do
       it "should tell its observers that it was told to deliver an email" do
         Mail.register_observer(MyObserver)
-        MyObserver.should_receive(:delivered_email).with(@message).once
+        expect(MyObserver).to receive(:delivered_email).with(@message).once
         @message.deliver
       end
 
       it "should tell its observers that it was told to deliver an email even if perform_deliveries is false" do
         Mail.register_observer(MyObserver)
         @message.perform_deliveries = false
-        MyObserver.should_receive(:delivered_email).with(@message).once
+        expect(MyObserver).to receive(:delivered_email).with(@message).once
         @message.deliver
       end
 
@@ -295,7 +295,7 @@ describe "Mail" do
         Mail.register_observer(MyObserver)
         @message.delivery_handler = MyYieldingDeliveryHandler.new
         @message.perform_deliveries = false
-        MyObserver.should_receive(:delivered_email).with(@message).once
+        expect(MyObserver).to receive(:delivered_email).with(@message).once
         @message.deliver
       end
 
@@ -304,25 +304,25 @@ describe "Mail" do
     describe "raise_delivery_errors" do
       it "should pass on delivery errors if raised" do
         delivery_agent = MyDeliveryMethod.new
-        @message.stub!(:delivery_method).and_return(delivery_agent)
-        delivery_agent.stub!(:deliver!).and_raise(StandardError)
-        doing { @message.deliver }.should raise_error(StandardError)
+        allow(@message).to receive(:delivery_method).and_return(delivery_agent)
+        allow(delivery_agent).to receive(:deliver!).and_raise(StandardError)
+        expect(doing { @message.deliver }).to raise_error(StandardError)
       end
 
       it "should not pass on delivery errors if raised raise_delivery_errors is set to false" do
         delivery_agent = MyDeliveryMethod.new
-        @message.stub!(:delivery_method).and_return(delivery_agent)
+        allow(@message).to receive(:delivery_method).and_return(delivery_agent)
         @message.raise_delivery_errors = false
-        delivery_agent.stub!(:deliver!).and_raise(StandardError)
-        doing { @message.deliver }.should_not raise_error(StandardError)
+        allow(delivery_agent).to receive(:deliver!).and_raise(StandardError)
+        expect(doing { @message.deliver }).not_to raise_error
       end
 
       it "should pass through Exceptions even when raise_delivery_errors is set to false" do
         delivery_agent = MyDeliveryMethod.new
-        @message.stub!(:delivery_method).and_return(delivery_agent)
+        allow(@message).to receive(:delivery_method).and_return(delivery_agent)
         @message.raise_delivery_errors = false
-        delivery_agent.stub!(:deliver!).and_raise(Exception)
-        doing { @message.deliver }.should raise_error(Exception)
+        allow(delivery_agent).to receive(:deliver!).and_raise(Exception)
+        expect(doing { @message.deliver }).to raise_error(Exception)
       end
     end
 
@@ -330,37 +330,37 @@ describe "Mail" do
 
       it "should allow you to hand off performing the actual delivery to another object" do
         delivery_handler = MyYieldingDeliveryHandler.new
-        delivery_handler.should_receive(:deliver_mail).with(@message).exactly(:once)
+        expect(delivery_handler).to receive(:deliver_mail).with(@message).exactly(:once)
         @message.delivery_handler = delivery_handler
         @message.deliver
       end
 
       it "mail should be told to :deliver once and then :deliver! once by the delivery handler" do
         @message.delivery_handler = MyYieldingDeliveryHandler.new
-        @message.should_receive(:do_delivery).exactly(:once)
+        expect(@message).to receive(:do_delivery).exactly(:once)
         @message.deliver
       end
 
       it "mail only call its delivery_method once" do
         @message.delivery_handler = MyYieldingDeliveryHandler.new
-        @message.should_receive(:delivery_method).exactly(:once).and_return(Mail::TestMailer.new({}))
+        expect(@message).to receive(:delivery_method).exactly(:once).and_return(Mail::TestMailer.new({}))
         @message.deliver
       end
 
       it "mail should not catch any exceptions when using a delivery_handler" do
         @message.delivery_handler = MyYieldingDeliveryHandler.new
-        @message.should_receive(:delivery_method).and_raise(Exception)
-        doing { @message.deliver }.should raise_error(Exception)
+        expect(@message).to receive(:delivery_method).and_raise(Exception)
+        expect(doing { @message.deliver }).to raise_error(Exception)
       end
 
       it "mail should not modify the Mail.deliveries object if using a delivery_handler that does not append to deliveries" do
         @message.delivery_handler = MyDeliveryHandler.new
-        doing { @message.deliver }.should_not change(Mail::TestMailer, :deliveries)
+        expect(doing { @message.deliver }).not_to change(Mail::TestMailer, :deliveries)
       end
 
       it "should be able to just yield and let mail do its thing" do
         @message.delivery_handler = MyYieldingDeliveryHandler.new
-        @message.should_receive(:do_delivery).exactly(:once)
+        expect(@message).to receive(:do_delivery).exactly(:once)
         @message.deliver
       end
 

--- a/spec/mail/parsers/address_lists_parser_spec.rb
+++ b/spec/mail/parsers/address_lists_parser_spec.rb
@@ -5,20 +5,20 @@ describe "AddressListsParser" do
   it "should parse an address" do
     text = 'Mikel Lindsaar <test@lindsaar.net>, Friends: test2@lindsaar.net, Ada <test3@lindsaar.net>;'
     a = Mail::Parsers::AddressListsParser.new
-    a.parse(text).should_not be_nil
+    expect(a.parse(text)).not_to be_nil
   end
 
   it "should parse an address list separated by semicolons" do
     text = 'Mikel Lindsaar <test@lindsaar.net>; Friends: test2@lindsaar.net; Ada <test3@lindsaar.net>;'
     a = Mail::Parsers::AddressListsParser.new
-    a.parse(text).should_not be_nil
+    expect(a.parse(text)).not_to be_nil
   end
 
   context "parsing an address with a space at the end" do
     it "only finds a single address" do
       text = 'Mikel Lindsaar <test@lindsaar.net> '
       a = Mail::Parsers::AddressListsParser.new
-      a.parse(text).addresses.size.should eq 1
+      expect(a.parse(text).addresses.size).to eq 1
     end
   end
 
@@ -27,8 +27,8 @@ describe "AddressListsParser" do
       text = '(xxxx xxxxxx xxxx)ababab@example.com'
 
       a = Mail::Parsers::AddressListsParser.new
-      a.parse(text).addresses.size.should eq 1
-      a.parse(text).addresses.first.local.should eq 'ababab'
+      expect(a.parse(text).addresses.size).to eq 1
+      expect(a.parse(text).addresses.first.local).to eq 'ababab'
     end
   end
 end

--- a/spec/mail/parsers/content_transfer_encoding_parser_spec.rb
+++ b/spec/mail/parsers/content_transfer_encoding_parser_spec.rb
@@ -6,8 +6,8 @@ describe "ContentTransferEncodingParser" do
   it "should work" do
     text = "quoted-printable"
     a = Mail::Parsers::ContentTransferEncodingParser.new
-    a.parse(text).error.should be_nil
-    a.parse(text).encoding.should eq 'quoted-printable'
+    expect(a.parse(text).error).to be_nil
+    expect(a.parse(text).encoding).to eq 'quoted-printable'
   end
 
   describe "trailing semi colons" do
@@ -15,29 +15,29 @@ describe "ContentTransferEncodingParser" do
     it "should parse" do
       text = "quoted-printable;"
       a = Mail::Parsers::ContentTransferEncodingParser.new
-      a.parse(text).error.should be_nil
-      a.parse(text).encoding.should eq 'quoted-printable'
+      expect(a.parse(text).error).to be_nil
+      expect(a.parse(text).encoding).to eq 'quoted-printable'
     end
 
     it "should parse with pre white space" do
       text = 'quoted-printable  ;'
       a = Mail::Parsers::ContentTransferEncodingParser.new
-      a.parse(text).error.should be_nil
-      a.parse(text).encoding.should eq 'quoted-printable'
+      expect(a.parse(text).error).to be_nil
+      expect(a.parse(text).encoding).to eq 'quoted-printable'
     end
 
     it "should parse with trailing white space" do
       text = 'quoted-printable; '
       a = Mail::Parsers::ContentTransferEncodingParser.new
-      a.parse(text).error.should be_nil
-      a.parse(text).encoding.should eq 'quoted-printable'
+      expect(a.parse(text).error).to be_nil
+      expect(a.parse(text).encoding).to eq 'quoted-printable'
     end
 
     it "should parse with pre and trailing white space" do
       text = 'quoted-printable  ;  '
       a = Mail::Parsers::ContentTransferEncodingParser.new
-      a.parse(text).error.should be_nil
-      a.parse(text).encoding.should eq 'quoted-printable'
+      expect(a.parse(text).error).to be_nil
+      expect(a.parse(text).encoding).to eq 'quoted-printable'
     end
   end
 
@@ -45,8 +45,8 @@ describe "ContentTransferEncodingParser" do
     it "should work" do
       text = 'x-my-token'
       a = Mail::Parsers::ContentTransferEncodingParser.new
-      a.parse(text).error.should be_nil
-      a.parse(text).encoding.should eq 'x-my-token'
+      expect(a.parse(text).error).to be_nil
+      expect(a.parse(text).encoding).to eq 'x-my-token'
     end
   end
 
@@ -54,8 +54,8 @@ describe "ContentTransferEncodingParser" do
     %w(7bits 8bits 7-bit 8-bit).each do |mechanism|
       it "should parse #{mechanism} variant" do
         a = Mail::Parsers::ContentTransferEncodingParser.new
-        a.parse(mechanism).error.should be_nil
-        a.parse(mechanism).encoding.should eq mechanism
+        expect(a.parse(mechanism).error).to be_nil
+        expect(a.parse(mechanism).encoding).to eq mechanism
       end
     end
   end

--- a/spec/mail/part_spec.rb
+++ b/spec/mail/part_spec.rb
@@ -5,27 +5,27 @@ describe Mail::Part do
   it "should not add a default Content-ID" do
     part = Mail::Part.new
     part.to_s
-    part.content_id.should be_nil
+    expect(part.content_id).to be_nil
   end
 
   it "should not add a default Content-ID to non-inline attachments" do
     part = Mail::Part.new(:content_disposition => 'attachment')
     part.to_s
-    part.content_id.should be_nil
+    expect(part.content_id).to be_nil
   end
 
   it "should add a default Content-ID to inline attachments" do
     part = Mail::Part.new(:content_disposition => 'inline')
     part.to_s
-    part.content_id.should_not be_nil
+    expect(part.content_id).not_to be_nil
   end
 
   it "should not add a Date, MIME-Version, or Message-ID" do
     part = Mail::Part.new
     part.to_s
-    part.date.should be_nil
-    part.mime_version.should be_nil
-    part.message_id.should be_nil
+    expect(part.date).to be_nil
+    expect(part.mime_version).to be_nil
+    expect(part.message_id).to be_nil
   end
 
   it "should preserve any content id that you put into it" do
@@ -33,7 +33,7 @@ describe Mail::Part do
       content_id "<thisis@acontentid>"
       body "This is Text"
     end
-    part.content_id.should eq "<thisis@acontentid>"
+    expect(part.content_id).to eq "<thisis@acontentid>"
   end
   
   it "should return an inline content_id" do
@@ -41,9 +41,9 @@ describe Mail::Part do
       content_id "<thisis@acontentid>"
       body "This is Text"
     end
-    part.cid.should eq "thisis@acontentid"
-    STDERR.should_receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
-    part.inline_content_id.should eq "thisis@acontentid"
+    expect(part.cid).to eq "thisis@acontentid"
+    expect(STDERR).to receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
+    expect(part.inline_content_id).to eq "thisis@acontentid"
   end
   
   
@@ -52,24 +52,24 @@ describe Mail::Part do
       content_id "<thi%%sis@acontentid>"
       body "This is Text"
     end
-    part.cid.should eq "thi%25%25sis@acontentid"
-    STDERR.should_receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
-    part.inline_content_id.should eq "thi%25%25sis@acontentid"
+    expect(part.cid).to eq "thi%25%25sis@acontentid"
+    expect(STDERR).to receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
+    expect(part.inline_content_id).to eq "thi%25%25sis@acontentid"
   end
   
   it "should add a content_id if there is none and is asked for an inline_content_id" do
     part = Mail::Part.new
-    part.cid.should_not be_nil
-    STDERR.should_receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
-    part.inline_content_id.should_not be_nil
+    expect(part.cid).not_to be_nil
+    expect(STDERR).to receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
+    expect(part.inline_content_id).not_to be_nil
   end
   
   it "should respond correctly to inline?" do
     part = Mail::Part.new(:content_disposition => 'attachment')
-    part.should_not be_inline
+    expect(part).not_to be_inline
 
     part = Mail::Part.new(:content_disposition => 'inline')
-    part.should be_inline
+    expect(part).to be_inline
   end
   
   
@@ -98,7 +98,7 @@ This message has been scanned for viruses and
 dangerous content by MailScanner, and is
 believed to be clean.
 PARTEND
-      STDERR.should_not_receive(:puts)
+      expect(STDERR).not_to receive(:puts)
       Mail::Part.new(part)
     end
   end
@@ -123,39 +123,39 @@ ENDPART
     end
 
     it "should know if it is a delivery-status report" do
-      @delivery_report.should be_delivery_status_report_part
+      expect(@delivery_report).to be_delivery_status_report_part
     end
     
     it "should create a delivery_status_data header object" do
-      @delivery_report.delivery_status_data.should_not be_nil
+      expect(@delivery_report.delivery_status_data).not_to be_nil
     end
 
     it "should be bounced" do
-      @delivery_report.should be_bounced
+      expect(@delivery_report).to be_bounced
     end
     
     it "should say action 'delayed'" do
-      @delivery_report.action.should eq 'failed'
+      expect(@delivery_report.action).to eq 'failed'
     end
     
     it "should give a final recipient" do
-      @delivery_report.final_recipient.should eq 'RFC822; edwin@zzzzzzz.com'
+      expect(@delivery_report.final_recipient).to eq 'RFC822; edwin@zzzzzzz.com'
     end
     
     it "should give an error code" do
-      @delivery_report.error_status.should eq '5.3.0'
+      expect(@delivery_report.error_status).to eq '5.3.0'
     end
     
     it "should give a diagostic code" do
-      @delivery_report.diagnostic_code.should eq 'SMTP; 553 5.3.0 <edwin@zzzzzzz.com>... Unknown E-Mail Address'
+      expect(@delivery_report.diagnostic_code).to eq 'SMTP; 553 5.3.0 <edwin@zzzzzzz.com>... Unknown E-Mail Address'
     end
     
     it "should give a remote-mta" do
-      @delivery_report.remote_mta.should eq 'DNS; mail.zzzzzz.com'
+      expect(@delivery_report.remote_mta).to eq 'DNS; mail.zzzzzz.com'
     end
     
     it "should be retryable" do
-      @delivery_report.should_not be_retryable
+      expect(@delivery_report).not_to be_retryable
     end
 
   end
@@ -164,8 +164,8 @@ ENDPART
     plain_text = "First Line\n\nSecond Line\n\nThird Line\n\n"
     #Note: trailing \n\n is stripped off by Mail::Part initialization
     part = Mail::Part.new(plain_text)
-    part[:content_type].content_type.should eq 'text/plain'
-    part.to_s.should match(/^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/)
+    expect(part[:content_type].content_type).to eq 'text/plain'
+    expect(part.to_s).to match(/^First Line\r\n\r\nSecond Line\r\n\r\nThird Line/)
   end
 
 end

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -7,7 +7,7 @@ describe "PartsList" do
     p = Mail::PartsList.new
     p << 2
     p << 1
-    p.sort.class.should eq Mail::PartsList
+    expect(p.sort.class).to eq Mail::PartsList
   end
 
   it "should not fail if we do not have a content_type" do
@@ -32,6 +32,6 @@ describe "PartsList" do
     p << no_content_type_part
     p << plain_text_part
     p << html_text_part
-    p.sort!(order).should eq [plain_text_part, html_text_part, no_content_type_part]
+    expect(p.sort!(order)).to eq [plain_text_part, html_text_part, no_content_type_part]
   end
 end

--- a/spec/mail/round_tripping_spec.rb
+++ b/spec/mail/round_tripping_spec.rb
@@ -7,8 +7,8 @@ describe "Round Tripping" do
     mail = Mail.new('Subject: FooBar')
     mail.body "This is Text"
     parsed_mail = Mail.new(mail.to_s)
-    parsed_mail.subject.to_s.should eq "FooBar"
-    parsed_mail.body.to_s.should eq "This is Text"
+    expect(parsed_mail.subject.to_s).to eq "FooBar"
+    expect(parsed_mail.body.to_s).to eq "This is Text"
   end
 
   it "should round trip a html multipart email" do
@@ -21,11 +21,11 @@ describe "Round Tripping" do
       body "<b>This is HTML</b>"
     end
     parsed_mail = Mail.new(mail.to_s)
-    parsed_mail.mime_type.should eq 'multipart/alternative'
-    parsed_mail.boundary.should eq mail.boundary
-    parsed_mail.parts.length.should eq 2
-    parsed_mail.parts[0].body.to_s.should eq "This is Text"
-    parsed_mail.parts[1].body.to_s.should eq "<b>This is HTML</b>"
+    expect(parsed_mail.mime_type).to eq 'multipart/alternative'
+    expect(parsed_mail.boundary).to eq mail.boundary
+    expect(parsed_mail.parts.length).to eq 2
+    expect(parsed_mail.parts[0].body.to_s).to eq "This is Text"
+    expect(parsed_mail.parts[1].body.to_s).to eq "<b>This is HTML</b>"
   end
 
   it "should round trip an email" do
@@ -39,13 +39,13 @@ describe "Round Tripping" do
       date      Time.local(2009, 11, 6)
       add_file  :filename => "foo.txt", :content => "I have \ntwo lines\n\n"
     end
-    Mail.new(initial.encoded).encoded.should eq initial.encoded
+    expect(Mail.new(initial.encoded).encoded).to eq initial.encoded
   end
 
   it "should round trip attachment newlines" do
     body = "I have \ntwo lines\n\n"
     initial = Mail.new
     initial.add_file :filename => "foo.txt", :content => body
-    Mail.new(initial.encoded).attachments.first.decoded.should eq body
+    expect(Mail.new(initial.encoded).attachments.first.decoded).to eq body
   end
 end

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -9,31 +9,31 @@ describe "Utilities Module" do
     
     describe "checking" do
       it "should return true if a string is token safe" do
-        token_safe?('.abc').should be_true
+        expect(token_safe?('.abc')).to be_true
       end
 
       it "should return false if a string is token safe" do
-        token_safe?('?=abc').should be_false
+        expect(token_safe?('?=abc')).to be_false
       end
 
       it "should work with mb_chars" do
-        token_safe?('.abc'.mb_chars).should be_true
-        token_safe?('?=abc'.mb_chars).should be_false
+        expect(token_safe?('.abc'.mb_chars)).to be_true
+        expect(token_safe?('?=abc'.mb_chars)).to be_false
       end
     end
 
     describe "quoting" do
       it "should return true if a string is token safe" do
-        quote_token('.abc').should eq '.abc'
+        expect(quote_token('.abc')).to eq '.abc'
       end
 
       it "should return false if a string is token safe" do
-        quote_token('?=abc').should eq '"?=abc"'
+        expect(quote_token('?=abc')).to eq '"?=abc"'
       end
 
       it "should work with mb_chars" do
-        quote_token('.abc'.mb_chars).should eq '.abc'
-        quote_token('?=abc'.mb_chars).should eq '"?=abc"'
+        expect(quote_token('.abc'.mb_chars)).to eq '.abc'
+        expect(quote_token('?=abc'.mb_chars)).to eq '"?=abc"'
       end
     end
 
@@ -43,41 +43,41 @@ describe "Utilities Module" do
     
     describe "checking" do
       it "should return true if a string is token safe" do
-        atom_safe?('?=abc').should be_true
+        expect(atom_safe?('?=abc')).to be_true
       end
 
       it "should return false if a string is token safe" do
-        atom_safe?('.abc').should be_false
+        expect(atom_safe?('.abc')).to be_false
       end
 
       it "should work with mb_chars" do
-        atom_safe?('?=abc'.mb_chars).should be_true
-        atom_safe?('.abc'.mb_chars).should be_false
+        expect(atom_safe?('?=abc'.mb_chars)).to be_true
+        expect(atom_safe?('.abc'.mb_chars)).to be_false
       end
     end
 
     describe "quoting" do
       it "should return true if a string is token safe" do
-        quote_atom('?=abc').should eq '?=abc'
+        expect(quote_atom('?=abc')).to eq '?=abc'
       end
 
       it "should return false if a string is token safe" do
-        quote_atom('.abc').should eq '".abc"'
+        expect(quote_atom('.abc')).to eq '".abc"'
       end
 
       it "should work with mb_chars" do
-        quote_atom('?=abc'.mb_chars).should eq '?=abc'
-        quote_atom('.abc'.mb_chars).should eq '".abc"'
+        expect(quote_atom('?=abc'.mb_chars)).to eq '?=abc'
+        expect(quote_atom('.abc'.mb_chars)).to eq '".abc"'
       end
 
       it "should work with mb_chars" do
-        quote_atom('?=abc'.mb_chars).should eq '?=abc'
-        quote_atom('.abc'.mb_chars).should eq '".abc"'
+        expect(quote_atom('?=abc'.mb_chars)).to eq '?=abc'
+        expect(quote_atom('.abc'.mb_chars)).to eq '".abc"'
       end
       
       it "should quote white space" do
-        quote_atom('ab abc'.mb_chars).should eq '"ab abc"'
-        quote_atom("a\sb\ta\r\nbc".mb_chars).should eq %{"a\sb\ta\r\nbc"}
+        expect(quote_atom('ab abc'.mb_chars)).to eq '"ab abc"'
+        expect(quote_atom("a\sb\ta\r\nbc".mb_chars)).to eq %{"a\sb\ta\r\nbc"}
       end
     end
 
@@ -92,7 +92,7 @@ describe "Utilities Module" do
 
           quote_phrase(input_str)
 
-          input_str.encoding.should eq input_str_encoding
+          expect(input_str.encoding).to eq input_str_encoding
         end
       end
 
@@ -103,7 +103,7 @@ describe "Utilities Module" do
 
           quote_phrase(input_str)
 
-          input_str.encoding.should eq input_str_encoding
+          expect(input_str.encoding).to eq input_str_encoding
         end
       end
     end
@@ -113,19 +113,19 @@ describe "Utilities Module" do
     it "should escape parens" do
       test = 'This is not (escaped)'
       result = 'This is not \(escaped\)'
-      escape_paren(test).should eq result
+      expect(escape_paren(test)).to eq result
     end
 
     it "should not double escape parens" do
       test = 'This is not \(escaped\)'
       result = 'This is not \(escaped\)'
-      escape_paren(test).should eq result
+      expect(escape_paren(test)).to eq result
     end
 
     it "should escape all parens" do
       test = 'This is not \()escaped(\)'
       result = 'This is not \(\)escaped\(\)'
-      escape_paren(test).should eq result
+      expect(escape_paren(test)).to eq result
     end
     
   end
@@ -135,25 +135,25 @@ describe "Utilities Module" do
     it "should work" do
       test = '(This is a string)'
       result = 'This is a string'
-      unparen(test).should eq result
+      expect(unparen(test)).to eq result
     end
 
     it "should work without parens" do
       test = 'This is a string'
       result = 'This is a string'
-      unparen(test).should eq result
+      expect(unparen(test)).to eq result
     end
 
     it "should work using ActiveSupport mb_chars" do
       test = '(This is a string)'.mb_chars
       result = 'This is a string'
-      unparen(test).should eq result
+      expect(unparen(test)).to eq result
     end
 
     it "should work without parens using ActiveSupport mb_chars" do
       test = 'This is a string'.mb_chars
       result = 'This is a string'
-      unparen(test).should eq result
+      expect(unparen(test)).to eq result
     end
 
   end
@@ -163,25 +163,25 @@ describe "Utilities Module" do
     it "should work" do
       test = '<This is a string>'
       result = 'This is a string'
-      unbracket(test).should eq result
+      expect(unbracket(test)).to eq result
     end
 
     it "should work without brackets" do
       test = 'This is a string'
       result = 'This is a string'
-      unbracket(test).should eq result
+      expect(unbracket(test)).to eq result
     end
 
     it "should work using ActiveSupport mb_chars" do
       test = '<This is a string>'.mb_chars
       result = 'This is a string'
-      unbracket(test).should eq result
+      expect(unbracket(test)).to eq result
     end
 
     it "should work without parens using ActiveSupport mb_chars" do
       test = 'This is a string'.mb_chars
       result = 'This is a string'
-      unbracket(test).should eq(result)
+      expect(unbracket(test)).to eq(result)
     end
 
   end
@@ -190,51 +190,51 @@ describe "Utilities Module" do
     it "should quote a phrase if it is unsafe" do
       test = 'this.needs quoting'
       result = '"this.needs quoting"'
-      dquote(test).should eq result
+      expect(dquote(test)).to eq result
     end
 
     it "should properly quote a string, even if quoted but not escaped properly" do
       test = '"this needs "escaping"'
       result = '"this needs \"escaping"'
-      dquote(test).should eq result
+      expect(dquote(test)).to eq result
     end
     
     it "should quote correctly a phrase with an escaped quote in it" do
       test = 'this needs \"quoting'
       result = '"this needs \\\\\\"quoting"'
-      dquote(test).should eq result
+      expect(dquote(test)).to eq result
     end
     
     it "should quote correctly a phrase with an escaped backslash followed by an escaped quote in it" do
       test = 'this needs \\\"quoting'
       result = '"this needs \\\\\\\\\\"quoting"'
-      dquote(test).should eq result
+      expect(dquote(test)).to eq result
     end
   end
 
   describe "unquoting phrases" do
     it "should remove quotes from the edge" do
-      unquote('"This is quoted"').should eq 'This is quoted'
+      expect(unquote('"This is quoted"')).to eq 'This is quoted'
     end
 
     it "should remove backslash escaping from quotes" do
-      unquote('"This is \\"quoted\\""').should eq 'This is "quoted"'
+      expect(unquote('"This is \\"quoted\\""')).to eq 'This is "quoted"'
     end
 
     it "should remove backslash escaping from any char" do
-      unquote('"This is \\quoted"').should eq 'This is quoted'
+      expect(unquote('"This is \\quoted"')).to eq 'This is quoted'
     end
 
     it "should be able to handle unquoted strings" do
-      unquote('This is not quoted').should eq 'This is not quoted'
+      expect(unquote('This is not quoted')).to eq 'This is not quoted'
     end
 
     it "should preserve backslashes in unquoted strings" do
-      unquote('This is not \"quoted').should eq 'This is not \"quoted'
+      expect(unquote('This is not \"quoted')).to eq 'This is not \"quoted'
     end
 
     it "should be able to handle unquoted quotes" do
-      unquote('"This is "quoted"').should eq 'This is "quoted'
+      expect(unquote('"This is "quoted"')).to eq 'This is "quoted'
     end
   end
   
@@ -243,61 +243,61 @@ describe "Utilities Module" do
     it "should parenthesize a phrase" do
       test = 'this.needs parenthesizing'
       result = '(this.needs parenthesizing)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
 
     it "should properly parenthesize a string, and escape properly" do
       test = 'this needs (escaping'
       result = '(this needs \(escaping)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
 
     it "should properly parenthesize a string, and escape properly (other way)" do
       test = 'this needs )escaping'
       result = '(this needs \)escaping)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
 
     it "should properly parenthesize a string, even if parenthesized but not escaped properly" do
       test = '(this needs (escaping)'
       result = '(this needs \(escaping)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
 
     it "should properly parenthesize a string, even if parenthesized but not escaped properly (other way)" do
       test = '(this needs )escaping)'
       result = '(this needs \)escaping)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
     
     it "should parenthesize correctly a phrase with an escaped parentheses in it" do
       test = 'this needs \(parenthesizing'
       result = '(this needs \(parenthesizing)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
     
     it "should parenthesize correctly a phrase with an escaped parentheses in it (other way)" do
       test = 'this needs \)parenthesizing'
       result = '(this needs \)parenthesizing)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
     
     it "should parenthesize correctly a phrase with an escaped backslash followed by an escaped parentheses in it" do
       test = 'this needs \\\(parenthesizing'
       result = '(this needs \\\(parenthesizing)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
     
     it "should parenthesize correctly a phrase with an escaped backslash followed by an escaped parentheses in it (other way)" do
       test = 'this needs \\\)parenthesizing'
       result = '(this needs \\\)parenthesizing)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
 
     it "should parenthesize correctly a phrase with a set of parentheses" do
       test = 'this (needs) parenthesizing'
       result = '(this \(needs\) parenthesizing)'
-      paren(test).should eq result
+      expect(paren(test)).to eq result
     end
     
   end
@@ -307,61 +307,61 @@ describe "Utilities Module" do
     it "should bracketize a phrase" do
       test = 'this.needs bracketizing'
       result = '<this.needs bracketizing>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
 
     it "should properly bracketize a string, and escape properly" do
       test = 'this needs <escaping'
       result = '<this needs \<escaping>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
 
     it "should properly bracketize a string, and escape properly (other way)" do
       test = 'this needs >escaping'
       result = '<this needs \>escaping>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
 
     it "should properly bracketize a string, even if bracketized but not escaped properly" do
       test = '<this needs <escaping>'
       result = '<this needs \<escaping>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
 
     it "should properly bracketize a string, even if bracketized but not escaped properly (other way)" do
       test = '<this needs >escaping>'
       result = '<this needs \>escaping>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
     
     it "should bracketize correctly a phrase with an escaped brackets in it" do
       test = 'this needs \<bracketizing'
       result = '<this needs \<bracketizing>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
     
     it "should bracketize correctly a phrase with an escaped brackets in it (other way)" do
       test = 'this needs \>bracketizing'
       result = '<this needs \>bracketizing>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
     
     it "should bracketize correctly a phrase with an escaped backslash followed by an escaped brackets in it" do
       test = 'this needs \\\<bracketizing'
       result = '<this needs \\\<bracketizing>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
     
     it "should bracketize correctly a phrase with an escaped backslash followed by an escaped brackets in it (other way)" do
       test = 'this needs \\\>bracketizing'
       result = '<this needs \\\>bracketizing>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
 
     it "should bracketize correctly a phrase with a set of brackets" do
       test = 'this <needs> bracketizing'
       result = '<this \<needs\> bracketizing>'
-      bracket(test).should eq result
+      expect(bracket(test)).to eq result
     end
     
   end
@@ -370,11 +370,11 @@ describe "Utilities Module" do
     uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
 
     it "should have a wrapper on URI.escape" do
-      uri_escape("@?@!").should eq uri_parser.escape("@?@!")
+      expect(uri_escape("@?@!")).to eq uri_parser.escape("@?@!")
     end
 
     it "should have a wrapper on URI.unescape" do
-      uri_unescape("@?@!").should eq uri_parser.unescape("@?@!")
+      expect(uri_unescape("@?@!")).to eq uri_parser.unescape("@?@!")
     end
   end
   

--- a/spec/mail/version_specific/escape_paren_1_8_spec.rb
+++ b/spec/mail/version_specific/escape_paren_1_8_spec.rb
@@ -5,24 +5,24 @@ describe "Ruby 1.8 Extensions" do
   
   describe "string ascii detection" do
     it "should say it is US-ASCII only if it is" do
-      "abc".should be_ascii_only
+      expect("abc").to be_ascii_only
     end
     
     it "should not say it is US-ASCII only if it isn't" do
-      "かきくけこ".should_not be_ascii_only
+      expect("かきくけこ").not_to be_ascii_only
     end
     
     it "should not say it is US-ASCII only if it is a mix" do
-      "abcかきくけこ123".should_not be_ascii_only
+      expect("abcかきくけこ123").not_to be_ascii_only
     end
     
     it "should handle edge cases" do
       ["\x00", "\x01", "\x40", "\x7f", "\x73"].each do |str|
-        str.should be_ascii_only
+        expect(str).to be_ascii_only
       end
 
       ["\x81", "\x99", "\xFF"].each do |str|
-        str.should_not be_ascii_only
+        expect(str).not_to be_ascii_only
       end
 
     end

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -34,7 +34,7 @@ describe "have_sent_email" do
     context "when no e-mail has been sent" do
       before(:each) do
         Mail::TestMailer.deliveries.clear
-        Mail::TestMailer.deliveries.should be_empty
+        expect(Mail::TestMailer.deliveries).to be_empty
       end
 
       it { should_not have_sent_email }
@@ -43,7 +43,7 @@ describe "have_sent_email" do
     context "when e-mail has been sent" do
       before(:each) do
         send_test_email
-        Mail::TestMailer.deliveries.should_not be_empty
+        expect(Mail::TestMailer.deliveries).not_to be_empty
       end
 
       it { should have_sent_email }


### PR DESCRIPTION
- Specify RSpec 2.14 dependency.
- Use `expect` syntax.
- Remove most deprecations.
- Required changes to stubbing and mocking.
