### PR TITLE
remove duplicate field stripping

### DIFF
--- a/lib/mail/elements/content_transfer_encoding_element.rb
+++ b/lib/mail/elements/content_transfer_encoding_element.rb
@@ -5,7 +5,7 @@ module Mail
     include Mail::Utilities
     
     def initialize(string)
-      content_transfer_encoding = Mail::Parsers::ContentTransferEncodingParser.new.parse(string)
+      content_transfer_encoding = Mail::Parsers::ContentTransferEncodingParser.new.parse(string.to_s)
       @encoding = content_transfer_encoding.encoding
     end
     

--- a/lib/mail/envelope.rb
+++ b/lib/mail/envelope.rb
@@ -1,23 +1,23 @@
 # encoding: utf-8
-# 
+#
 # = Mail Envelope
-# 
+#
 # The Envelope class provides a field for the first line in an
 # mbox file, that looks like "From mikel@test.lindsaar.net DATETIME"
-# 
+#
 # This envelope class reads that line, and turns it into an
 # Envelope.from and Envelope.date for your use.
 module Mail
   class Envelope < StructuredField
-    
+
     def initialize(*args)
-      super(FIELD_NAME, strip_field(FIELD_NAME, args.last))
+      super(FIELD_NAME, args.last.to_s)
     end
-    
+
     def element
       @element ||= Mail::EnvelopeFromElement.new(value)
     end
-    
+
     def date
       ::DateTime.parse("#{element.date_time}")
     end
@@ -25,6 +25,6 @@ module Mail
     def from
       element.address
     end
-    
+
   end
 end

--- a/lib/mail/fields/bcc_field.rb
+++ b/lib/mail/fields/bcc_field.rb
@@ -1,47 +1,47 @@
 # encoding: utf-8
-# 
+#
 # = Blind Carbon Copy Field
-# 
+#
 # The Bcc field inherits from StructuredField and handles the Bcc: header
 # field in the email.
-# 
+#
 # Sending bcc to a mail message will instantiate a Mail::Field object that
 # has a BccField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Bcc field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.bcc = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.bcc    #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:bcc]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::BccField:0x180e1c4
 #  mail['bcc'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::BccField:0x180e1c4
 #  mail['Bcc'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::BccField:0x180e1c4
-# 
+#
 #  mail[:bcc].encoded   #=> ''      # Bcc field does not get output into an email
 #  mail[:bcc].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:bcc].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:bcc].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class BccField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'bcc'
     CAPITALIZED_FIELD = 'Bcc'
-    
+
     def initialize(value = '', charset = 'utf-8')
       @charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def include_in_headers=(include_in_headers)
       @include_in_headers = include_in_headers
     end
@@ -58,10 +58,10 @@ module Mail
         ''
       end
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/cc_field.rb
+++ b/lib/mail/fields/cc_field.rb
@@ -1,54 +1,54 @@
 # encoding: utf-8
-# 
+#
 # = Carbon Copy Field
-# 
+#
 # The Cc field inherits from StructuredField and handles the Cc: header
 # field in the email.
-# 
+#
 # Sending cc to a mail message will instantiate a Mail::Field object that
 # has a CcField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Cc field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.cc = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.cc    #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:cc]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::CcField:0x180e1c4
 #  mail['cc'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::CcField:0x180e1c4
 #  mail['Cc'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::CcField:0x180e1c4
-# 
+#
 #  mail[:cc].encoded   #=> 'Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net\r\n'
 #  mail[:cc].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:cc].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:cc].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class CcField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'cc'
     CAPITALIZED_FIELD = 'Cc'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/comments_field.rb
+++ b/lib/mail/fields/comments_field.rb
@@ -1,41 +1,41 @@
 # encoding: utf-8
-# 
+#
 # = Comments Field
-# 
+#
 # The Comments field inherits from UnstructuredField and handles the Comments:
 # header field in the email.
-# 
+#
 # Sending comments to a mail message will instantiate a Mail::Field object that
 # has a CommentsField as its field type.
-#  
+#
 # An email header can have as many comments fields as it wants.  There is no upper
 # limit, the comments field is also optional (that is, no comment is needed)
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.comments = 'This is a comment'
 #  mail.comments    #=> 'This is a comment'
 #  mail[:comments]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::CommentsField:0x180e1c4
 #  mail['comments'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::CommentsField:0x180e1c4
 #  mail['comments'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::CommentsField:0x180e1c4
-# 
+#
 #  mail.comments = "This is another comment"
-#  mail[:comments].map { |c| c.to_s } 
+#  mail[:comments].map { |c| c.to_s }
 #  #=> ['This is a comment', "This is another comment"]
 #
 module Mail
   class CommentsField < UnstructuredField
-    
+
     FIELD_NAME = 'comments'
     CAPITALIZED_FIELD = 'Comments'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       @charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value))
+      super(CAPITALIZED_FIELD, value || "")
       self.parse
       self
     end
-    
+
   end
 end

--- a/lib/mail/fields/common/common_field.rb
+++ b/lib/mail/fields/common/common_field.rb
@@ -40,14 +40,6 @@ module Mail
 
     private
 
