### PR TITLE
use pending and fix unnecessary skips

### DIFF
--- a/spec/mail/elements/address_list_spec.rb
+++ b/spec/mail/elements/address_list_spec.rb
@@ -13,7 +13,7 @@ describe Mail::AddressList do
       parse_text = '@@@@@@'
       expect { Mail::AddressList.new(parse_text) }.to raise_error
     end
-    
+
     it "should not raise an error if the input is just blank" do
       parse_text = nil
       expect { Mail::AddressList.new(parse_text) }.not_to raise_error
@@ -68,7 +68,7 @@ describe Mail::AddressList do
     end
 
     it "should handle malformed folding whitespace" do
-      skip
+      pending
       parse_text = "leads@sg.dc.com,\n\t sag@leads.gs.ry.com,\n\t sn@example-hotmail.com,\n\t e-s-a-g-8718@app.ar.com,\n\t jp@t-exmaple.com,\n\t\n\t cc@c-l-example.com"
       result = %w(leads@sg.dc.com sag@leads.gs.ry.com sn@example-hotmail.com e-s-a-g-8718@app.ar.com jp@t-exmaple.com cc@c-l-example.com)
       a = Mail::AddressList.new(parse_text)
@@ -81,9 +81,8 @@ describe Mail::AddressList do
       a = Mail::AddressList.new(parse_text)
       expect(a.addresses.first.comments).to eq result
     end
-
   end
-  
+
   describe "functionality" do
     it "should give all the groups when asked" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
@@ -99,14 +98,13 @@ describe Mail::AddressList do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(list.addresses.length).to eq 3
     end
-    
+
     it "should handle a really nasty obsolete address list" do
-      skip
       psycho_obsolete = "Mary Smith <@machine.tld:mary@example.net>, , jdoe@test   . example"
       list = Mail::AddressList.new(psycho_obsolete)
       expect(list.addresses.length).to eq 2
     end
-    
+
 
     it "should create an address instance for each address returned" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
@@ -119,7 +117,7 @@ describe Mail::AddressList do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(list.group_names).to eq ["my_group"]
     end
-    
+
   end
-  
+
 end

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -567,7 +567,7 @@ describe Mail::Address do
       end
 
       it "should handle |jdoe@test   . example|" do
-        skip
+        pending
         address = Mail::Address.new('jdoe@test   . example')
         expect(address).to break_down_to({
                                          :name         => 'jdoe@test.example',

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -96,7 +96,6 @@ describe "mail encoding" do
 
     describe "quoting token unsafe chars" do
       it "should quote the display name" do
-        skip
         mail = Mail.new
         mail.charset = 'utf-8'
         mail.to = "Mikel @ me Lindsaar <mikel@test.lindsaar.net>"

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -510,7 +510,6 @@ describe Mail::Encodings do
     end
 
     it "should handle Base64 encoded ISO-2022-JP string" do
-      skip
       string = "ISO-2022-JP =?iso-2022-jp?B?GyRCJCQkPSRLITwkXiRrJEskSyE8JDgkJyQkJFQhPBsoQg==?="
       result = "ISO-2022-JP いそにーまるににーじぇいぴー"
       expect(Mail::Encodings.value_decode(string)).to eq result

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -204,7 +204,7 @@ describe "Test emails" do
     # that appear in the "To:" field, and the spaces that appear around the
     # "." in the jdoe address.
     it "should handle the rfc obsolete addressing" do
-      skip
+      pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example11.eml'))
       expect(mail[:from].addresses).to eq ['john.q.public@example.com']
       expect(mail.from).to eq '"Joe Q. Public" <john.q.public@example.com>'
@@ -220,7 +220,7 @@ describe "Test emails" do
     # day-of-week is missing, that is not specific to the obsolete syntax;
     # it is optional in the current syntax as well.
     it "should handle the rfc obsolete dates" do
-      skip
+      pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example12.eml'))
       expect(mail.from).to eq 'jdoe@machine.example'
       expect(mail.to).to eq 'mary@example.net'
@@ -241,7 +241,7 @@ describe "Test emails" do
     # addresses, dates, and message identifiers are all part of the
     # obsolete syntax.
     it "should handle the rfc obsolete whitespace email" do
-      skip
+      pending
       mail = Mail.read(fixture('emails', 'rfc2822', 'example13.eml'))
       expect(mail.from).to eq 'John Doe <jdoe@machine(comment).example>'
       expect(mail.to).to eq 'Mary Smith <mary@example.net>'

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -646,7 +646,7 @@ describe Mail::ContentTypeField do
       end
       c = Mail::ContentTypeField.new('application/octet-stream')
       string = "01 Quien Te Dij\221at. Pitbull.mp3"
-      case 
+      case
       when RUBY_VERSION >= '1.9.3'
         string.force_encoding('SJIS')
         result = %Q{Content-Type: application/octet-stream;\r\n\sfilename*=windows-31j'jp'01%20Quien%20Te%20Dij%91%61t.%20Pitbull.mp3\r\n}
@@ -738,7 +738,6 @@ describe Mail::ContentTypeField do
     end
 
     it "should just ignore illegal params like audio/x-midi;\r\n\sname=Part .exe" do
-      skip "fixed in pr #481"
       c = Mail::ContentTypeField.new("audio/x-midi;\r\n\sname=Part .exe")
       expect(c.string).to eq 'audio/x-midi'
       expect(c.parameters['name']).to eq nil

--- a/spec/mail/fields/sender_field_spec.rb
+++ b/spec/mail/fields/sender_field_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 
 describe Mail::SenderField do
   # sender          =       "Sender:" mailbox CRLF
-  # 
-  
+  #
+
   describe "initialization" do
 
     it "should initialize" do
@@ -12,7 +12,7 @@ describe Mail::SenderField do
     end
 
     it "should mix in the CommonAddress module" do
-      expect(Mail::SenderField.included_modules).to include(Mail::CommonAddress) 
+      expect(Mail::SenderField.included_modules).to include(Mail::CommonAddress)
     end
 
     it "should accept a string with the field name" do
@@ -28,12 +28,11 @@ describe Mail::SenderField do
     end
 
     it "should reject headers with multiple mailboxes" do
-      skip 'Sender accepts an address list now, but should only accept a single address'
+      pending 'Sender accepts an address list now, but should only accept a single address'
       expect { Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>') }.to raise_error
     end
-
   end
-  
+
   # Actual testing of CommonAddress methods oSenderurs in the address field spec file
 
   describe "instance methods" do
@@ -46,18 +45,18 @@ describe Mail::SenderField do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
       expect(t.address.to_s).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
-    
+
     it "should return the encoded line" do
       t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
       expect(t.encoded).to eq "Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
     end
-    
+
   end
-  
-  
+
+
 end


### PR DESCRIPTION
pending will alert when a skip is fixed, increasing the test coverage.
Afaik skip should only be used when the spec causes infinite loops etc evils.

@bf4
