### PR TITLE
resolve mime-types based on ruby version

### DIFF
--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,28 @@
+#This file needs to be named mkrf_conf.rb
+#so that rubygems will recognize it as a ruby extension
+#file and not think it is a C extension file
+
+require 'rubygems/dependency_installer.rb'
+
+#Load up the rubygem's dependency installer to 
+#installer the gems we want based on the version
+#of Ruby the user has installed
+installer = Gem::DependencyInstaller.new
+begin
+  if RUBY_VERSION < "1.9"
+    installer.install 'mime-types', "~> 1.16"
+  else 
+    installer.install 'mime-types', "~> 2.0"
+  end
+
+  rescue
+    #Exit with a non-zero value to let rubygems something went wrong
+    exit(1)
+end  
+
+#If this was C, rubygems would attempt to run make
+#Since this is Ruby, rubygems will attempt to run rake
+#If it doesn't find and successfully run a rakefile, it errors out
+f = File.open(File.join(File.dirname(__FILE__), "Rakefile"), "w")
+f.write("task :default\n")
+f.close

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "CONTRIBUTING.md", "CHANGELOG.rdoc", "TODO.rdoc"]
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 
-  s.add_dependency('mime-types', "~> 1.16")
+  # Pseudo-extension to resolve different mime-types gem versions based on ruby version
+  s.extensions = ["ext/mkrf_conf.rb"]
   s.add_dependency('jruby-openssl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
   s.add_dependency('tlsmail', '~> 0.0.1') if RUBY_VERSION == '1.8.6'
 


### PR DESCRIPTION
Rather than do a straight version update of the dependencies, do an (admittedly hacky) check for the ruby version and install the appropriate version. This should give people more time before needing to upgrade their ruby/update `mail` to 3.0, while allowing others to resolve to the newer version.
