### PR TITLE
Decoding adjustments

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -78,6 +78,8 @@ module Mail
       [Ruby19.encode_base64(str), encoding]
     end
 
+    ENCODE_OPTIONS = {:invalid => :replace, :undef => :replace, :replace => ""}
+
     def Ruby19.b_value_decode(str)
       orig_str = str
       match = str.match(/\=\?(.+)?\?[Bb]\?(.*)\?\=/m)
@@ -86,8 +88,8 @@ module Mail
         str = Ruby19.decode_base64(match[2])
         str = charset_encoder.encode(str, charset)
       end
-      decoded = str.encode(Encoding::UTF_8, :invalid => :replace, :replace => "")
-      decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
+      decoded = str.encode(Encoding::UTF_8, ENCODE_OPTIONS)
+      decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, ENCODE_OPTIONS).encode(Encoding::UTF_8)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
       warn "Encoding conversion failed #{$!}"
       orig_str.dup.force_encoding(Encoding::UTF_8)
@@ -112,8 +114,8 @@ module Mail
         # jruby/jruby#829 which subtly changes String#encode semantics.
         str.force_encoding(Encoding::UTF_8) if str.encoding == Encoding::ASCII_8BIT
       end
-      decoded = str.encode(Encoding::UTF_8, :invalid => :replace, :replace => "")
-      decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
+      decoded = str.encode(Encoding::UTF_8, ENCODE_OPTIONS)
+      decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, ENCODE_OPTIONS).encode(Encoding::UTF_8)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
       warn "Encoding conversion failed #{$!}"
       orig_str.dup.force_encoding(Encoding::UTF_8)

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -79,6 +79,7 @@ module Mail
     end
 
     def Ruby19.b_value_decode(str)
+      orig_str = str
       match = str.match(/\=\?(.+)?\?[Bb]\?(.*)\?\=/m)
       if match
         charset = match[1]
@@ -89,7 +90,7 @@ module Mail
       decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
       warn "Encoding conversion failed #{$!}"
-      str.dup.force_encoding(Encoding::UTF_8)
+      orig_str.dup.force_encoding(Encoding::UTF_8)
     end
 
     def Ruby19.q_value_encode(str, encoding = nil)
@@ -98,6 +99,7 @@ module Mail
     end
 
     def Ruby19.q_value_decode(str)
+      orig_str = str
       match = str.match(/\=\?(.+)?\?[Qq]\?(.*)\?\=/m)
       if match
         charset = match[1]
@@ -114,7 +116,7 @@ module Mail
       decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
       warn "Encoding conversion failed #{$!}"
-      str.dup.force_encoding(Encoding::UTF_8)
+      orig_str.dup.force_encoding(Encoding::UTF_8)
     end
 
     def Ruby19.param_decode(str, encoding)

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -190,9 +190,8 @@ describe "mail encoding" do
     m['Subject'] = Mail::SubjectField.new("=?utf-8?Q?Hello_=96_World?=")
     if RUBY_VERSION > '1.9'
       expect { expect(m.subject).to be_valid_encoding }.not_to raise_error
-    else
-      expect(m.subject).to eq "Hello  World"
     end
+    expect(m.subject).to eq "Hello  World"
   end
 
   if RUBY_VERSION > '1.9'
@@ -201,6 +200,13 @@ describe "mail encoding" do
       m['Subject'] = Mail::SubjectField.new("=?unicode-1-1-utf-7?B?K2tVMVA0WEsyWVV1UUduZmwtICAoK01LZ3c2VEQ4LSk=?=")
       expect { expect(m.subject).to be_valid_encoding }.not_to raise_error
       expect(m.subject).to eq "=?unicode-1-1-utf-7?B?K2tVMVA0WEsyWVV1UUduZmwtICAoK01LZ3c2VEQ4LSk=?="
+    end
+
+    it "shouldn't fail with unconvertable chars" do
+      m = Mail.new
+      m['Subject'] = Mail::SubjectField.new("=?iso-2022-jp?B?GyRCOVY6Qi0iIVshISF6Nls1XjMrOkUheiFWQmdOLjlUGyhC?=")
+      expect { expect(m.subject).to be_valid_encoding }.not_to raise_error
+      expect(m.subject).to eq "講座】　★緊急開催★「大流行"
     end
   end
 end

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -194,4 +194,13 @@ describe "mail encoding" do
       expect(m.subject).to eq "Hello  World"
     end
   end
+
+  if RUBY_VERSION > '1.9'
+    it "shouldn't fail with utf-7 encoding" do
+      m = Mail.new
+      m['Subject'] = Mail::SubjectField.new("=?unicode-1-1-utf-7?B?K2tVMVA0WEsyWVV1UUduZmwtICAoK01LZ3c2VEQ4LSk=?=")
+      expect { expect(m.subject).to be_valid_encoding }.not_to raise_error
+      expect(m.subject).to eq "=?unicode-1-1-utf-7?B?K2tVMVA0WEsyWVV1UUduZmwtICAoK01LZ3c2VEQ4LSk=?="
+    end
+  end
 end


### PR DESCRIPTION
I've rebased some of my old encoding related pull requests on master. Thanks to @grosser and @jeremy  some of this stuff is finally getting into mail :)

Part of this pull request are:
- some more tests based on some strange stuff we've seen that broke the mail lib
- adjusted the b_value_decode to return the original string instead of some part of it (str is overwritten by the match).
- Japanese users love to use emoji which are sometimes non-defined UTF-8 characters. So telling the encode method to simply skip those gives us at least a decoded string without the characters that can't be displayed anyway. Better than the encoded version.

Please consider merging this, we've been using those since quite a while and I'd really appreciate it if I could get rid of my patch branch. Thanks!
