### PR TITLE
deal with complex encoding patters during collapsing

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,7 @@
 == HEAD
 
+* #789 - Fix encoding collapsing not dealing with multiple encodings in 1 line (grosser)
+
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 
 * #796 support uu encoding (grosser)

--- a/lib/mail/constants.rb
+++ b/lib/mail/constants.rb
@@ -33,7 +33,8 @@ module Mail
     ATOM_UNSAFE   = /[#{Regexp.quote aspecial}#{control}#{sp}]/n
     PHRASE_UNSAFE = /[#{Regexp.quote aspecial}#{control}]/n
     TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{sp}]/n
-    ENCODED_VALUE = /\=\?[^?]+\?([QB])\?[^?]*?\?\=/mi
+    ENCODED_VALUE = /\=\?([^?]+)\?([QB])\?[^?]*?\?\=/mi
+    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)/mi
 
     EMPTY          = ''
     SPACE          = ' '

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -47,7 +47,7 @@ module Mail
     end
 
     def Encodings.get_name(enc)
-      enc = underscoreize(enc).downcase
+      underscoreize(enc).downcase
     end
 
     # Encodes a parameter value using URI Escaping, note the language field 'en' can
@@ -121,7 +121,7 @@ module Mail
       # Split on white-space boundaries with capture, so we capture the white-space as well
       lines.each do |line|
         line.gsub!(ENCODED_VALUE) do |string|
-          case $1
+          case $2
           when *B_VALUES then b_value_decode(string)
           when *Q_VALUES then q_value_decode(string)
           end
@@ -240,27 +240,13 @@ module Mail
       RubyVer.q_value_decode(str)
     end
 
-    def Encodings.split_encoding_from_string( str )
-      match = str.match(/\=\?([^?]+)?\?[QB]\?(.*)\?\=/mi)
-      if match
-        match[1]
-      else
-        nil
-      end
-    end
-
     def Encodings.find_encoding(str)
       RUBY_VERSION >= '1.9' ? str.encoding : $KCODE
     end
 
     # Gets the encoding type (Q or B) from the string.
-    def Encodings.split_value_encoding_from_string(str)
-      match = str.match(/\=\?[^?]+?\?([QB])\?(.*)\?\=/mi)
-      if match
-        match[1]
-      else
-        nil
-      end
+    def Encodings.value_encoding_from_string(str)
+      str[ENCODED_VALUE, 1]
     end
 
     # When the encoded string consists of multiple lines, lines with the same
@@ -268,19 +254,22 @@ module Mail
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      lines = str.split(/(\?=)\s*(=\?)/).each_slice(2).map(&:join)
       results = []
       previous_encoding = nil
-
-      lines.each do |line|
-        encoding = split_value_encoding_from_string(line)
-
-        if encoding == previous_encoding
-          line = results.pop + line
+      lines = str.split(FULL_ENCODED_VALUE)
+      lines.each_slice(2) do |unencoded, encoded|
+        if encoded
+          encoding = value_encoding_from_string(encoded)
+          if encoding == previous_encoding && unencoded.blank?
+            results.last << encoded
+          else
+            results << unencoded unless unencoded == EMPTY
+            results << encoded
+          end
+          previous_encoding = encoding
+        else
+          results << unencoded
         end
-
-        previous_encoding = encoding
-        results << line
       end
 
       results

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -166,6 +166,12 @@ describe Mail::Encodings do
       expect(Mail::Encodings.value_decode(string)).to eq(result)
     end
 
+    it "should collapse adjacent words with multiple encodings on one line seperated by non-spaces" do
+      string = "Re:[=?iso-2022-jp?B?GyRCJTAlayE8JV0lcyEmJTglYyVRJXMzdDwwMnEbKEI=?=\n =?iso-2022-jp?B?GyRCPFIbKEI=?=] =?iso-2022-jp?B?GyRCSlY/LiEnGyhC?=\n  =?iso-2022-jp?B?GyRCIVolMCVrITwlXSVzIVskKkxkJCQ5ZyRvJDsbKEI=?=\n =?iso-2022-jp?B?GyRCJE43byRLJEQkJCRGIUolaiUvJSglOSVIGyhC?=#1056273\n =?iso-2022-jp?B?GyRCIUsbKEI=?="
+      result = "Re:[グルーポン・ジャパン株式会社] 返信：【グルーポン】お問い合わせの件について（リクエスト#1056273\n ）"
+      expect(Mail::Encodings.value_decode(string)).to eq(result)
+    end
+
     it "should decode a blank string" do
       expect(Mail::Encodings.value_decode("=?utf-8?B??=")).to eq ""
     end
@@ -859,6 +865,44 @@ describe Mail::Encodings do
           expect(Mail::Encodings.value_decode("=?windows-1258?Q?SV=3A_Spr=F8sm=E5l_om_tilbod?=")).to eq "SV: Sprøsmål om tilbod"
         end
       end
+    end
+  end
+
+  describe ".collapse_adjacent_encodings" do
+    def convert(from, to)
+      expect(Mail::Encodings.collapse_adjacent_encodings(from)).to eq to
+    end
+
+    it "leaves blank intact" do
+      convert "    ", ["    "]
+    end
+
+    it "leaves pure unencoded intact" do
+      convert "AB CD EF ?= =? G", ["AB CD EF ?= =? G"]
+    end
+
+    it "does not modify 1 encoded" do
+      convert "=?iso-2022-jp?B?X=?=", ["=?iso-2022-jp?B?X=?="]
+    end
+
+    it "splits unencoded and encoded into separate parts" do
+      convert "A=?iso-2022-jp?B?X=?=B", ["A", "=?iso-2022-jp?B?X=?=", "B"]
+    end
+
+    it "joins adjacent encodings" do
+      convert "A=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=B", ["A", "=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=", "B"]
+    end
+
+    it "joins adjacent encodings without unencoded" do
+      convert "=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=", ["=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?="]
+    end
+
+    it "does not join encodings when separated by unencoded" do
+      convert "A=?iso-2022-jp?B?X=?=B=?iso-2022-jp?B?Y=?=C", ["A", "=?iso-2022-jp?B?X=?=", "B", "=?iso-2022-jp?B?Y=?=", "C"]
+    end
+
+    it "does not join different encodings" do
+      convert "A=?iso-2022-jp?B?X=?==?utf-8?B?Y=?=B", ["A", "=?iso-2022-jp?B?X=?=", "=?utf-8?B?Y=?=", "B"]
     end
   end
 end


### PR DESCRIPTION
@jeremy @mikel @bf4 

a line like `encodedX encoded` was previously considered 1 encoded word -> errors

also speccing out collapse_adjacent_encodings since I found a few scenarios that were not covered by any tests