-    def strip_field(field_name, value)
-      if value.is_a?(Array)
-        value
-      else
-        value.to_s.sub(/\A#{field_name}:\s+/i, EMPTY)
-      end
-    end
-
     FILENAME_RE = /\b(filename|name)=([^;"\r\n]+\s[^;"\r\n]+)/
     def ensure_filename_quoted(value)
       if value.is_a?(String)

--- a/lib/mail/fields/content_description_field.rb
+++ b/lib/mail/fields/content_description_field.rb
@@ -1,19 +1,19 @@
 # encoding: utf-8
-# 
-# 
-# 
+#
+#
+#
 module Mail
   class ContentDescriptionField < UnstructuredField
-    
+
     FIELD_NAME = 'content-description'
     CAPITALIZED_FIELD = 'Content-Description'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
     end
-    
+
   end
 end

--- a/lib/mail/fields/content_disposition_field.rb
+++ b/lib/mail/fields/content_disposition_field.rb
@@ -10,7 +10,7 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       ensure_filename_quoted(value)
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
     end

--- a/lib/mail/fields/content_id_field.rb
+++ b/lib/mail/fields/content_id_field.rb
@@ -1,62 +1,62 @@
 # encoding: utf-8
-# 
-# 
-# 
+#
+#
+#
 module Mail
   class ContentIdField < StructuredField
-    
+
     FIELD_NAME = 'content-id'
     CAPITALIZED_FIELD = "Content-ID"
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       @uniq = 1
       if value.blank?
         value = generate_content_id
       else
-        value = strip_field(FIELD_NAME, value)
+        value = value.to_s
       end
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
     end
-    
+
     def parse(val = value)
       unless val.blank?
         @element = Mail::MessageIdsElement.new(val)
       end
     end
-    
+
     def element
       @element ||= Mail::MessageIdsElement.new(value)
     end
-    
+
     def name
       'Content-ID'
     end
-    
+
     def content_id
       element.message_id
     end
-    
+
     def to_s
       "<#{content_id}>"
     end
-    
+
     # TODO: Fix this up
     def encoded
       "#{CAPITALIZED_FIELD}: #{to_s}\r\n"
     end
-    
+
     def decoded
       "#{to_s}"
     end
-    
+
     private
-    
+
     def generate_content_id
       "<#{Mail.random_tag}@#{::Socket.gethostname}.mail>"
     end
-    
+
   end
 end

--- a/lib/mail/fields/content_location_field.rb
+++ b/lib/mail/fields/content_location_field.rb
@@ -1,26 +1,26 @@
 # encoding: utf-8
-# 
-# 
-# 
+#
+#
+#
 module Mail
   class ContentLocationField < StructuredField
-    
+
     FIELD_NAME = 'content-location'
     CAPITALIZED_FIELD = 'Content-Location'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
     end
-    
+
     def parse(val = value)
       unless val.blank?
         @element = Mail::ContentLocationElement.new(val)
       end
     end
-    
+
     def element
       @element ||= Mail::ContentLocationElement.new(value)
     end
@@ -33,9 +33,9 @@ module Mail
     def encoded
       "#{CAPITALIZED_FIELD}: #{location}\r\n"
     end
-    
+
     def decoded
-      location 
+      location
     end
 
   end

--- a/lib/mail/fields/content_transfer_encoding_field.rb
+++ b/lib/mail/fields/content_transfer_encoding_field.rb
@@ -1,44 +1,44 @@
 # encoding: utf-8
-# 
-# 
-# 
+#
+#
+#
 module Mail
   class ContentTransferEncodingField < StructuredField
-    
+
     FIELD_NAME = 'content-transfer-encoding'
     CAPITALIZED_FIELD = 'Content-Transfer-Encoding'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       value = '7bit' if value.to_s =~ /7-?bits?/i
       value = '8bit' if value.to_s =~ /8-?bits?/i
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
     end
-    
+
     def parse(val = value)
       unless val.blank?
         @element = Mail::ContentTransferEncodingElement.new(val)
       end
     end
-    
+
     def element
       @element ||= Mail::ContentTransferEncodingElement.new(value)
     end
-    
+
     def encoding
       element.encoding
     end
-    
+
     # TODO: Fix this up
     def encoded
       "#{CAPITALIZED_FIELD}: #{encoding}\r\n"
     end
-    
+
     def decoded
       encoding
     end
-    
+
   end
 end

--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -17,7 +17,7 @@ module Mail
         @main_type = nil
         @sub_type = nil
         @parameters = nil
-        value = strip_field(FIELD_NAME, value)
+        value = value.to_s
       end
       ensure_filename_quoted(value)
       super(CAPITALIZED_FIELD, value, charset)

--- a/lib/mail/fields/date_field.rb
+++ b/lib/mail/fields/date_field.rb
@@ -36,7 +36,7 @@ module Mail
       if value.blank?
         value = ::DateTime.now.strftime('%a, %d %b %Y %H:%M:%S %z')
       else
-        value = strip_field(FIELD_NAME, value)
+        value = value.to_s
         value.to_s.gsub!(/\(.*?\)/, '')
         value = ::DateTime.parse(value.to_s.squeeze(" ")).strftime('%a, %d %b %Y %H:%M:%S %z')
       end

--- a/lib/mail/fields/from_field.rb
+++ b/lib/mail/fields/from_field.rb
@@ -1,51 +1,51 @@
 # encoding: utf-8
-# 
+#
 # = From Field
-# 
+#
 # The From field inherits from StructuredField and handles the From: header
 # field in the email.
-# 
+#
 # Sending from to a mail message will instantiate a Mail::Field object that
 # has a FromField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one From field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.from = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.from    #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:from]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::FromField:0x180e1c4
 #  mail['from'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::FromField:0x180e1c4
 #  mail['From'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::FromField:0x180e1c4
-# 
+#
 #  mail[:from].encoded   #=> 'from: Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net\r\n'
 #  mail[:from].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:from].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:from].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class FromField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'from'
     CAPITALIZED_FIELD = 'From'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end

--- a/lib/mail/fields/in_reply_to_field.rb
+++ b/lib/mail/fields/in_reply_to_field.rb
@@ -1,56 +1,56 @@
 # encoding: utf-8
-# 
+#
 # = In-Reply-To Field
-# 
-# The In-Reply-To field inherits from StructuredField and handles the 
+#
+# The In-Reply-To field inherits from StructuredField and handles the
 # In-Reply-To: header field in the email.
-# 
+#
 # Sending in_reply_to to a mail message will instantiate a Mail::Field object that
 # has a InReplyToField as its field type.  This includes all Mail::CommonMessageId
 # module instance metods.
-# 
+#
 # Note that, the #message_ids method will return an array of message IDs without the
 # enclosing angle brackets which per RFC are not syntactically part of the message id.
-# 
+#
 # Only one InReplyTo field can appear in a header, though it can have multiple
 # Message IDs.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.in_reply_to = '<F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom>'
 #  mail.in_reply_to    #=> '<F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom>'
 #  mail[:in_reply_to]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::InReplyToField:0x180e1c4
 #  mail['in_reply_to'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::InReplyToField:0x180e1c4
 #  mail['In-Reply-To'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::InReplyToField:0x180e1c4
-# 
+#
 #  mail[:in_reply_to].message_ids #=> ['F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom']
-# 
+#
 require 'mail/fields/common/common_message_id'
 
 module Mail
   class InReplyToField < StructuredField
-    
+
     include Mail::CommonMessageId
-    
+
     FIELD_NAME = 'in-reply-to'
     CAPITALIZED_FIELD = 'In-Reply-To'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       value = value.join("\r\n\s") if value.is_a?(Array)
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/keywords_field.rb
+++ b/lib/mail/fields/keywords_field.rb
@@ -1,15 +1,15 @@
 # encoding: utf-8
-# 
+#
 # keywords        =       "Keywords:" phrase *("," phrase) CRLF
 module Mail
   class KeywordsField < StructuredField
-    
+
     FIELD_NAME = 'keywords'
     CAPITALIZED_FIELD = 'Keywords'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
 
@@ -18,19 +18,19 @@ module Mail
         @phrase_list ||= PhraseList.new(value)
       end
     end
-    
+
     def phrase_list
       @phrase_list ||= PhraseList.new(value)
     end
-      
+
     def keywords
       phrase_list.phrases
     end
-    
+
     def encoded
       "#{CAPITALIZED_FIELD}: #{keywords.join(",\r\n ")}\r\n"
     end
-    
+
     def decoded
       keywords.join(', ')
     end
@@ -38,6 +38,6 @@ module Mail
     def default
       keywords
     end
-    
+
   end
 end

--- a/lib/mail/fields/message_id_field.rb
+++ b/lib/mail/fields/message_id_field.rb
@@ -1,43 +1,43 @@
 # encoding: utf-8
-# 
+#
 # = Message-ID Field
-# 
-# The Message-ID field inherits from StructuredField and handles the 
+#
+# The Message-ID field inherits from StructuredField and handles the
 # Message-ID: header field in the email.
-# 
+#
 # Sending message_id to a mail message will instantiate a Mail::Field object that
 # has a MessageIdField as its field type.  This includes all Mail::CommonMessageId
 # module instance metods.
-# 
+#
 # Only one MessageId field can appear in a header, and syntactically it can only have
 # one Message ID.  The message_ids method call has been left in however as it will only
 # return the one message id, ie, an array of length 1.
-# 
+#
 # Note that, the #message_ids method will return an array of message IDs without the
 # enclosing angle brackets which per RFC are not syntactically part of the message id.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.message_id = '<F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom>'
 #  mail.message_id    #=> '<F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom>'
 #  mail[:message_id]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::MessageIdField:0x180e1c4
 #  mail['message_id'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::MessageIdField:0x180e1c4
 #  mail['Message-ID'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::MessageIdField:0x180e1c4
-# 
+#
 #  mail[:message_id].message_id   #=> 'F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom'
 #  mail[:message_id].message_ids  #=> ['F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom']
-# 
+#
 require 'mail/fields/common/common_message_id'
 
 module Mail
   class MessageIdField < StructuredField
-    
+
     include Mail::CommonMessageId
-    
+
     FIELD_NAME = 'message-id'
     CAPITALIZED_FIELD = 'Message-ID'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       @uniq = 1
@@ -45,38 +45,38 @@ module Mail
         self.name = CAPITALIZED_FIELD
         self.value = generate_message_id
       else
-        super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+        super(CAPITALIZED_FIELD, value || "", charset)
       end
       self.parse
       self
 
     end
-    
+
     def name
       'Message-ID'
     end
-    
+
     def message_ids
       [message_id]
     end
-    
+
     def to_s
       "<#{message_id}>"
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
     private
-    
+
     def generate_message_id
       "<#{Mail.random_tag}@#{::Socket.gethostname}.mail>"
     end
-    
+
   end
 end

--- a/lib/mail/fields/mime_version_field.rb
+++ b/lib/mail/fields/mime_version_field.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
-# 
-# 
-# 
+#
+#
+#
 module Mail
   class MimeVersionField < StructuredField
-    
+
     FIELD_NAME = 'mime-version'
     CAPITALIZED_FIELD = 'Mime-Version'
 
@@ -13,22 +13,22 @@ module Mail
       if value.blank?
         value = '1.0'
       end
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
 
     end
-    
+
     def parse(val = value)
       unless val.blank?
         @element = Mail::MimeVersionElement.new(val)
       end
     end
-    
+
     def element
       @element ||= Mail::MimeVersionElement.new(value)
     end
-    
+
     def version
       "#{element.major}.#{element.minor}"
     end
@@ -40,14 +40,14 @@ module Mail
     def minor
       element.minor.to_i
     end
-    
+
     def encoded
       "#{CAPITALIZED_FIELD}: #{version}\r\n"
     end
-    
+
     def decoded
       version
     end
-    
+
   end
 end

--- a/lib/mail/fields/received_field.rb
+++ b/lib/mail/fields/received_field.rb
@@ -1,48 +1,48 @@
 # encoding: utf-8
-# 
+#
 # trace           =       [return]
 #                         1*received
-# 
+#
 # return          =       "Return-Path:" path CRLF
-# 
+#
 # path            =       ([CFWS] "<" ([CFWS] / addr-spec) ">" [CFWS]) /
 #                         obs-path
-# 
+#
 # received        =       "Received:" name-val-list ";" date-time CRLF
-# 
+#
 # name-val-list   =       [CFWS] [name-val-pair *(CFWS name-val-pair)]
-# 
+#
 # name-val-pair   =       item-name CFWS item-value
-# 
+#
 # item-name       =       ALPHA *(["-"] (ALPHA / DIGIT))
-# 
+#
 # item-value      =       1*angle-addr / addr-spec /
 #                          atom / domain / msg-id
-# 
+#
 module Mail
   class ReceivedField < StructuredField
-    
+
     FIELD_NAME = 'received'
     CAPITALIZED_FIELD = 'Received'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
 
     end
-    
+
     def parse(val = value)
       unless val.blank?
         @element = Mail::ReceivedElement.new(val)
       end
     end
-    
+
     def element
       @element ||= Mail::ReceivedElement.new(value)
     end
-    
+
     def date_time
       @datetime ||= ::DateTime.parse("#{element.date_time}")
     end
@@ -50,11 +50,11 @@ module Mail
     def info
       element.info
     end
-   
+
     def formatted_date
       date_time.strftime("%a, %d %b %Y %H:%M:%S ") + date_time.zone.delete(':')
     end
- 
+
     def encoded
       if value.blank?
         "#{CAPITALIZED_FIELD}: \r\n"
@@ -62,14 +62,14 @@ module Mail
         "#{CAPITALIZED_FIELD}: #{info}; #{formatted_date}\r\n"
       end
     end
-    
+
     def decoded
       if value.blank?
         ""
       else
-        "#{info}; #{formatted_date}" 
+        "#{info}; #{formatted_date}"
       end
     end
-    
+
   end
 end

--- a/lib/mail/fields/references_field.rb
+++ b/lib/mail/fields/references_field.rb
@@ -1,56 +1,56 @@
 # encoding: utf-8
-# 
+#
 # = References Field
-# 
+#
 # The References field inherits references StructuredField and handles the References: header
 # field in the email.
-# 
+#
 # Sending references to a mail message will instantiate a Mail::Field object that
 # has a ReferencesField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Note that, the #message_ids method will return an array of message IDs without the
 # enclosing angle brackets which per RFC are not syntactically part of the message id.
-# 
+#
 # Only one References field can appear in a header, though it can have multiple
 # Message IDs.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.references = '<F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom>'
 #  mail.references    #=> '<F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom>'
 #  mail[:references]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ReferencesField:0x180e1c4
 #  mail['references'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ReferencesField:0x180e1c4
 #  mail['References'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ReferencesField:0x180e1c4
-# 
+#
 #  mail[:references].message_ids #=> ['F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@test.me.dom']
-# 
+#
 require 'mail/fields/common/common_message_id'
 
 module Mail
   class ReferencesField < StructuredField
-    
+
     include CommonMessageId
-    
+
     FIELD_NAME = 'references'
     CAPITALIZED_FIELD = 'References'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       value = value.join("\r\n\s") if value.is_a?(Array)
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/reply_to_field.rb
+++ b/lib/mail/fields/reply_to_field.rb
@@ -1,54 +1,54 @@
 # encoding: utf-8
-# 
+#
 # = Reply-To Field
-# 
+#
 # The Reply-To field inherits reply-to StructuredField and handles the Reply-To: header
 # field in the email.
-# 
+#
 # Sending reply_to to a mail message will instantiate a Mail::Field object that
 # has a ReplyToField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Reply-To field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.reply_to = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.reply_to    #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:reply_to]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ReplyToField:0x180e1c4
 #  mail['reply-to'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ReplyToField:0x180e1c4
 #  mail['Reply-To'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ReplyToField:0x180e1c4
-# 
+#
 #  mail[:reply_to].encoded   #=> 'Reply-To: Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net\r\n'
 #  mail[:reply_to].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:reply_to].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:reply_to].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class ReplyToField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'reply-to'
     CAPITALIZED_FIELD = 'Reply-To'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/resent_bcc_field.rb
+++ b/lib/mail/fields/resent_bcc_field.rb
@@ -1,54 +1,54 @@
 # encoding: utf-8
-# 
+#
 # = Resent-Bcc Field
-# 
-# The Resent-Bcc field inherits resent-bcc StructuredField and handles the 
+#
+# The Resent-Bcc field inherits resent-bcc StructuredField and handles the
 # Resent-Bcc: header field in the email.
-# 
+#
 # Sending resent_bcc to a mail message will instantiate a Mail::Field object that
 # has a ResentBccField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Resent-Bcc field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.resent_bcc = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.resent_bcc    #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:resent_bcc]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentBccField:0x180e1c4
 #  mail['resent-bcc'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentBccField:0x180e1c4
 #  mail['Resent-Bcc'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentBccField:0x180e1c4
-# 
+#
 #  mail[:resent_bcc].encoded   #=> 'Resent-Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net\r\n'
 #  mail[:resent_bcc].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:resent_bcc].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:resent_bcc].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class ResentBccField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'resent-bcc'
     CAPITALIZED_FIELD = 'Resent-Bcc'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/resent_cc_field.rb
+++ b/lib/mail/fields/resent_cc_field.rb
@@ -1,54 +1,54 @@
 # encoding: utf-8
-# 
+#
 # = Resent-Cc Field
-# 
+#
 # The Resent-Cc field inherits resent-cc StructuredField and handles the Resent-Cc: header
 # field in the email.
-# 
+#
 # Sending resent_cc to a mail message will instantiate a Mail::Field object that
 # has a ResentCcField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Resent-Cc field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.resent_cc = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.resent_cc    #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:resent_cc]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentCcField:0x180e1c4
 #  mail['resent-cc'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentCcField:0x180e1c4
 #  mail['Resent-Cc'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentCcField:0x180e1c4
-# 
+#
 #  mail[:resent_cc].encoded   #=> 'Resent-Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net\r\n'
 #  mail[:resent_cc].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:resent_cc].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:resent_cc].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class ResentCcField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'resent-cc'
     CAPITALIZED_FIELD = 'Resent-Cc'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/resent_date_field.rb
+++ b/lib/mail/fields/resent_date_field.rb
@@ -1,35 +1,35 @@
 # encoding: utf-8
-# 
+#
 # resent-date     =       "Resent-Date:" date-time CRLF
 require 'mail/fields/common/common_date'
 
 module Mail
   class ResentDateField < StructuredField
-    
+
     include Mail::CommonDate
-    
+
     FIELD_NAME = 'resent-date'
     CAPITALIZED_FIELD = 'Resent-Date'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       if value.blank?
         value = ::DateTime.now.strftime('%a, %d %b %Y %H:%M:%S %z')
       else
-        value = strip_field(FIELD_NAME, value)
+        value = value.to_s
         value = ::DateTime.parse(value.to_s).strftime('%a, %d %b %Y %H:%M:%S %z')
       end
       super(CAPITALIZED_FIELD, value, charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/resent_from_field.rb
+++ b/lib/mail/fields/resent_from_field.rb
@@ -1,17 +1,17 @@
 # encoding: utf-8
-# 
+#
 # = Resent-From Field
-# 
+#
 # The Resent-From field inherits resent-from StructuredField and handles the Resent-From: header
 # field in the email.
-# 
+#
 # Sending resent_from to a mail message will instantiate a Mail::Field object that
 # has a ResentFromField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Resent-From field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
 #
 #  mail = Mail.new
@@ -20,35 +20,35 @@
 #  mail[:resent_from]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentFromField:0x180e1c4
 #  mail['resent-from'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentFromField:0x180e1c4
 #  mail['Resent-From'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentFromField:0x180e1c4
-# 
+#
 #  mail[:resent_from].encoded   #=> 'Resent-From: Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net\r\n'
 #  mail[:resent_from].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:resent_from].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:resent_from].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class ResentFromField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'resent-from'
     CAPITALIZED_FIELD = 'Resent-From'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/resent_message_id_field.rb
+++ b/lib/mail/fields/resent_message_id_field.rb
@@ -1,34 +1,34 @@
 # encoding: utf-8
-# 
+#
 # resent-msg-id   =       "Resent-Message-ID:" msg-id CRLF
 require 'mail/fields/common/common_message_id'
 
 module Mail
   class ResentMessageIdField < StructuredField
-    
+
     include CommonMessageId
-    
+
     FIELD_NAME = 'resent-message-id'
     CAPITALIZED_FIELD = 'Resent-Message-ID'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self.parse
       self
     end
-    
+
     def name
       'Resent-Message-ID'
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/resent_sender_field.rb
+++ b/lib/mail/fields/resent_sender_field.rb
@@ -1,43 +1,43 @@
 # encoding: utf-8
-# 
+#
 # = Resent-Sender Field
-# 
+#
 # The Resent-Sender field inherits resent-sender StructuredField and handles the Resent-Sender: header
 # field in the email.
-# 
+#
 # Sending resent_sender to a mail message will instantiate a Mail::Field object that
 # has a ResentSenderField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Resent-Sender field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.resent_sender = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.resent_sender    #=> ['mikel@test.lindsaar.net']
 #  mail[:resent_sender]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentSenderField:0x180e1c4
 #  mail['resent-sender'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentSenderField:0x180e1c4
 #  mail['Resent-Sender'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentSenderField:0x180e1c4
-# 
+#
 #  mail.resent_sender.to_s  #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.resent_sender.addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail.resent_sender.formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class ResentSenderField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'resent-sender'
     CAPITALIZED_FIELD = 'Resent-Sender'
 
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
 
@@ -48,14 +48,14 @@ module Mail
     def address
       address_list.addresses.first
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/resent_to_field.rb
+++ b/lib/mail/fields/resent_to_field.rb
@@ -1,54 +1,54 @@
 # encoding: utf-8
-# 
+#
 # = Resent-To Field
-# 
+#
 # The Resent-To field inherits resent-to StructuredField and handles the Resent-To: header
 # field in the email.
-# 
+#
 # Sending resent_to to a mail message will instantiate a Mail::Field object that
 # has a ResentToField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Resent-To field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.resent_to = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.resent_to    #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:resent_to]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentToField:0x180e1c4
 #  mail['resent-to'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentToField:0x180e1c4
 #  mail['Resent-To'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ResentToField:0x180e1c4
-# 
+#
 #  mail[:resent_to].encoded   #=> 'Resent-To: Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net\r\n'
 #  mail[:resent_to].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:resent_to].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:resent_to].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class ResentToField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'resent-to'
     CAPITALIZED_FIELD = 'Resent-To'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/lib/mail/fields/return_path_field.rb
+++ b/lib/mail/fields/return_path_field.rb
@@ -1,64 +1,64 @@
 # encoding: utf-8
-# 
+#
 # 4.4.3.  REPLY-TO / RESENT-REPLY-TO
-# 
+#
 #    Note:  The "Return-Path" field is added by the mail  transport
 #           service,  at the time of final deliver.  It is intended
 #           to identify a path back to the orginator  of  the  mes-
 #           sage.   The  "Reply-To"  field  is added by the message
 #           originator and is intended to direct replies.
-# 
+#
 # trace           =       [return]
 #                         1*received
-# 
+#
 # return          =       "Return-Path:" path CRLF
-# 
+#
 # path            =       ([CFWS] "<" ([CFWS] / addr-spec) ">" [CFWS]) /
 #                         obs-path
-# 
+#
 # received        =       "Received:" name-val-list ";" date-time CRLF
-# 
+#
 # name-val-list   =       [CFWS] [name-val-pair *(CFWS name-val-pair)]
-# 
+#
 # name-val-pair   =       item-name CFWS item-value
-# 
+#
 # item-name       =       ALPHA *(["-"] (ALPHA / DIGIT))
-# 
+#
 # item-value      =       1*angle-addr / addr-spec /
 #                          atom / domain / msg-id
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class ReturnPathField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'return-path'
     CAPITALIZED_FIELD = 'Return-Path'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       value = nil if value == '<>'
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       "#{CAPITALIZED_FIELD}: <#{address}>\r\n"
     end
-    
+
     def decoded
       do_decode
     end
-    
+
     def address
       addresses.first
     end
-    
+
     def default
       address
     end
-    
+
   end
 end

--- a/lib/mail/fields/sender_field.rb
+++ b/lib/mail/fields/sender_field.rb
@@ -1,44 +1,44 @@
 # encoding: utf-8
-# 
+#
 # = Sender Field
-# 
+#
 # The Sender field inherits sender StructuredField and handles the Sender: header
 # field in the email.
-# 
+#
 # Sending sender to a mail message will instantiate a Mail::Field object that
 # has a SenderField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one Sender field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.sender = 'Mikel Lindsaar <mikel@test.lindsaar.net>'
 #  mail.sender    #=> 'mikel@test.lindsaar.net'
 #  mail[:sender]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::SenderField:0x180e1c4
 #  mail['sender'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::SenderField:0x180e1c4
 #  mail['Sender'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::SenderField:0x180e1c4
-# 
+#
 #  mail[:sender].encoded   #=> "Sender: Mikel Lindsaar <mikel@test.lindsaar.net>\r\n"
 #  mail[:sender].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>'
 #  mail[:sender].addresses #=> ['mikel@test.lindsaar.net']
 #  mail[:sender].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class SenderField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'sender'
     CAPITALIZED_FIELD = 'Sender'
 
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
 
@@ -49,18 +49,18 @@ module Mail
     def address
       address_list.addresses.first
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
     def default
       address.address
     end
-    
+
   end
 end

--- a/lib/mail/fields/subject_field.rb
+++ b/lib/mail/fields/subject_field.rb
@@ -1,16 +1,16 @@
 # encoding: utf-8
-# 
+#
 # subject         =       "Subject:" unstructured CRLF
 module Mail
   class SubjectField < UnstructuredField
-    
+
     FIELD_NAME = 'subject'
     CAPITALIZED_FIELD = "Subject"
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
     end
-    
+
   end
 end

--- a/lib/mail/fields/to_field.rb
+++ b/lib/mail/fields/to_field.rb
@@ -1,54 +1,54 @@
 # encoding: utf-8
-# 
+#
 # = To Field
-# 
+#
 # The To field inherits to StructuredField and handles the To: header
 # field in the email.
-# 
+#
 # Sending to to a mail message will instantiate a Mail::Field object that
 # has a ToField as its field type.  This includes all Mail::CommonAddress
 # module instance metods.
-# 
+#
 # Only one To field can appear in a header, though it can have multiple
 # addresses and groups of addresses.
-# 
+#
 # == Examples:
-# 
+#
 #  mail = Mail.new
 #  mail.to = 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail.to    #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:to]  #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ToField:0x180e1c4
 #  mail['to'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ToField:0x180e1c4
 #  mail['To'] #=> '#<Mail::Field:0x180e5e8 @field=#<Mail::ToField:0x180e1c4
-# 
+#
 #  mail[:to].encoded   #=> 'To: Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net\r\n'
 #  mail[:to].decoded   #=> 'Mikel Lindsaar <mikel@test.lindsaar.net>, ada@test.lindsaar.net'
 #  mail[:to].addresses #=> ['mikel@test.lindsaar.net', 'ada@test.lindsaar.net']
 #  mail[:to].formatted #=> ['Mikel Lindsaar <mikel@test.lindsaar.net>', 'ada@test.lindsaar.net']
-# 
+#
 require 'mail/fields/common/common_address'
 
 module Mail
   class ToField < StructuredField
-    
+
     include Mail::CommonAddress
-    
+
     FIELD_NAME = 'to'
     CAPITALIZED_FIELD = 'To'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value || "", charset)
       self
     end
-    
+
     def encoded
       do_encode(CAPITALIZED_FIELD)
     end
-    
+
     def decoded
       do_decode
     end
-    
+
   end
 end

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -126,7 +126,7 @@ describe Mail::Field do
 
     it "should not strip out content that looks like the field name" do
       pending "pr#766"
-      field = Mail::Field.new('Subject: subject: for your approval')
+      field = Mail::Field.new('subject: for your approval')
       expect(field.value).to eq 'subject: for your approval'
     end
   end
@@ -224,7 +224,7 @@ describe Mail::Field do
     end
 
     it "should allow you to send in multiple unencoded strings to address fields and encode them" do
-      to = Mail::ToField.new(["Mikel Lindsああr <mikel@test.lindsaar.net>", "あdあ <ada@test.lindsaar.net>"], 'utf-8')
+      to = Mail::ToField.new(["Mikel Lindsああr <mikel@test.lindsaar.net>", "あdあ <ada@test.lindsaar.net>"],  'utf-8')
       expect(to.encoded).to eq "To: Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, \r\n\s=?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>\r\n"
     end
 

--- a/spec/mail/fields/bcc_field_spec.rb
+++ b/spec/mail/fields/bcc_field_spec.rb
@@ -26,7 +26,7 @@ describe Mail::BccField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::BccField.new("Bcc: Mikel") }.not_to raise_error
+      expect { Mail::BccField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -34,7 +34,7 @@ describe Mail::BccField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::BccField.new('Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::BccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'Bcc'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/cc_field_spec.rb
+++ b/spec/mail/fields/cc_field_spec.rb
@@ -7,19 +7,19 @@ require 'spec_helper'
 #    content of the message may not be directed at them.
 
 describe Mail::CcField do
-  
+
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::CcField.new("Cc: Mikel") }.not_to raise_error
+      expect { Mail::CcField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      expect(Mail::CcField.included_modules).to include(Mail::CommonAddress) 
+      expect(Mail::CcField.included_modules).to include(Mail::CommonAddress)
     end
 
     it "should accept a string with the field name" do
-      t = Mail::CcField.new('Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::CcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'Cc'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
@@ -31,7 +31,7 @@ describe Mail::CcField do
     end
 
   end
-  
+
   # Actual testing of CommonAddress methods occurs in the address field spec file
 
   describe "instance methods" do
@@ -52,28 +52,28 @@ describe Mail::CcField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return the encoded line for one address" do
       t = Mail::CcField.new('sam@me.com')
       expect(t.encoded).to eq "Cc: sam@me.com\r\n"
     end
-    
+
     it "should return the encoded line" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq "Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
     it "should return the decoded line" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.decoded).to eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
-    
+
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/comments_field_spec.rb
+++ b/spec/mail/fields/comments_field_spec.rb
@@ -10,7 +10,7 @@ describe Mail::CommentsField do
   end
 
   it "should accept a string with the field name" do
-    t = Mail::CommentsField.new('Comments: this is a comment')
+    t = Mail::CommentsField.new('this is a comment')
     expect(t.name).to eq 'Comments'
     expect(t.value).to eq 'this is a comment'
   end

--- a/spec/mail/fields/common/common_address_spec.rb
+++ b/spec/mail/fields/common/common_address_spec.rb
@@ -6,51 +6,51 @@ describe "Mail::CommonAddress" do
   describe "address handling" do
 
     it "should give the addresses it is going to" do
-      field = Mail::ToField.new("To: test1@lindsaar.net")
+      field = Mail::ToField.new("test1@lindsaar.net")
       expect(field.addresses.first).to eq "test1@lindsaar.net"
     end
 
     it "should split up the address list into individual addresses" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, test2@lindsaar.net")
+      field = Mail::ToField.new("test1@lindsaar.net, test2@lindsaar.net")
       expect(field.addresses).to eq ["test1@lindsaar.net", "test2@lindsaar.net"]
     end
 
     it "should give the formatted addresses" do
-      field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
+      field = Mail::ToField.new("Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
       expect(field.formatted).to eq ["Mikel <test1@lindsaar.net>", "Bob <test2@lindsaar.net>"]
     end
 
     it "should give the display names" do
-      field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
+      field = Mail::ToField.new("Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
       expect(field.display_names).to eq ["Mikel", "Bob"]
     end
 
     it "should give the actual address objects" do
-      field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
+      field = Mail::ToField.new("Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
       field.addrs.each do |addr|
         expect(addr.class).to eq Mail::Address
       end
     end
 
     it "should handle groups as well" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, group: test2@lindsaar.net, me@lindsaar.net;")
+      field = Mail::ToField.new("test1@lindsaar.net, group: test2@lindsaar.net, me@lindsaar.net;")
       expect(field.addresses).to eq ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
     end
 
     it "should provide a list of groups" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
+      field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
       expect(field.group_names).to eq ["My Group"]
     end
 
     it "should provide a list of addresses per group" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
+      field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
       expect(field.groups["My Group"].length).to eq 2
       expect(field.groups["My Group"].first.to_s).to eq 'test2@lindsaar.net'
       expect(field.groups["My Group"].last.to_s).to eq 'me@lindsaar.net'
     end
 
     it "should provide a list of addresses that are just in the groups" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
+      field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
       expect(field.group_addresses).to eq ['test2@lindsaar.net', 'me@lindsaar.net']
     end
 

--- a/spec/mail/fields/common/common_field_spec.rb
+++ b/spec/mail/fields/common/common_field_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe Mail::CommonField do
 
   describe "multi-charset support" do
-    
+
     before(:each) do
       @original = $KCODE if RUBY_VERSION < '1.9'
     end
@@ -16,13 +16,13 @@ describe Mail::CommonField do
     it "should return '' on to_s if there is no value" do
       expect(Mail::SubjectField.new(nil).to_s).to eq ''
     end
-    
+
     it "should leave ascii alone" do
       field = Mail::SubjectField.new("This is a test")
       expect(field.encoded).to eq "Subject: This is a test\r\n"
       expect(field.decoded).to eq "This is a test"
     end
-    
+
     it "should encode a utf-8 string as utf-8 quoted printable" do
       value = "かきくけこ"
       if RUBY_VERSION < '1.9'
@@ -52,7 +52,7 @@ describe Mail::CommonField do
       expect(field.decoded).to eq value
       expect(field.value).to eq value
     end
-  
+
     it "should handle charsets in assigned addresses" do
       value = '"かきくけこ" <mikel@test.lindsaar.net>'
       if RUBY_VERSION < '1.9'
@@ -69,17 +69,15 @@ describe Mail::CommonField do
 
   end
 
-  context "when including the field name" do
-    it "does not strip out content that looks identitcal to the field name" do
-      field = Mail::SubjectField.new("Subject: Subject: for your approval")
+  describe "with content that looks like the field name" do
+    it "does not strip from start" do
+      field = Mail::SubjectField.new("Subject: for your approval")
       expect(field.decoded).to eq("Subject: for your approval")
     end
-  end
 
-  context "when not including the field name" do
-    it "does not strip out content that looks identitcal to the field name" do
-      field = Mail::SubjectField.new("This is an important subject: here")
-      expect(field.decoded).to eq("This is an important subject: here")
+    it "does not strip from middle" do
+      field = Mail::SubjectField.new("for your approval subject: xyz")
+      expect(field.decoded).to eq("for your approval subject: xyz")
     end
   end
 end

--- a/spec/mail/fields/content_description_field_spec.rb
+++ b/spec/mail/fields/content_description_field_spec.rb
@@ -19,11 +19,11 @@ describe Mail::ContentDescriptionField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ContentDescriptionField.new("Content-Description: This is a description") }.not_to raise_error
+      expect { Mail::ContentDescriptionField.new("This is a description") }.not_to raise_error
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ContentDescriptionField.new('Content-Description: This is a description')
+      t = Mail::ContentDescriptionField.new('This is a description')
       expect(t.name).to eq 'Content-Description'
       expect(t.value).to eq 'This is a description'
     end

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -9,7 +9,7 @@ describe Mail::ContentDispositionField do
     end
 
     it "should accept a string with the field name" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
+      c = Mail::ContentDispositionField.new('attachment; filename=File')
       expect(c.name).to eq 'Content-Disposition'
       expect(c.value).to eq 'attachment; filename=File'
     end
@@ -27,54 +27,54 @@ describe Mail::ContentDispositionField do
     end
 
     it "should render encoded" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
+      c = Mail::ContentDispositionField.new('attachment; filename=File')
       expect(c.encoded).to eq "Content-Disposition: attachment;\r\n\sfilename=File\r\n"
     end
 
     it "should render encoded for inline" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: inline')
+      c = Mail::ContentDispositionField.new('inline')
       expect(c.encoded).to eq "Content-Disposition: inline\r\n"
     end
 
     it "should wrap a filename in double quotation marks only if the filename contains spaces and does not already have double quotation marks" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=This is a bad filename.txt')
+      c = Mail::ContentDispositionField.new('attachment; filename=This is a bad filename.txt')
       expect(c.value).to eq 'attachment; filename="This is a bad filename.txt"'
 
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=some.jpg')
+      c = Mail::ContentDispositionField.new('attachment; filename=some.jpg')
       expect(c.value).to eq 'attachment; filename=some.jpg'
 
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename="Bad filename but at least it is wrapped in quotes.txt"')
+      c = Mail::ContentDispositionField.new('attachment; filename="Bad filename but at least it is wrapped in quotes.txt"')
       expect(c.value).to eq 'attachment; filename="Bad filename but at least it is wrapped in quotes.txt"'
     end
 
     it "should render decoded" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
+      c = Mail::ContentDispositionField.new('attachment; filename=File')
       expect(c.decoded).to eq 'attachment; filename=File'
     end
 
     it "should render decoded inline" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: inline')
+      c = Mail::ContentDispositionField.new('inline')
       expect(c.decoded).to eq 'inline'
     end
 
     it "should handle upper and mixed case INLINE and AttachMent" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: INLINE')
+      c = Mail::ContentDispositionField.new('INLINE')
       expect(c.decoded).to eq 'inline'
-      c = Mail::ContentDispositionField.new('Content-Disposition: AttachMent')
+      c = Mail::ContentDispositionField.new('AttachMent')
       expect(c.decoded).to eq 'attachment'
     end
   end
 
   describe "instance methods" do
     it "should give its disposition type" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
+      c = Mail::ContentDispositionField.new('attachment; filename=File')
       expect(c.disposition_type).to eq 'attachment'
       expect(c.parameters).to eql({"filename" => 'File'})
     end
 
     # see spec/fixtures/trec_2005_corpus/missing_content_disposition.eml
     it "should accept a blank disposition type" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: ')
+      c = Mail::ContentDispositionField.new('')
       expect(c.disposition_type).not_to be_nil
     end
 

--- a/spec/mail/fields/content_id_field_spec.rb
+++ b/spec/mail/fields/content_id_field_spec.rb
@@ -34,7 +34,7 @@ describe Mail::ContentIdField do
     end
 
     it "should accept a string with the field name" do
-      c = Mail::ContentIdField.new('Content-ID: <1234@test.lindsaar.net>')
+      c = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
       expect(c.name).to eq 'Content-ID'
       expect(c.value).to eq '<1234@test.lindsaar.net>'
       expect(c.content_id).to eq '1234@test.lindsaar.net'

--- a/spec/mail/fields/content_location_field_spec.rb
+++ b/spec/mail/fields/content_location_field_spec.rb
@@ -11,7 +11,7 @@ describe Mail::ContentLocationField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ContentLocationField.new('Content-Location: photo.jpg')
+      t = Mail::ContentLocationField.new('photo.jpg')
       expect(t.name).to eq 'Content-Location'
       expect(t.value).to eq 'photo.jpg'
     end

--- a/spec/mail/fields/content_transfer_encoding_field_spec.rb
+++ b/spec/mail/fields/content_transfer_encoding_field_spec.rb
@@ -40,11 +40,11 @@ describe Mail::ContentTransferEncodingField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ContentTransferEncodingField.new("Content-Transfer-Encoding: 7bit") }.not_to raise_error
+      expect { Mail::ContentTransferEncodingField.new("7bit") }.not_to raise_error
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ContentTransferEncodingField.new('Content-Transfer-Encoding: 7bit')
+      t = Mail::ContentTransferEncodingField.new('7bit')
       expect(t.name).to eq 'Content-Transfer-Encoding'
       expect(t.value).to eq '7bit'
     end

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -75,7 +75,7 @@ describe Mail::ContentTypeField do
     end
 
     it "should accept a string with the field name" do
-      c = Mail::ContentTypeField.new('Content-Type: text/plain')
+      c = Mail::ContentTypeField.new('text/plain')
       expect(c.name).to eq 'Content-Type'
       expect(c.value).to eq 'text/plain'
     end
@@ -93,7 +93,7 @@ describe Mail::ContentTypeField do
     end
 
     it "should render encoded" do
-      c = Mail::ContentTypeField.new('Content-Type: text/plain')
+      c = Mail::ContentTypeField.new('text/plain')
       expect(c.encoded).to eq "Content-Type: text/plain\r\n"
     end
 
@@ -668,12 +668,12 @@ describe Mail::ContentTypeField do
   describe "handling badly formated content-type fields" do
 
     it "should handle missing sub-type on a text content type" do
-      c = Mail::ContentTypeField.new('Content-Type: text')
+      c = Mail::ContentTypeField.new('text')
       expect(c.content_type).to eq 'text/plain'
     end
 
     it "should handle missing ; after content-type" do
-      c = Mail::ContentTypeField.new('Content-Type: multipart/mixed boundary="----=_NextPart_000_000F_01C17754.8C3CAF30"')
+      c = Mail::ContentTypeField.new('multipart/mixed boundary="----=_NextPart_000_000F_01C17754.8C3CAF30"')
       expect(c.content_type).to eq 'multipart/mixed'
       expect(c.parameters['boundary']).to eq '----=_NextPart_000_000F_01C17754.8C3CAF30'
     end

--- a/spec/mail/fields/date_field_spec.rb
+++ b/spec/mail/fields/date_field_spec.rb
@@ -35,7 +35,7 @@ describe Mail::DateField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::DateField.new('Date: 12 Aug 2009 00:00:02 GMT')
+      t = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
       expect(t.name).to eq 'Date'
       expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
       expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')

--- a/spec/mail/fields/from_field_spec.rb
+++ b/spec/mail/fields/from_field_spec.rb
@@ -9,7 +9,7 @@ describe Mail::FromField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::FromField.new("From: Mikel") }.not_to raise_error
+      expect { Mail::FromField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -17,7 +17,7 @@ describe Mail::FromField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::FromField.new('From: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::FromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'From'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/in_reply_to_field_spec.rb
+++ b/spec/mail/fields/in_reply_to_field_spec.rb
@@ -17,7 +17,7 @@ describe Mail::InReplyToField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::InReplyToField.new('In-Reply-To: <1234@test.lindsaar.net>')
+      t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
       expect(t.name).to eq 'In-Reply-To'
       expect(t.value).to eq '<1234@test.lindsaar.net>'
       expect(t.message_id).to eq '1234@test.lindsaar.net'

--- a/spec/mail/fields/keywords_field_spec.rb
+++ b/spec/mail/fields/keywords_field_spec.rb
@@ -10,7 +10,7 @@ describe Mail::KeywordsField do
     end
     
     it "should accept a string with the field name" do
-      k = Mail::KeywordsField.new('Keywords: these are keywords, so there')
+      k = Mail::KeywordsField.new('these are keywords, so there')
       expect(k.name).to eq 'Keywords'
       expect(k.value).to eq 'these are keywords, so there'
     end

--- a/spec/mail/fields/message_id_field_spec.rb
+++ b/spec/mail/fields/message_id_field_spec.rb
@@ -61,7 +61,7 @@ describe Mail::MessageIdField do
     end
 
     it "should accept a string with the field name" do
-      m = Mail::MessageIdField.new('Message-ID: <1234@test.lindsaar.net>')
+      m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
       expect(m.name).to eq 'Message-ID'
       expect(m.value).to eq '<1234@test.lindsaar.net>'
       expect(m.message_id).to eq '1234@test.lindsaar.net'

--- a/spec/mail/fields/mime_version_field_spec.rb
+++ b/spec/mail/fields/mime_version_field_spec.rb
@@ -87,7 +87,7 @@ describe Mail::MimeVersionField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::MimeVersionField.new('Mime-Version: 1.0')
+      t = Mail::MimeVersionField.new('1.0')
       expect(t.name).to eq 'Mime-Version'
       expect(t.value).to eq '1.0'
     end

--- a/spec/mail/fields/received_field_spec.rb
+++ b/spec/mail/fields/received_field_spec.rb
@@ -4,15 +4,15 @@ require 'spec_helper'
 describe Mail::ReceivedField do
 
   it "should initialize" do
-    expect { Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)") }.not_to raise_error
+    expect { Mail::ReceivedField.new("from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)") }.not_to raise_error
   end
 
   it "should be able to tell the time" do
-    expect(Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)").date_time.class).to eq DateTime
+    expect(Mail::ReceivedField.new("from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)").date_time.class).to eq DateTime
   end
 
   it "should accept a string with the field name" do
-    t = Mail::ReceivedField.new('Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
+    t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
     expect(t.name).to eq 'Received'
     expect(t.value).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
     expect(t.info).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'

--- a/spec/mail/fields/references_field_spec.rb
+++ b/spec/mail/fields/references_field_spec.rb
@@ -19,7 +19,7 @@ describe Mail::ReferencesField do
   end
 
   it "should accept a string with the field name" do
-    t = Mail::ReferencesField.new('References: <1234@test.lindsaar.net>')
+    t = Mail::ReferencesField.new('<1234@test.lindsaar.net>')
     expect(t.name).to eq 'References'
     expect(t.value).to eq '<1234@test.lindsaar.net>'
     expect(t.message_id).to eq '1234@test.lindsaar.net'

--- a/spec/mail/fields/reply_to_field_spec.rb
+++ b/spec/mail/fields/reply_to_field_spec.rb
@@ -9,7 +9,7 @@ describe Mail::ReplyToField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ReplyToField.new("Reply-To: Mikel") }.not_to raise_error
+      expect { Mail::ReplyToField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -17,7 +17,7 @@ describe Mail::ReplyToField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ReplyToField.new('Reply-To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::ReplyToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'Reply-To'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/resent_bcc_field_spec.rb
+++ b/spec/mail/fields/resent_bcc_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentBccField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentBccField.new("Resent-Bcc: Mikel") }.not_to raise_error
+      expect { Mail::ResentBccField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -16,7 +16,7 @@ describe Mail::ResentBccField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ResentBccField.new('Resent-Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::ResentBccField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'Resent-Bcc'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/resent_cc_field_spec.rb
+++ b/spec/mail/fields/resent_cc_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentCcField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentCcField.new("Resent-Cc: Mikel") }.not_to raise_error
+      expect { Mail::ResentCcField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -16,7 +16,7 @@ describe Mail::ResentCcField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ResentCcField.new('Resent-Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::ResentCcField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'Resent-Cc'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/resent_date_field_spec.rb
+++ b/spec/mail/fields/resent_date_field_spec.rb
@@ -15,7 +15,7 @@ describe Mail::ResentDateField do
   end
 
   it "should accept a string with the field name" do
-    t = Mail::ResentDateField.new('Resent-Date: 12 Aug 2009 00:00:02 GMT')
+    t = Mail::ResentDateField.new('12 Aug 2009 00:00:02 GMT')
     expect(t.name).to eq 'Resent-Date'
     expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
     expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')

--- a/spec/mail/fields/resent_from_field_spec.rb
+++ b/spec/mail/fields/resent_from_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentFromField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentFromField.new("Resent-From: Mikel") }.not_to raise_error
+      expect { Mail::ResentFromField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -16,7 +16,7 @@ describe Mail::ResentFromField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ResentFromField.new('Resent-From: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::ResentFromField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'Resent-From'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/resent_message_id_field_spec.rb
+++ b/spec/mail/fields/resent_message_id_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentMessageIdField do
   end
 
   it "should accept a string with the field name" do
-    t = Mail::ResentMessageIdField.new('Resent-Message-ID: <1234@test.lindsaar.net>')
+    t = Mail::ResentMessageIdField.new('<1234@test.lindsaar.net>')
     expect(t.name).to eq 'Resent-Message-ID'
     expect(t.value).to eq '<1234@test.lindsaar.net>'
     expect(t.message_id).to eq '1234@test.lindsaar.net'

--- a/spec/mail/fields/resent_sender_field_spec.rb
+++ b/spec/mail/fields/resent_sender_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentSenderField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentSenderField.new("Resent-Sender: Mikel") }.not_to raise_error
+      expect { Mail::ResentSenderField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -16,7 +16,7 @@ describe Mail::ResentSenderField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ResentSenderField.new('Resent-Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'Resent-Sender'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/resent_to_field_spec.rb
+++ b/spec/mail/fields/resent_to_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::ResentToField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentToField.new("Resent-To: Mikel") }.not_to raise_error
+      expect { Mail::ResentToField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -16,7 +16,7 @@ describe Mail::ResentToField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ResentToField.new('Resent-To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::ResentToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'Resent-To'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/return_path_field_spec.rb
+++ b/spec/mail/fields/return_path_field_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe Mail::ReturnPathField do
   it "should allow you to specify a field" do
-    rp = Mail::ReturnPathField.new('Return-Path: mikel@test.lindsaar.net')
+    rp = Mail::ReturnPathField.new('mikel@test.lindsaar.net')
     expect(rp.address).to eq 'mikel@test.lindsaar.net'
   end
   
   it "should encode the addr_spec in <>" do
-    rp = Mail::ReturnPathField.new('Return-Path: mikel@test.lindsaar.net')
+    rp = Mail::ReturnPathField.new('mikel@test.lindsaar.net')
     expect(rp.encoded).to eq "Return-Path: <mikel@test.lindsaar.net>\r\n"
   end
 

--- a/spec/mail/fields/sender_field_spec.rb
+++ b/spec/mail/fields/sender_field_spec.rb
@@ -8,7 +8,7 @@ describe Mail::SenderField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::SenderField.new("Sender: Mikel") }.not_to raise_error
+      expect { Mail::SenderField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
@@ -16,7 +16,7 @@ describe Mail::SenderField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>')
+      t = Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
       expect(t.name).to eq 'Sender'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
@@ -29,7 +29,7 @@ describe Mail::SenderField do
 
     it "should reject headers with multiple mailboxes" do
       pending 'Sender accepts an address list now, but should only accept a single address'
-      expect { Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>') }.to raise_error
+      expect { Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>') }.to raise_error
     end
   end
 

--- a/spec/mail/fields/to_field_spec.rb
+++ b/spec/mail/fields/to_field_spec.rb
@@ -17,7 +17,7 @@ describe Mail::ToField do
     end
 
     it "should accept a string with the field name" do
-      t = Mail::ToField.new('To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
+      t = Mail::ToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'To'
       expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -75,7 +75,7 @@ describe Mail::UnstructuredField do
     end
 
     it "should just add the CRLF at the end of the line" do
-      @field = Mail::SubjectField.new("Subject: =?utf-8?Q?testing_testing_=D6=A4?=")
+      @field = Mail::SubjectField.new("=?utf-8?Q?testing_testing_=D6=A4?=")
       result = "Subject: =?UTF-8?Q?testing_testing_=D6=A4?=\r\n"
       expect(@field.encoded).to eq result
       expect(@field.decoded).to eq "testing testing \326\244"


### PR DESCRIPTION
@bf4 @jeremy @mikel 

calling afield with it's own name seems like a pretty useless feature, removing this breaks ~30 specs, that I'd fix if we decide to go this way ...

https://github.com/mikel/mail/pull/720

Ideally the .to_s would not be necessary, but something in mail or action_mailer passes in a class for content_transfer_encoding :/

fix:

``` Ruby
# https://github.com/mikel/mail/pull/766
Mail::CommonField.class_eval do
  def strip_field(field_name, value)
    value.to_s
  end
end
```
