### PR TITLE
unkown/broken encoding should be binary, not text/plain

### DIFF
--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -194,7 +194,7 @@ module Mail
       when val =~ /^([\w\-]+)\/([\w\-]+);.+$/i
         "#{$1}/#{$2}"
       else
-        'text/plain'
+        'encoding/binary'
       end
     end
   end


### PR DESCRIPTION
this seems wrong and leads to users trying to open weird file in their text-editor

```
Mail::ContentTypeField.new("; name=\"logs.zip\"").to_s
=> text/plain
```

not sure what you think about this ...

@jeremy @bf4
