### PR TITLE
Set the Ruby string encoding from the charset

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2149,7 +2149,6 @@ module Mail
         else
           if encoding = Encoding.find(charset) rescue nil
             body_text.force_encoding(encoding)
-            return body_text.encode(Encoding::UTF_8, :undef => :replace, :invalid => :replace, :replace => '')
           end
         end
       end

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -195,4 +195,36 @@ describe "mail encoding" do
       expect(m.subject).to eq "Hello  World"
     end
   end
+
+  context "decoded Ruby string encoding" do
+    context "non multipart" do
+      it "should set Ruby string encoding from charset" do
+        original_body = "hey"
+        encoding = 'ISO-8859-1'
+        original_body.force_encoding(encoding) if original_body.respond_to?(:force_encoding)
+        mail = Mail.new
+        mail.content_type = "text/plain"
+        mail.charset = encoding
+        mail.body = original_body
+        expect(mail.decoded).to eq(original_body)
+        expect(mail.decoded.encoding).to eq(original_body.encoding) if original_body.respond_to?(:encoding)
+      end
+    end
+
+    context "multipart" do
+      it "should set Ruby string encoding from charset" do
+        original_body = "hey"
+        encoding = 'ISO-8859-1'
+        original_body.force_encoding(encoding) if original_body.respond_to?(:force_encoding)
+        mail = Mail.new
+        part = Mail::Part.new
+        part.content_type = "text/plain"
+        part.charset = encoding
+        part.body = original_body
+        mail.add_part(part)
+        expect(mail.text_part.decoded).to eq(original_body)
+        expect(mail.text_part.decoded.encoding).to eq(original_body.encoding) if original_body.respond_to?(:encoding)
+      end
+    end
+  end
 end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -341,11 +341,10 @@ describe Mail::Message do
 
     it "should parse non-UTF8 sources" do
       raw_message = File.read(fixture('emails', 'multi_charset', 'japanese_shiftjis.eml'))
-      original_encoding = raw_message.encoding if raw_message.respond_to?(:encoding)
       mail = Mail.new(raw_message)
       expect(mail.to).to eq ["raasdnil@gmail.com"]
-      expect(mail.decoded).to eq "すみません。\n\n"
-      expect(raw_message.encoding).to eq original_encoding if raw_message.respond_to?(:encoding)
+      expect(mail.decoded).to eq "すみません。\n\n".encode("ISO-2022-JP")
+      expect(mail.decoded.encoding.name).to eq "ISO-2022-JP" if mail.decoded.respond_to?(:encoding)
     end
   end
 
@@ -1455,7 +1454,7 @@ describe Mail::Message do
     end
 
     it "should be decoded using content type charset" do
-      expect(@message.decoded).to eq "América"
+      expect(@message.decoded).to eq "América".encode("ISO-8859-1")
     end
 
     it "should respond true to text?" do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1456,7 +1456,9 @@ describe Mail::Message do
     end
 
     it "should be decoded using content type charset" do
-      expect(@message.decoded).to eq "América".encode("ISO-8859-1")
+      expected_string = "América"
+      expected_string = expected_string.encode("ISO-8859-1") if expected_string.respond_to?(:encode)
+      expect(@message.decoded).to eq expected_string
     end
 
     it "should respond true to text?" do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -341,9 +341,11 @@ describe Mail::Message do
 
     it "should parse non-UTF8 sources" do
       raw_message = File.read(fixture('emails', 'multi_charset', 'japanese_shiftjis.eml'))
+      original_body = "すみません。\n\n"
+      original_body = original_body.encode("ISO-2022-JP") if original_body.respond_to?(:encode)
       mail = Mail.new(raw_message)
       expect(mail.to).to eq ["raasdnil@gmail.com"]
-      expect(mail.decoded).to eq "すみません。\n\n".encode("ISO-2022-JP")
+      expect(mail.decoded).to eq original_body
       expect(mail.decoded.encoding.name).to eq "ISO-2022-JP" if mail.decoded.respond_to?(:encoding)
     end
   end


### PR DESCRIPTION
Related: https://github.com/mikel/mail/issues/618#issuecomment-49389043

When getting the decoded string back for the body of a `Message` which is text (i.e. `text?` is true), the original encoding (which should be present in the charset) is lost, and it currently always forces to UTF-8. That seems bad, since if we know the "right" encoding (which we do, presuming the charset on the message is correct) if seems more desirable to use it.

The encoding stuff seems super hairy, so if I've totally misunderstood something, let me know :)

Only implemented for Ruby 1.9+, I'm not sure it's possible for < 1.9 since we do not know the current string encoding to pass to `Iconv`. Let me know if there is a way.
