### PR TITLE
Allow interceptors and observers to be unregistered.

### DIFF
--- a/lib/mail/mail.rb
+++ b/lib/mail/mail.rb
@@ -206,6 +206,12 @@ module Mail
     end
   end
 
+  # Unregister the given observer, allowing mail to resume operations
+  # without it.
+  def self.unregister_observer(observer)
+    @@delivery_notification_observers.delete(observer)
+  end
+
   # You can register an object to be given every mail object that will be sent,
   # before it is sent.  So if you want to add special headers or modify any
   # email that gets sent through the Mail library, you can do so.
@@ -217,6 +223,12 @@ module Mail
     unless @@delivery_interceptors.include?(interceptor)
       @@delivery_interceptors << interceptor
     end
+  end
+
+  # Unregister the given interceptor, allowing mail to resume operations
+  # without it.
+  def self.unregister_interceptor(interceptor)
+    @@delivery_interceptors.delete(interceptor)
   end
 
   def self.inform_observers(mail)

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1520,6 +1520,15 @@ describe Mail::Message do
       mail.deliver
     end
 
+    it "should allow observers to be unregistered" do
+      mail = Mail.new(:from => 'bob@example.com', :to => 'bobette@example.com')
+      mail.delivery_method :test
+      Mail.register_observer(ObserverAgent)
+      Mail.unregister_observer(ObserverAgent)
+      ObserverAgent.should_not_receive(:delivered_email).with(mail)
+      mail.deliver
+    end
+
     it "should inform observers that the mail was sent, even if a delivery agent is used" do
       mail = Mail.new
       mail.delivery_handler = DeliveryAgent
@@ -1559,6 +1568,18 @@ describe Mail::Message do
       mail.deliver
       InterceptorAgent.intercept = false
       mail.to.should eq ['bob@example.com']
+    end
+
+    it "should allow interceptors to be unregistered" do
+      mail = Mail.new(:from => 'bob@example.com', :to => 'bobette@example.com')
+      mail.to = 'fred@example.com'
+      mail.delivery_method :test
+      Mail.register_interceptor(InterceptorAgent)
+      InterceptorAgent.intercept = true
+      Mail.unregister_interceptor(InterceptorAgent)
+      mail.deliver
+      InterceptorAgent.intercept = false
+      mail.to.should eq ['fred@example.com']
     end
 
   end


### PR DESCRIPTION
This is the minimum amount of code to allow interceptors and observers to be unregistered.

Optionally, this patch allows me to get rid of `InterceptorAgent.intercept = true` in the tests. These seem to be just for testing purposes, and we should probably use the unregister functionality to unregister them, instead of this artifact. Agreed?

Fixes #703 and #704
