### PR TITLE
Using Mail::Field.new can strip out content that looks like the field name

### DIFF
--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -125,8 +125,9 @@ describe Mail::Field do
     end
 
     it "should not strip out content that looks like the field name" do
+      pending "pr#766"
       field = Mail::Field.new('Subject: subject: for your approval')
-      field.value.should == 'subject: for your approval'
+      expect(field.value).to eq 'subject: for your approval'
     end
   end
 

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -123,6 +123,11 @@ describe Mail::Field do
       field = Mail::Field.new('Subject: こんにちは', charset)
       expect(field.charset).to eq charset
     end
+
+    it "should not strip out content that looks like the field name" do
+      field = Mail::Field.new('Subject: subject: for your approval')
+      field.value.should == 'subject: for your approval'
+    end
   end
 
   describe "error handling" do


### PR DESCRIPTION
I need some advice here. I have this failing spec, but I'm not sure how to go about making it pass.

The issue is when calling `Mail::Field.new('Subject: subject: for your approval')` @name and @value are [parsed out](https://github.com/mikel/mail/blob/ed9edf5a8db32537a90ff77317e377a8b5916225/lib/mail/field.rb#L140) to "Subject:" and "subject: for your approval" respectively.

Later the @field is [set by calling](https://github.com/mikel/mail/blob/ed9edf5a8db32537a90ff77317e377a8b5916225/lib/mail/field.rb#L239) `Mail::SubjectField.new("subject: for your approval", charset)`

SubjectField then does its initialization and [calls strip_field](https://github.com/mikel/mail/blob/ed9edf5a8db32537a90ff77317e377a8b5916225/lib/mail/fields/subject_field.rb#L12) on "subject: for your approval". Since "subject: " looks like the name of the subject field, it gets stripped out, and thus ultimately the subject value gets set incorrectly.

I tried having the `new_field` method of Mail::Field add back in the field_name before passing it to the specific field type class, but that breaks other functionality.

Any advice as to the best set of changes I can make to fix this behavior?