### PR TITLE
use mime-types 2.2.0 and bump version to 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "mime-types", "~> 1.16"
 gem "tlsmail" if RUBY_VERSION <= '1.8.6'
 
 gem 'jruby-openssl', :platform => :jruby

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-major:2
-minor:6
+major:3
+minor:0
 patch:0
 build:edge

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "CONTRIBUTING.md", "CHANGELOG.rdoc", "TODO.rdoc"]
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 
-  s.add_dependency('mime-types', "~> 1.16")
+  s.add_dependency('mime-types', "~> 2.2.0")
   s.add_dependency('jruby-openssl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
   s.add_dependency('tlsmail', '~> 0.0.1') if RUBY_VERSION == '1.8.6'
 


### PR DESCRIPTION
Let me preface this by saying I am not familiar with the history of this library or even how to use it, I am simply another person annoyed by gem conflicts because of this gem's requirement on such an old version of mime-types.

That said, this appears to be the right way to upgrade, we need to change the major version number if we are going to drop support for 1.8.

Looks like there are probably more 1.8 specific things that could be dropped as well.
