### PR TITLE
avoid failed encodings / stop bad charsets early

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,6 +1,7 @@
 == HEAD
 
 * #789 - Fix encoding collapsing not dealing with multiple encodings in 1 line (grosser)
+* #775 - avoid failed encodings / stop bad charsets early (grosser)
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -140,7 +140,7 @@ module Mail
     #   Encoding.list.map { |e| [e.to_s.upcase == pick_encoding(e.to_s.downcase.gsub("-", "")), e.to_s] }.select {|a,b| !b}
     #   Encoding.list.map { |e| [e.to_s == pick_encoding(e.to_s), e.to_s] }.select {|a,b| !b}
     def Ruby19.pick_encoding(charset)
-      case charset
+      encoding = case charset
 
       # ISO-8859-8-I etc. http://en.wikipedia.org/wiki/ISO-8859-8-I
       when /^iso-?8859-(\d+)(-i)?$/i
@@ -187,6 +187,24 @@ module Mail
 
       else
         charset
+      end
+
+      convert_to_encoding(encoding)
+    end
+
+    class << self
+      private
+
+      def convert_to_encoding(encoding)
+        if encoding.is_a?(Encoding)
+          encoding
+        else
+          begin
+            Encoding.find(encoding)
+          rescue ArgumentError
+            Encoding::BINARY
+          end
+        end
       end
     end
   end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -315,6 +315,12 @@ describe Mail::Encodings do
     it "should decode a string with spaces" do
       expect(Mail::Encodings.value_decode("=?utf-8?Q?a a?=")).to eq "a a"
     end
+
+    it "should treat unrecognized charsets as binary" do
+      if RUBY_VERSION >= "1.9"
+        expect(Mail::Encodings.value_decode("=?ISO-FOOO?Q?Morten_R=F8verdatt=E9r?=")).to eq "Morten Rverdattr"
+      end
+    end
   end
 
   describe "mixed Q and B encodings" do
@@ -903,6 +909,20 @@ describe Mail::Encodings do
 
     it "does not join different encodings" do
       convert "A=?iso-2022-jp?B?X=?==?utf-8?B?Y=?=B", ["A", "=?iso-2022-jp?B?X=?=", "=?utf-8?B?Y=?=", "B"]
+    end
+  end
+
+  describe ".pick_encoding" do
+    it "finds encoding" do
+      if RUBY_VERSION >= "1.9"
+        expect(Mail::Ruby19.pick_encoding("Windows-1252")).to eq Encoding::Windows_1252
+      end
+    end
+
+    it "uses binary for unfound" do
+      if RUBY_VERSION >= "1.9"
+        expect(Mail::Ruby19.pick_encoding("ISO-Foo")).to eq Encoding::BINARY
+      end
     end
   end
 end


### PR DESCRIPTION
@bf4 @jeremy 

hotfix:

``` Ruby
module NoInvalidEncoding
  def pick_encoding(enc)
    Encoding.find(super(enc)).to_s
  rescue ArgumentError
    "ISO-8859-1"
  end
end

class << Mail::Ruby19
  prepend NoInvalidEncoding
end
```
