### PR TITLE
Test showing content id parsing failure

### DIFF
--- a/spec/mail/fields/content_id_field_spec.rb
+++ b/spec/mail/fields/content_id_field_spec.rb
@@ -63,6 +63,14 @@ describe Mail::ContentIdField do
       expect(m.decoded).to eq "<1234@test.lindsaar.net>"
     end
 
+    it "should work with strange hostnames" do
+      allow(Socket).to receive(:gethostname).and_return("unknown-28:")
+
+      expect {
+        m = Mail::ContentIdField.new
+      }.not_to raise_exception
+    end
+
   end
   
   describe "ensuring only one message ID" do


### PR DESCRIPTION
Problem with #555. Content-ID seems to choke on the `:`