### PR TITLE
Mail::Field responds_to? delegated methods properly

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -9,6 +9,7 @@ Performance:
 
 Bugs:
 * #736 - Mail.new copes with non-UTF8 messages marked as UTF8 (jeremy)
+* Mail::Field responds_to? delegated methods properly (owenr)
 
 == Version 2.6.1 - Sun Jun 8 15:34 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -185,6 +185,10 @@ module Mail
       @field_order_id ||= (FIELD_ORDER_LOOKUP[self.name.to_s.downcase] || 100)
     end
 
+    def respond_to?(name)
+      field.respond_to?(name) || super
+    end
+
     def method_missing(name, *args, &block)
       field.send(name, *args, &block)
     end

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -156,6 +156,18 @@ describe Mail::Field do
       list = [Mail::Field.new("To: mikel"), Mail::Field.new("Return-Path: bob")]
       expect(list.sort[0].name).to eq "Return-Path"
     end
+
+    it "should claim to respond_to? delegated methods" do
+      field = Mail::Field.new("References: <deadbeef@test.lindsaar.net>")
+      expect(field.respond_to?(:charset)).to be_truthy
+      expect(field.respond_to?(:decoded)).to be_truthy
+      expect(field.respond_to?(:message_id)).to be_truthy
+    end
+
+    it "should not claim to respond_to? all possible field methods" do
+      field = Mail::Field.new("To: mikel@test.lindsaar.net")
+      expect(field.respond_to?(:message_id)).to be_falsey
+    end
   end
 
   describe 'user defined fields' do


### PR DESCRIPTION
Mail::Field delegates method calls to the contained field using `method_missing` but did not also override `respond_to?`. As an example, attempts to call `mail[:to].try(:decoded)` always return `nil` instead of the decoded field value.
`respond_to?` used instead of `respond_to_missing?` for Ruby 1.8.7 compatibility. (See http://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding)
Tests pass on MRI 1.8.7-p375, 1.9.3-p547, 2.0.0-p247.