### PR TITLE
Fix Mail::Exim, forgotten in 4875bc2b

### DIFF
--- a/lib/mail/network/delivery_methods/exim.rb
+++ b/lib/mail/network/delivery_methods/exim.rb
@@ -41,9 +41,9 @@ module Mail
                         :arguments      => '-i -t' }.merge(values)
     end
 
-    def self.call(path, arguments, destinations, mail)
+    def self.call(path, arguments, destinations, encoded_message)
       popen "#{path} #{arguments}" do |io|
-        io.puts mail.encoded.to_lf
+        io.puts encoded_message.to_lf
         io.flush
       end
     end


### PR DESCRIPTION
The parameters of Mail::Sendmail.call changed in 4875bc2b, but Mail::Exim, which inherits from Mail::Sendmail, was not changed accordingly.
