### PR TITLE
Fix for when content looks like field name

### DIFF
--- a/lib/mail/fields/common/common_field.rb
+++ b/lib/mail/fields/common/common_field.rb
@@ -43,7 +43,7 @@ module Mail
       if value.is_a?(Array)
         value
       else
-        value.to_s.gsub(/#{field_name}:\s+/i, '')
+        value.to_s.sub(/#{field_name}:\s+/i, '')
       end
     end
 

--- a/spec/mail/fields/common/common_field_spec.rb
+++ b/spec/mail/fields/common/common_field_spec.rb
@@ -69,4 +69,8 @@ describe Mail::CommonField do
     
   end
 
+  it "does not strip out content that looks identitcal to the field name" do
+    field = Mail::SubjectField.new("Subject: Subject: for your approval")
+    field.decoded.should == "Subject: for your approval"
+  end
 end


### PR DESCRIPTION
For example if a subject contains the the string "Subject: " in it. It currently gets dropped.

Fixes #710
