### PR TITLE
support windows-1258

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -124,6 +124,10 @@ module Mail
       when /utf[\-_]?(\d{1,2})?(\w{1,2})/i
         "UTF-#{$1}#{$2}".gsub(/\A(UTF-(?:16|32))\z/, '\\1BE')
 
+      # Windows-1258 is similar to 1252
+      when /Windows-?1258/i
+        "Windows-1252"
+
       # Windows-1252 and alike
       when /Windows-?(.*)/i
         "Windows-#{$1}"

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -260,6 +260,11 @@ describe Mail::Field do
       expect(subject.decoded).to eq "It’s a test?"
     end
 
+    it "should decode Windows-1258" do
+      subject = Mail::SubjectField.new("=?windows-1258?Q?C=E9drine?=", 'utf-8')
+      expect(subject.decoded).to eq "Cédrine"
+    end
+
     it "should support ascii encoded utf-8 subjects" do
       s = "=?utf-8?Q?simp?= =?utf-8?Q?le_=E2=80=93_dash_=E2=80=93_?="
 


### PR DESCRIPTION
fixes https://github.com/mikel/mail/issues/544

Fix:

``` Ruby
module Windows1258
  def pick_encoding(enc)
    case enc
    when /windows-?1258/i
      'Windows-1252'
    else
      super
    end
  end
end
class << Mail::Ruby19
  prepend Windows1258
end
```
