### PR TITLE
Allow blank filenames in Content-Disposition field

### DIFF
--- a/lib/mail/fields/content_disposition_field.rb
+++ b/lib/mail/fields/content_disposition_field.rb
@@ -3,10 +3,10 @@ require 'mail/fields/common/parameter_hash'
 
 module Mail
   class ContentDispositionField < StructuredField
-    
+
     FIELD_NAME = 'content-disposition'
     CAPITALIZED_FIELD = 'Content-Disposition'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       ensure_filename_quoted(value)
@@ -14,13 +14,13 @@ module Mail
       self.parse
       self
     end
-    
+
     def parse(val = value)
       unless val.blank?
         @element = Mail::ContentDispositionElement.new(val)
       end
     end
-    
+
     def element
       @element ||= Mail::ContentDispositionElement.new(value)
     end
@@ -28,7 +28,7 @@ module Mail
     def disposition_type
       element.disposition_type
     end
-    
+
     def parameters
       @parameters = ParameterHash.new
       element.parameters.each { |p| @parameters.merge!(p) }
@@ -37,11 +37,11 @@ module Mail
 
     def filename
       case
-      when !parameters['filename'].blank?
+      when parameters['filename']
         @filename = parameters['filename']
-      when !parameters['name'].blank?
+      when parameters['name']
         @filename = parameters['name']
-      else 
+      else
         @filename = nil
       end
       @filename
@@ -56,7 +56,7 @@ module Mail
       end
       "#{CAPITALIZED_FIELD}: #{disposition_type}" + p
     end
-    
+
     def decoded
       if parameters.length > 0
         p = "; #{parameters.decoded}"

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -79,4 +79,43 @@ describe Mail::ContentDispositionField do
     end
   end
 
+  describe "finding a filename" do
+
+    it "should locate a filename if there is a filename" do
+      string = %q{Content-Disposition: attachment; filename=mikel.jpg}
+      c = Mail::ContentDispositionField.new(string)
+      expect(c.filename).to eq 'mikel.jpg'
+    end
+
+    it "should locate a name if there is no filename" do
+      string = %q{Content-Disposition: attachment; name=mikel.jpg}
+      c = Mail::ContentDispositionField.new(string)
+      expect(c.filename).to eq 'mikel.jpg'
+    end
+
+    it "should return an empty string when filename or name is empty" do
+      string = %q{Content-Disposition: attachment; filename=""}
+      c = Mail::ContentDispositionField.new(string)
+      expect(c.filename).to eq ''
+
+      string = %q{Content-Disposition: attachment; name=""}
+      c = Mail::ContentDispositionField.new(string)
+      expect(c.filename).to eq ''
+    end
+
+    it "should locate an encoded name as a filename" do
+      string = %q{Content-Disposition: attachment; name*=iso-2022-jp'ja'01%20Quien%20Te%20Dij%91at.%20Pitbull.mp3}
+      c = Mail::ContentDispositionField.new(string)
+      if RUBY_VERSION >= '1.9'
+        expected = "01 Quien Te Dij\221at. Pitbull.mp3".force_encoding(Encoding::BINARY)
+        result = c.filename.force_encoding(Encoding::BINARY)
+      else
+        expected = "01 Quien Te Dij\221at. Pitbull.mp3"
+        result = c.filename
+      end
+      expect(expected).to eq result
+    end
+
+  end
+
 end

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -626,6 +626,16 @@ describe Mail::ContentTypeField do
       expect(c.filename).to eq 'mikel.jpg'
     end
 
+    it "should return an empty string when filename or name is empty" do
+      string = %q{application/octet-stream; filename=""}
+      c = Mail::ContentTypeField.new(string)
+      expect(c.filename).to eq ''
+
+      string = %q{application/octet-stream; name=""}
+      c = Mail::ContentTypeField.new(string)
+      expect(c.filename).to eq ''
+    end
+
     it "should locate an encoded name as a filename" do
       string = %q{application/octet-stream; name*=iso-2022-jp'ja'01%20Quien%20Te%20Dij%91at.%20Pitbull.mp3}
       c = Mail::ContentTypeField.new(string)


### PR DESCRIPTION
Attachments containing an empty string as a filename in the Content-Disposition header are skipped.

This was introduced as a side-effect of commit https://github.com/mikel/mail/commit/b1b17961dbc4adbf1205b5201495b2fa6f4afebd.

Take, for example, the following Content-Disposition header:

```
Content-Disposition: inline;
  filename=""
```

Prior to that commit the parameters in the ContentDispositionField class would return:

``` ruby
{"filename"=>"\"\""}
```

After the commit the following is returned:

``` ruby
{"filename"=>""}
```

This is correct, but the code returning the filename from the ContentDispositionField class checks on `!blank?`. Which would return true before, and now returns false.

This would result in `Message#find_attachment` not decoding the attachment because nil instead of "" is returned.

For this PR I made the `ContentDispositionField#filename` implementation match the one in `ContentTypeField#filename`. 
