### PR TITLE
support blank q/b value

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -114,7 +114,7 @@ module Mail
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.value_decode(str)
       # Optimization: If there's no encoded-words in the string, just return it
-      return str unless str =~ /\=\?[^?]+\?[QB]\?[^?]+?\?\=/xmi
+      return str unless str =~ /\=\?[^?]+\?[QB]\?[^?]*?\?\=/xmi
 
       lines = collapse_adjacent_encodings(str)
 
@@ -126,7 +126,7 @@ module Mail
           else
             # Search for occurences of quoted strings or plain strings
             text.scan(/(                                 # Group around entire regex to include it in matches
-                        \=\?[^?]+\?([QB])\?[^?]+?\?\=    # Quoted String with subgroup for encoding method
+                        \=\?[^?]+\?([QB])\?[^?]*?\?\=    # Quoted String with subgroup for encoding method
                         |                                # or
                         .+?(?=\=\?|$)                    # Plain String
                       )/xmi).map do |matches|
@@ -256,7 +256,7 @@ module Mail
     end
 
     def Encodings.split_encoding_from_string( str )
-      match = str.match(/\=\?([^?]+)?\?[QB]\?(.+)?\?\=/mi)
+      match = str.match(/\=\?([^?]+)?\?[QB]\?(.*)\?\=/mi)
       if match
         match[1]
       else
@@ -270,7 +270,7 @@ module Mail
 
     # Gets the encoding type (Q or B) from the string.
     def Encodings.split_value_encoding_from_string(str)
-      match = str.match(/\=\?[^?]+?\?([QB])\?(.+)?\?\=/mi)
+      match = str.match(/\=\?[^?]+?\?([QB])\?(.*)\?\=/mi)
       if match
         match[1]
       else

--- a/lib/mail/version_specific/ruby_1_8.rb
+++ b/lib/mail/version_specific/ruby_1_8.rb
@@ -62,7 +62,7 @@ module Mail
     end
 
     def Ruby18.b_value_decode(str)
-      match = str.match(/\=\?(.+)?\?[Bb]\?(.+)?\?\=/m)
+      match = str.match(/\=\?(.+)?\?[Bb]\?(.*)\?\=/m)
       if match
         encoding = match[1]
         str = Ruby18.decode_base64(match[2])
@@ -79,7 +79,7 @@ module Mail
     end
 
     def Ruby18.q_value_decode(str)
-      match = str.match(/\=\?(.+)?\?[Qq]\?(.+)?\?\=/m)
+      match = str.match(/\=\?(.+)?\?[Qq]\?(.*)\?\=/m)
       if match
         encoding = match[1]
         string = match[2].gsub(/_/, '=20')

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -49,7 +49,7 @@ module Mail
     end
 
     def Ruby19.b_value_decode(str)
-      match = str.match(/\=\?(.+)?\?[Bb]\?(.+)?\?\=/m)
+      match = str.match(/\=\?(.+)?\?[Bb]\?(.*)\?\=/m)
       if match
         charset = match[1]
         str = Ruby19.decode_base64(match[2])
@@ -65,7 +65,7 @@ module Mail
     end
 
     def Ruby19.q_value_decode(str)
-      match = str.match(/\=\?(.+)?\?[Qq]\?(.+)?\?\=/m)
+      match = str.match(/\=\?(.+)?\?[Qq]\?(.*)\?\=/m)
       if match
         charset = match[1]
         string = match[2].gsub(/_/, '=20')

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -166,6 +166,10 @@ describe Mail::Encodings do
       expect(Mail::Encodings.value_decode(string)).to eq(result)
     end
 
+    it "should decode a blank string" do
+      expect(Mail::Encodings.value_decode("=?utf-8?B??=")).to eq ""
+    end
+
     if '1.9'.respond_to?(:force_encoding)
       it "should decode 8bit encoded string" do
         string = "=?8bit?Q?ALPH=C3=89E?="
@@ -296,6 +300,10 @@ describe Mail::Encodings do
       wrapped = mail[:subject].wrapped_value
       unwrapped = Mail::Encodings.value_decode(wrapped)
       expect(unwrapped.gsub("Subject: ", "")).to eq original
+    end
+
+    it "should decode a blank string" do
+      expect(Mail::Encodings.value_decode("=?utf-8?Q??=")).to eq ""
     end
   end
 


### PR DESCRIPTION
blank q/b values were ignored and blow up when used directly since `match[2]` is nil (since it was optional) and then blows up

@bf4
