### PR TITLE
Allow more options when using Message#add_file

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1772,7 +1772,10 @@ module Mail
         filedata = File.open(values, 'rb') { |f| f.read }
       else
         basename = values[:filename]
-        filedata = values[:content] || File.open(values[:filename], 'rb') { |f| f.read }
+        filedata = values
+        unless filedata[:content]
+          filedata = values.merge(:content=>File.open(values[:filename], 'rb') { |f| f.read })
+        end
       end
       self.attachments[basename] = filedata
     end

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -503,6 +503,12 @@ describe "MIME Emails" do
         end
       end
 
+      it "should support :mime_type option" do
+        mail = Mail::Message.new
+        mail.add_file(:filename => 'test.png', :content => 'a', :mime_type=>'text/plain')
+        expect(mail.attachments.first.content_type).to eq 'text/plain'
+      end
+
       it "should be able to add a body before adding a file" do
         m = Mail.new do
           from    'mikel@from.lindsaar.net'


### PR DESCRIPTION
Previously, Message#add_file would ignore options other than
:filename and :content.  This breaks the principal of least
surprise.  The documentation for #add_file says "see also
attachments", and attachments shows other possible options,
but those are not supported.

This changes the code to pass an options hash given to add_file
through to attachments[]=, allowing you to use options such as
:mime_type or :content_disposition.  Currently, you have to do
the following:

  add_file :filename=>"cal.ics", :content=>c.to_ical
  attachments.last.content_type 'text/calendar'

You would think you could work around this using:

  attachments["cal.ics"] = {:content=>c.to_ical,
                            :mime_type=>'text/calendar'}

However, that doesn't work because unlike add_file,
attachments[]= doesn't automatically convert the message to
multipart, which results in the removal of the existing body.
With this change, you can now do:

  add_file :filename=>"cal.ics", :content=>c.to_ical,
           :mime_type=>'text/calendar'