### PR TITLE
Handle parts with an un-parsable content-disposition

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,7 @@
 * #772 - normalize encoding matchers (grosser)
 * #789 - Fix encoding collapsing not dealing with multiple encodings in 1 line (grosser)
 * #775 - avoid failed encodings / stop bad charsets early (grosser)
+* #849 - Handle calling Part#inline? when the Content-Disposition field couldn't be parsed (kjg)
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/part.rb
+++ b/lib/mail/part.rb
@@ -34,7 +34,7 @@ module Mail
     end
     
     def inline?
-      header[:content_disposition].disposition_type == 'inline' if header[:content_disposition]
+      header[:content_disposition].disposition_type == 'inline' if header[:content_disposition].respond_to?(:disposition_type)
     end
     
     def add_required_fields

--- a/spec/mail/part_spec.rb
+++ b/spec/mail/part_spec.rb
@@ -71,8 +71,15 @@ describe Mail::Part do
     part = Mail::Part.new(:content_disposition => 'inline')
     expect(part).to be_inline
   end
-  
-  
+
+  it "handles un-parsable content_disposition headers" do
+    part = Mail::Part.new
+    field = Mail::Field.new('content-disposition')
+    field.field = Mail::UnstructuredField.new('content-disposition', 'failed to parse')
+    part.header.fields << field
+    expect(part).not_to be_inline
+  end
+
   describe "parts that have a missing header" do
     it "should not try to init a header if there is none" do
       part =<<PARTEND


### PR DESCRIPTION
Otherwise a NoMethodError is raised when calling `Part#inline?`