### PR TITLE
Remove redundant parse in address fields

### DIFF
--- a/lib/mail/fields/bcc_field.rb
+++ b/lib/mail/fields/bcc_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = '', charset = 'utf-8')
       @charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/cc_field.rb
+++ b/lib/mail/fields/cc_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/from_field.rb
+++ b/lib/mail/fields/from_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/keywords_field.rb
+++ b/lib/mail/fields/keywords_field.rb
@@ -10,7 +10,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
 

--- a/lib/mail/fields/reply_to_field.rb
+++ b/lib/mail/fields/reply_to_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/resent_bcc_field.rb
+++ b/lib/mail/fields/resent_bcc_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/resent_cc_field.rb
+++ b/lib/mail/fields/resent_cc_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/resent_from_field.rb
+++ b/lib/mail/fields/resent_from_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/resent_sender_field.rb
+++ b/lib/mail/fields/resent_sender_field.rb
@@ -38,7 +38,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
 

--- a/lib/mail/fields/resent_to_field.rb
+++ b/lib/mail/fields/resent_to_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/return_path_field.rb
+++ b/lib/mail/fields/return_path_field.rb
@@ -41,7 +41,6 @@ module Mail
       value = nil if value == '<>'
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     

--- a/lib/mail/fields/sender_field.rb
+++ b/lib/mail/fields/sender_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
 

--- a/lib/mail/fields/to_field.rb
+++ b/lib/mail/fields/to_field.rb
@@ -39,7 +39,6 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
-      self.parse
       self
     end
     


### PR DESCRIPTION
The value is already parsed by the call to `super`. The [`StructuredField` initializer](https://github.com/mikel/mail/blob/17457e44596308d8092d340e372fb8a582bb66be/lib/mail/fields/structured_field.rb#L29) calls the [`value` setter](https://github.com/mikel/mail/blob/17457e44596308d8092d340e372fb8a582bb66be/lib/mail/fields/common/common_address.rb#L96) which parses the value.

I dug around to see if there was a reason for this but it just looks like the duplication was unintentionally added in edbe7861e75721f376f53dd51ca1a68c80a3573c