### PR TITLE
Stop quote_phrase from modifying input string encoding

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -21,7 +21,9 @@ module Mail
         original_encoding = str.encoding
         str.force_encoding('ASCII-8BIT')
         if (PHRASE_UNSAFE === str)
-          dquote(str).force_encoding(original_encoding)
+          quoted_str = dquote(str).force_encoding(original_encoding)
+          str.force_encoding(original_encoding)
+          quoted_str
         else
           str.force_encoding(original_encoding)
         end

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -83,6 +83,30 @@ describe "Utilities Module" do
 
   end
 
+  describe "quoting phrases" do
+    describe "given a non-unsafe string" do
+      it "should not change the encoding" do
+        input_str = "blargh"
+        input_str_encoding = input_str.encoding
+
+        quote_phrase(input_str)
+
+        input_str.encoding.should eq input_str_encoding
+      end
+    end
+
+    describe "given an unsafe string" do
+      it "should not change the encoding" do
+        input_str = "Bjørn"
+        input_str_encoding = input_str.encoding
+
+        quote_phrase(input_str)
+
+        input_str.encoding.should eq input_str_encoding
+      end
+    end
+  end
+
   describe "escaping parenthesies" do
     it "should escape parens" do
       test = 'This is not (escaped)'


### PR DESCRIPTION
In the case where it acted to quote the input string, quote_phrase
shouldn't modify the encoding of the input string to be ASCII-8BIT, but
should leave the encoding as it found it.
