### PR TITLE
Improve performance of Message#find_attachment

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2137,8 +2137,10 @@ module Mail
         field.location
       when ContentTypeField, ContentDispositionField
         field.filename
-      else
+      when NilClass, UnstructuredField
         nil
+      else
+        raise ArgumentError, "Don't know how to extract filename from #{field}"
       end
     end
 


### PR DESCRIPTION
This is faster because we,
- Don't trigger exceptions for flow control.
- Retrieve each header only once (at most).

The exceptions this was throwing were particularly expensive for us on jruby. This change cut our mail processing time in half for a particular task.

The tests are passing with this change but it's possible that the `rescue`s in the previous code were catching other exceptions that will now bubble up. We could add a `rescue` to `find_attachment_filename` to catch those.
