### PR TITLE
refactor address

### DIFF
--- a/lib/mail/elements/address.rb
+++ b/lib/mail/elements/address.rb
@@ -25,7 +25,6 @@ module Mail
       if value.nil?
         @parsed = false
         @data = nil
-        return
       else
         parse(value)
       end
@@ -47,11 +46,11 @@ module Mail
     def format
       parse unless @parsed
       if @data.nil?
-        ''
+        EMPTY
       elsif display_name
-        [quote_phrase(display_name), "<#{address}>", format_comments].compact.join(" ")
+        [quote_phrase(display_name), "<#{address}>", format_comments].compact.join(SPACE)
       elsif address
-        [address, format_comments].compact.join(" ")
+        [address, format_comments].compact.join(SPACE)
       else
         raw
       end
@@ -123,11 +122,7 @@ module Mail
     #  a.comments #=> ['My email address']
     def comments
       parse unless @parsed
-      if get_comments.empty?
-        nil
-      else
-        get_comments.map { |c| c.squeeze(SPACE) }
-      end
+      get_comments.map { |c| c.squeeze(SPACE) } unless get_comments.empty?
     end
     
     # Sometimes an address will not have a display name, but might have the name
@@ -175,18 +170,13 @@ module Mail
     
     def parse(value = nil)
       @parsed = true
+      @data = nil
 
       case value
-      when NilClass
-        @data = nil
-        nil
       when Mail::Parsers::AddressStruct
         @data = value
       when String
-        @raw_text = value
-        if value.blank?
-          @data = nil
-        else
+        unless value.blank?
           address_list = Mail::Parsers::AddressListsParser.new.parse(value)
           @data = address_list.addresses.first
         end
@@ -206,7 +196,7 @@ module Mail
       unless comments.blank?
         comments.each do |comment|
           if @data.domain && @data.domain.include?("(#{comment})")
-            value = value.gsub("(#{comment})", '')
+            value = value.gsub("(#{comment})", EMPTY)
           end
         end
       end
@@ -216,43 +206,26 @@ module Mail
     def get_display_name
       if @data.display_name
         str = strip_all_comments(@data.display_name.to_s)
-      elsif @data.comments
-        if @data.domain
-          str = strip_domain_comments(format_comments)
-        else
-          str = nil
-        end
-      else
-        nil
+      elsif @data.comments && @data.domain
+        str = strip_domain_comments(format_comments)
       end
-      
-      if str.blank?
-        nil
-      else
-        str
-      end
+
+      str unless str.blank?
     end
     
     def get_name
       if display_name
         str = display_name
-      else
-        if comments
-          comment_text = comments.join(' ').squeeze(" ")
-          str = "(#{comment_text})"
-        end
+      elsif comments
+        str = "(#{comments.join(SPACE).squeeze(SPACE)})"
       end
 
-      if str.blank?
-        nil
-      else
-        unparen(str)
-      end
+      unparen(str) unless str.blank?
     end
     
     def format_comments
       if comments
-        comment_text = comments.map {|c| escape_paren(c) }.join(' ').squeeze(" ")
+        comment_text = comments.map {|c| escape_paren(c) }.join(SPACE).squeeze(SPACE)
         @format_comments ||= "(#{comment_text})"
       else
         nil


### PR DESCRIPTION
I was looking through the source the other day and was trying to make heads and tails of the address class what better way that a little refactoring.

All tests pass on 1.9.3-p547, 2.0.0-p481, 2.1.2, and jruby-1.7.9. (all supported versions of mime-types) I do however run into difficulties testing on 1.8.7-p375.

here is the output  from the failed attempt of 1.8.7

``` sh
Gem::InstallError: mime-types requires Ruby version >= 1.9.2.
An error occurred while installing mime-types (2.3), and Bundler cannot continue.
Make sure that `gem install mime-types -v '2.3'` succeeds before bundling.
```

any pointers would be great
