### PR TITLE
parse non-ascci filenames

### DIFF
--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -96,15 +96,7 @@ module Mail
     end
 
     def filename
-      case
-      when parameters['filename']
-        @filename = parameters['filename']
-      when parameters['name']
-        @filename = parameters['name']
-      else
-        @filename = nil
-      end
-      @filename
+      parameters['filename'] || parameters['name'] || value[/name="(.*?)"/, 1]
     end
 
     # TODO: Fix this up

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -620,6 +620,12 @@ describe Mail::ContentTypeField do
       expect(c.filename).to eq 'mikel.jpg'
     end
 
+    it "should locate non-ascii filename" do
+      string = 'application/msword; name="Êëèêîâàÿ_ðåêëàìà.doc"'
+      c = Mail::ContentTypeField.new(string)
+      expect(c.filename).to eq 'Êëèêîâàÿ_ðåêëàìà.doc'
+    end
+
     it "should locate a name if there is no filename" do
       string = %q{application/octet-stream; name=mikel.jpg}
       c = Mail::ContentTypeField.new(string)


### PR DESCRIPTION
failing spec, not sure how to fix :/

when I remove the rescue in `def element` I get:

```
Mail::ContentTypeElement can not parse |application/msword; name="Êëèêîâàÿ_ðåêëàìà.doc"|
       Reason was: Only able to parse up to application/msword; name="Ê
```

@jeremy @bf4
