### PR TITLE
prevent any future encoding errors

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -57,6 +57,9 @@ module Mail
       end
       decoded = str.encode("utf-8", :invalid => :replace, :replace => "")
       decoded.valid_encoding? ? decoded : decoded.encode("utf-16le", :invalid => :replace, :replace => "").encode("utf-8")
+    rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
+      warn "Encoding conversion failed #{$!}"
+      str.dup.force_encoding("utf-8")
     end
 
     def Ruby19.q_value_encode(str, encoding = nil)
@@ -79,7 +82,8 @@ module Mail
       end
       decoded = str.encode("utf-8", :invalid => :replace, :replace => "")
       decoded.valid_encoding? ? decoded : decoded.encode("utf-16le", :invalid => :replace, :replace => "").encode("utf-8")
-    rescue Encoding::UndefinedConversionError
+    rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
+      warn "Encoding conversion failed #{$!}"
       str.dup.force_encoding("utf-8")
     end
 


### PR DESCRIPTION
I'd prefer broken emails over getting no emails ...

@jeremy @bf4 @mikel 

Fix:

``` Ruby
# https://github.com/mikel/mail/pull/768
# prevent any kind of encoding foobar
module PreventEncodingExceptions
  def value_decode(str)
    super
  rescue ArgumentError, Encoding::ConverterNotFoundError
    warn "Invalid encoding caught #{$!}"
    str
  end
end
prepend PreventEncodingExceptions
```
