### PR TITLE
Makes RSpec3 compatible

### DIFF
--- a/lib/mail/matchers/has_sent_mail.rb
+++ b/lib/mail/matchers/has_sent_mail.rb
@@ -84,12 +84,14 @@ module Mail
         result
       end
 
-      def negative_failure_message
+      def failure_message_when_negated
         result = "Expected no email to be sent "
         result += explain_expectations
         result += dump_deliveries
         result
       end
+
+      alias_method :negative_failure_message, :failure_message_when_negated
 
       protected
       


### PR DESCRIPTION
`negative_failure_message` is replaced with `failure_message_when_negated`.
Remain `negative_failure_message` for the backwards compat.

It's a similar issue of capybara: https://github.com/jnicklas/capybara/pull/1219
