### PR TITLE
fix SMTP dot-stuffing

### DIFF
--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -96,6 +96,7 @@ module Mail
     # The from and to attributes are optional. If not set, they are retrieve from the Message.
     def deliver!(mail)
       smtp_from, smtp_to, message = check_delivery_params(mail)
+      message = dot_stuff(message)
 
       smtp = Net::SMTP.new(settings[:address], settings[:port])
       if settings[:tls] || settings[:ssl]
@@ -107,7 +108,7 @@ module Mail
           smtp.enable_starttls_auto(ssl_context)
         end
       end
-
+      
       response = nil
       smtp.start(settings[:domain], settings[:user_name], settings[:password], settings[:authentication]) do |smtp_obj|
         response = smtp_obj.sendmail(message, smtp_from, smtp_to)
@@ -122,6 +123,10 @@ module Mail
     
 
     private
+    
+    def dot_stuff(message)
+      message.gsub(/(\r\n\.)(\r\n|$)/, "\\1.\\2")
+    end
 
     # Allow SSL context to be configured via settings, for Ruby >= 1.9
     # Just returns openssl verify mode for Ruby 1.8.x

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -22,6 +22,26 @@ describe "SMTP Delivery Method" do
   end
 
   describe "general usage" do
+    
+    it "properly dot-stuff emails" do
+      
+      mail = Mail.deliver do
+        from    'roger@moore.com'
+        to      'marcel@amont.com'
+        subject 'invalid RFC2822'
+        body "this is a test\n.\nonly a test\n."
+
+        smtp_envelope_from 'smtp_from'
+        smtp_envelope_to 'smtp_to'
+      end
+
+      MockSMTP.deliveries[0][0].should include "\r\n..\r\n"
+      MockSMTP.deliveries[0][0].should =~ %r{\r\n..$}
+      MockSMTP.deliveries[0][0].should eq Mail::SMTP.new({}).send :dot_stuff, mail.encoded
+      MockSMTP.deliveries[0][1].should eq 'smtp_from'
+      MockSMTP.deliveries[0][2].should eq %w(smtp_to)
+      
+    end
 
     it "should send emails from given settings" do
 


### PR DESCRIPTION
Mail does not do proper dot-stuffing and some MTAs will completely fail when trying to send email with un-stuffed periods
