### PR TITLE
Infinite loop found in conjunction with ruby-units

### DIFF
--- a/lib/mail/field_list.rb
+++ b/lib/mail/field_list.rb
@@ -19,7 +19,7 @@ module Mail
       hi = size
 
       while lo < hi
-        mid = (lo + hi) / 2
+        mid = (lo + hi).div(2)
         if new_field < self[mid]
           hi = mid
         else


### PR DESCRIPTION
defends against libraries (such as ruby-units) which override division yielding non-zero values for fractions like 1/2

This would also allow you to close PR: 754

https://github.com/mikel/mail/pull/754

Using @jeremy suggestion. CC: @cbillen and @olbrich
