### PR TITLE
Always use an SSL context. [Fixes #548]

### DIFF
--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -132,15 +132,11 @@ module Mail
         openssl_verify_mode = "OpenSSL::SSL::VERIFY_#{openssl_verify_mode.upcase}".constantize
       end
 
-      if RUBY_VERSION < '1.9.0'
-        openssl_verify_mode
-      else
-        context = Net::SMTP.default_ssl_context
-        context.verify_mode = openssl_verify_mode
-        context.ca_path = settings[:ca_path] if settings[:ca_path]
-        context.ca_file = settings[:ca_file] if settings[:ca_file]
-        context
-      end
+      context = Net::SMTP.default_ssl_context
+      context.verify_mode = openssl_verify_mode
+      context.ca_path = settings[:ca_path] if settings[:ca_path]
+      context.ca_file = settings[:ca_file] if settings[:ca_file]
+      context
     end
   end
 end


### PR DESCRIPTION
This reverts commit 9890b197c51f1d340fa7275aa4bc17103746657b, as latest
patch releases of 1.8.7 do accept an OpenSSL context object.

This has been broken since the refactoring d6e25e5e37e6d591f94cc04a2a52c1128fde81db,
which increased the scope of the original breakage.

montdidier: I'm not sure why a PR wasn't created for this already, maybe i am missing something but it seems there are folks who would benefit from this being released upstream.
