### PR TITLE
avoid buggy collapse_adjacent_encoding()

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -117,7 +117,7 @@ module Mail
       return str unless str =~ /\=\?[^?]+\?[QB]\?[^?]+?\?\=/xmi
  
       # Split on white-space boundaries with capture, so we capture the white-space as well
-      str.gsub(/\s*$/, '').gsub(/\?=\s*=\?/, '?==?').split(/([ \t])/).map do |text|
+      str.gsub(/\?=\s*=\?/, '?==?').split(/([ \t])/).map do |text|
         if text.index('=?').nil?
           text
         else


### PR DESCRIPTION
avoiding collapsing might be inefficient bit, but it works anyway in
cases like:

```
  =?UTF-8?B?56eB44Gu5ZCN5YmN44Gv5p2+5pys44Gn44GZ44CC?=
  =?UTF-8?B?UnVieeOCkumWi+eZuuOBl+OBpuOBhOOBvuOBmQ==?=
```

that will be broken by collapse_adjacent_encoding().
