### PR TITLE
Use composition over inheritance for `PartsList`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,4 @@ matrix:
   allow_failures:
     - rvm: ruby-head    # green, but unstable
     - rvm: jruby-head   # green, but unstable
-    - rvm: rbx-2        # see https://github.com/rubinius/rubinius/issues/3050
   fast_finish: true

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,6 @@
 == HEAD
 
+* Make the gem compatible with Rubinius (Robin Dupret)
 * #808 - Mail::Field correctly responds_to? the methods of its instantiated field (thegcat)
 * #772 - normalize encoding matchers (grosser)
 * #789 - Fix encoding collapsing not dealing with multiple encodings in 1 line (grosser)

--- a/lib/mail/parts_list.rb
+++ b/lib/mail/parts_list.rb
@@ -1,8 +1,16 @@
+require 'delegate'
+
 module Mail
-  class PartsList < Array
+  class PartsList < DelegateClass(Array)
+    attr_reader :parts
+
+    def initialize(*args)
+      @parts = Array.new(*args)
+      super @parts
+    end
 
     def attachments
-      Mail::AttachmentsList.new(self)
+      Mail::AttachmentsList.new(@parts)
     end
 
     def collect
@@ -14,8 +22,6 @@ module Mail
         to_a
       end
     end
-
-    undef :map
     alias_method :map, :collect
 
     def map!
@@ -27,20 +33,20 @@ module Mail
     end
 
     def sort
-      self.class.new(super)
+      self.class.new(@parts.sort)
     end
 
     def sort!(order)
       # stable sort should be used to maintain the relative order as the parts are added
       i = 0;
-      sorted = self.sort_by do |a|
+      sorted = @parts.sort_by do |a|
         # OK, 10000 is arbitrary... if anyone actually wants to explicitly sort 10000 parts of a
         # single email message... please show me a use case and I'll put more work into this method,
         # in the meantime, it works :)
         [get_order_value(a, order), i += 1]
       end
-      self.clear
-      sorted.each { |p| self << p }
+      @parts.clear
+      sorted.each { |p| @parts << p }
     end
 
   private

--- a/lib/mail/parts_list.rb
+++ b/lib/mail/parts_list.rb
@@ -9,6 +9,17 @@ module Mail
       super @parts
     end
 
+    # The #encode_with and #to_yaml methods are just implemented
+    # for the sake of backward compatibility ; the delegator does
+    # not correctly delegate these calls to the delegated object
+    def encode_with(coder) # :nodoc:
+      coder.represent_object(nil, @parts)
+    end
+
+    def to_yaml(options = {}) # :nodoc:
+      @parts.to_yaml(options)
+    end
+
     def attachments
       Mail::AttachmentsList.new(@parts)
     end

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -34,4 +34,36 @@ describe "PartsList" do
     p << html_text_part
     expect(p.sort!(order)).to eq [plain_text_part, html_text_part, no_content_type_part]
   end
+
+  it "should have a parts reader" do
+    p = Mail::PartsList.new([1, 2])
+    expect(p.parts).to eq([1, 2])
+  end
+
+  it "should behave like an array" do
+    p = Mail::PartsList.new([1, 2])
+    expect(p.first).to eq(1)
+  end
+
+  it "is equal to itself" do
+    p = Mail::PartsList.new([1, 2])
+    expect(p).to eq(p)
+  end
+
+  it "is equal to its parts array" do
+    p = Mail::PartsList.new
+    p << "foo"
+    p << "bar"
+    expect(p).to eq(["foo", "bar"])
+  end
+
+  it "can be mixed with an array" do
+    p = Mail::PartsList.new([3, 4])
+    expect([1, 2] + p).to eq [1, 2, 3, 4]
+  end
+
+  it "should respond to Array methods" do
+    p = Mail::PartsList.new
+    expect(p).to respond_to(:reduce)
+  end
 end

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -66,4 +66,9 @@ describe "PartsList" do
     p = Mail::PartsList.new
     expect(p).to respond_to(:reduce)
   end
+
+  it "should have a round-tripping YAML serialization" do
+    p = Mail::PartsList.new([1, 2])
+    expect(YAML.load(YAML.dump(p))).to eq(p)
+  end
 end


### PR DESCRIPTION
Hello,

This pull request makes this gem compatible with Rubinius relying on the composition over inheritance technique. Even Rails no longer uses the inheritance pattern (see [this article](http://tenderlovemaking.com/2014/06/02/yagni-methods-are-killing-me.html) and rails/rails#16299).

For now, there is a compatibility layer that delegates any missing methods to the parts list's `@parts` so it behaves like an array. This is up to you but you may need to deprecate this path and tell people to access `#parts` first, then call the given method or provide your very own API (through `Enumerable` for instance).

If you want me to squash some commits together let me know !

Refs rubinius/rubinius#3050.

This has been tested under MRI 2.1.2 and 1.9.3, JRuby 1.7.13 and Rubinius 2.2.10.

Have a nice day.