### PR TITLE
let me set a default charset

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -105,7 +105,7 @@ module Mail
       @html_part = nil
       @errors = nil
       @header = nil
-      @charset = 'UTF-8'
+      @charset = self.class.default_charset
       @defaulted_charset = true
 
       @smtp_envelope_from = nil
@@ -206,6 +206,10 @@ module Mail
     # This setting is ignored by mail (though still available as a flag) if you
     # define a delivery_handler
     attr_accessor :raise_delivery_errors
+
+    def self.default_charset; @@default_charset; end
+    def self.default_charset=(charset); @@default_charset = charset; end
+    self.default_charset = 'UTF-8'
 
     def register_for_delivery_notification(observer)
       STDERR.puts("Message#register_for_delivery_notification is deprecated, please call Mail.register_observer instead")

--- a/lib/mail/parsers/ragel/ruby.rb
+++ b/lib/mail/parsers/ragel/ruby.rb
@@ -3,11 +3,12 @@ module Mail
     module Ragel
       module Ruby
         def self.silence_warnings
-          original_verbose = $VERBOSE
-          $VERBOSE = nil
+          old, $VERBOSE = $VERBOSE, nil
           yield
-          $VERBOSE = original_verbose
+        ensure
+          $VERBOSE = old
         end
+
         # Ragel-generated parsers give a lot of warnings
         # and may cause logs to balloon in size
         silence_warnings do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -70,6 +70,14 @@ describe Mail::Message do
       Mail.read(fixture('emails', 'error_emails', 'bad_subject.eml')).subject
     end
 
+    it 'should use default charset' do
+      begin
+        Mail::Message.default_charset, old = 'iso-8859-1', Mail::Message.default_charset
+        expect(Mail::Message.new.charset).to eq 'iso-8859-1'
+      ensure
+        Mail::Message.default_charset = old
+      end
+    end
 
     it 'should be able to parse an email missing an encoding' do
       Mail.read(fixture('emails', 'error_emails', 'must_supply_encoding.eml'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,12 +30,10 @@ end
 # NOTE: We set the KCODE manually here in 1.8.X because upgrading to rspec-2.8.0 caused it
 #       to default to "NONE" (Why!?).
 $KCODE='UTF8' if RUBY_VERSION < '1.9'
+
 if defined?(Encoding) && Encoding.respond_to?(:default_external=)
-  begin
-    old, $VERBOSE = $VERBOSE, nil
+  Mail::Parsers::Ragel::Ruby.silence_warnings do
     Encoding.default_external = 'utf-8'
-  ensure
-    $VERBOSE = old
   end
 end
 


### PR DESCRIPTION
I'd prefer iso-8859-1, let me set it without doing monkeypatches

@jeremy @bf4

atm I'm using this:

``` Ruby
module DefaultCharset
  def init_with_string(*args, &block)
    @charset = 'iso-8859-1'
    super
  end
end

Mail::Message.prepend(DefaultCharset)
```
