### PR TITLE
refactor into common-content

### DIFF
--- a/lib/mail/fields/common/common_content.rb
+++ b/lib/mail/fields/common/common_content.rb
@@ -1,0 +1,29 @@
+module Mail
+  module CommonContent # :nodoc:
+    def filename
+      parameters['filename'] || parameters['name']
+    end
+
+    def encoded
+      p = if parameters.length > 0
+        ";\r\n\s#{parameters.encoded}\r\n"
+      else
+        "\r\n"
+      end
+      "#{self.class::CAPITALIZED_FIELD}: #{decode_encode_field}" + p
+    end
+
+    def decoded
+      p = if parameters.length > 0
+        "; #{parameters.decoded}"
+      else
+        ""
+      end
+      "#{decode_encode_field}" + p
+    end
+
+    def parameters
+      @parameters ||= element.parameters.inject(ParameterHash.new) { |h,p| h.merge!(p) }
+    end
+  end
+end

--- a/lib/mail/fields/content_disposition_field.rb
+++ b/lib/mail/fields/content_disposition_field.rb
@@ -1,8 +1,11 @@
 # encoding: utf-8
 require 'mail/fields/common/parameter_hash'
+require 'mail/fields/common/common_content'
 
 module Mail
   class ContentDispositionField < StructuredField
+
+    include Mail::CommonContent
     
     FIELD_NAME = 'content-disposition'
     CAPITALIZED_FIELD = 'Content-Disposition'
@@ -28,43 +31,12 @@ module Mail
     def disposition_type
       element.disposition_type
     end
-    
-    def parameters
-      @parameters = ParameterHash.new
-      element.parameters.each { |p| @parameters.merge!(p) }
-      @parameters
-    end
 
-    def filename
-      case
-      when !parameters['filename'].blank?
-        @filename = parameters['filename']
-      when !parameters['name'].blank?
-        @filename = parameters['name']
-      else 
-        @filename = nil
-      end
-      @filename
-    end
+    private
 
-    # TODO: Fix this up
-    def encoded
-      if parameters.length > 0
-        p = ";\r\n\s#{parameters.encoded}\r\n"
-      else
-        p = "\r\n"
-      end
-      "#{CAPITALIZED_FIELD}: #{disposition_type}" + p
+    def decode_encode_field
+      disposition_type
     end
     
-    def decoded
-      if parameters.length > 0
-        p = "; #{parameters.decoded}"
-      else
-        p = ""
-      end
-      "#{disposition_type}" + p
-    end
-
   end
 end

--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -1,8 +1,11 @@
 # encoding: utf-8
 require 'mail/fields/common/parameter_hash'
+require 'mail/fields/common/common_content'
 
 module Mail
   class ContentTypeField < StructuredField
+
+    include Mail::CommonContent
 
     FIELD_NAME = 'content-type'
     CAPITALIZED_FIELD = 'Content-Type'
@@ -67,14 +70,6 @@ module Mail
 
     alias :content_type :string
 
-    def parameters
-      unless @parameters
-        @parameters = ParameterHash.new
-        element.parameters.each { |p| @parameters.merge!(p) }
-      end
-      @parameters
-    end
-
     def ContentTypeField.with_boundary(type)
       new("#{type}; boundary=#{generate_boundary}")
     end
@@ -95,37 +90,6 @@ module Mail
       params.map { |k,v| "#{k}=#{Encodings.param_encode(v)}" }.join("; ")
     end
 
-    def filename
-      case
-      when parameters['filename']
-        @filename = parameters['filename']
-      when parameters['name']
-        @filename = parameters['name']
-      else
-        @filename = nil
-      end
-      @filename
-    end
-
-    # TODO: Fix this up
-    def encoded
-      if parameters.length > 0
-        p = ";\r\n\s#{parameters.encoded}"
-      else
-        p = ""
-      end
-      "#{CAPITALIZED_FIELD}: #{content_type}#{p}\r\n"
-    end
-
-    def decoded
-      if parameters.length > 0
-        p = "; #{parameters.decoded}"
-      else
-        p = ""
-      end
-      "#{content_type}" + p
-    end
-
     private
 
     def method_missing(name, *args, &block)
@@ -135,6 +99,10 @@ module Mail
       else
         super
       end
+    end
+
+    def decode_encode_field
+      content_type
     end
 
     # Various special cases from random emails found that I am not going to change


### PR DESCRIPTION
@jeremy @bf4

cleaning up some repetition and simplifying logic, also removing blank checks on filename, since we do not do them in content_disposition_field to avoid blowing up on invalid encoding
