### PR TITLE
Regexp instead of string comparison for message/rfc822

### DIFF
--- a/lib/mail/attachments_list.rb
+++ b/lib/mail/attachments_list.rb
@@ -5,7 +5,7 @@ module Mail
       @parts_list = parts_list
       @content_disposition_type = 'attachment'
       parts_list.map { |p|
-        if p.content_type == "message/rfc822"
+        if p.content_type =~ %r/message\/rfc822/
           Mail.new(p.body).attachments
         elsif p.parts.empty?
           p if p.attachment?

--- a/spec/fixtures/emails/attachment_emails/attachment_message_rfc822.eml
+++ b/spec/fixtures/emails/attachment_emails/attachment_message_rfc822.eml
@@ -17,7 +17,8 @@ Content-Type: text/plain;
 This is the first part.
 
 --Apple-Mail-13-196941151
-Content-Type: message/rfc822
+Content-Type: message/rfc822;
+  name="ForwardedMessage.eml";
 
 From xxxx@xxxx.com Tue May 10 11:28:07 2005
 Return-Path: <xxxx@xxxx.com>


### PR DESCRIPTION
Some mail clients (e.g. Thunderbird) add an extra `name` field to the `Content-Type` header when attaching an `.eml` file.

In my case, the header then was something like this..

```
Content-Type: message/rfc822;
  name="ForwardedMessage.eml";
```

..instead of

```
Content-Type: message/rfc822;
```

This led to problems when trying to get all attachments recurisvely through the `Mail::AttachmentList` class.

Luckily, the solution was pretty simple: Instead of doing a hard string comparison when checking the `Content-Type` header of a part, I changed it to use a regular expression instead. Also adjusted the fixture mail to ensure that its actually tested.
