### PR TITLE
Removed the "VERSION" file, as it breaks JRuby compiled JARs

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,0 @@
-major:2
-minor:6
-patch:2
-build:edge

--- a/lib/mail/version.rb
+++ b/lib/mail/version.rb
@@ -1,24 +1,4 @@
 # encoding: utf-8
 module Mail
-  module VERSION
-    
-    version = {}
-    File.read(File.join(File.dirname(__FILE__), '../', '../', 'VERSION')).each_line do |line|
-      type, value = line.chomp.split(":")
-      next if type =~ /^\s+$/  || value =~ /^\s+$/
-      version[type] = value
-    end
-    
-    MAJOR = version['major']
-    MINOR = version['minor']
-    PATCH = version['patch']
-    BUILD = version['build']
-
-    STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
-    
-    def self.version
-      STRING
-    end
-    
-  end
+  VERSION = "2.6.2.edge"
 end

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -4,7 +4,7 @@ require 'mail/version'
 
 Gem::Specification.new do |s|
   s.name        = "mail"
-  s.version     = Mail::VERSION::STRING
+  s.version     = Mail::VERSION
   s.author      = "Mikel Lindsaar"
   s.email       = "raasdnil@gmail.com"
   s.homepage    = "http://github.com/mikel/mail"
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc')
 
   s.require_path = 'lib'
-  s.files = %w(README.md VERSION MIT-LICENSE CONTRIBUTING.md CHANGELOG.rdoc Dependencies.txt Gemfile Rakefile TODO.rdoc) + Dir.glob("lib/**/*")
+  s.files = %w(README.md MIT-LICENSE CONTRIBUTING.md CHANGELOG.rdoc Dependencies.txt Gemfile Rakefile TODO.rdoc) + Dir.glob("lib/**/*")
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ require File.join(File.dirname(__FILE__), 'matchers', 'break_down_to')
 
 require 'mail'
 
-STDERR.puts("Running Specs for Mail Version #{Mail::VERSION::STRING}")
+STDERR.puts("Running Specs for Mail Version #{Mail::VERSION}")
 
 RSpec.configure do |c|
   c.mock_with :rspec


### PR DESCRIPTION
I'm curious as to why this pattern is/was used.

```
Errno::ENOENT: No such file or directory - file:/usr/lib/...jar!/gems/mail-2.5.4/lib/mail/../VERSION
     read at org/jruby/RubyIO.java:3776
     read at org/jruby/RubyIO.java:3955
```
