### PR TITLE
Allow overwriting Mail::Message sort order… for real

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -31,7 +31,7 @@ module Mail
       @preamble = nil
       @epilogue = nil
       @charset  = nil
-      @part_sort_order = [ "text/plain", "text/enriched", "text/html" ]
+      @part_sort_order = [ "text/plain", "text/enriched", "text/html", "multipart/alternative" ]
       @parts = Mail::PartsList.new
       if string.blank?
         @raw_source = ''
@@ -114,8 +114,8 @@ module Mail
     end
 
     # Allows you to set the sort order of the parts, overriding the default sort order.
-    # Defaults to 'text/plain', then 'text/enriched', then 'text/html' with any other content
-    # type coming after.
+    # Defaults to 'text/plain', then 'text/enriched', then 'text/html', then 'multipart/alternative'
+    # with any other content type coming after.
     def set_sort_order(order)
       @part_sort_order = order
     end

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1790,7 +1790,6 @@ module Mail
     # ready to send
     def ready_to_send!
       identify_and_set_transfer_encoding
-      parts.sort!([ "text/plain", "text/enriched", "text/html", "multipart/alternative" ])
       parts.each do |part|
         part.transport_encoding = transport_encoding
         part.ready_to_send!

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1783,7 +1783,6 @@ describe Mail::Message do
 
   describe "ordering messages" do
     it "should put all attachments as the last item" do
-      # XXX: AFAICT, this is not actually working. The code does not appear to implement this. -- singpolyma
       mail = Mail.new
       mail.attachments['image.png'] = "\302\302\302\302"
       p = Mail::Part.new(:content_type => 'multipart/alternative')
@@ -1795,6 +1794,21 @@ describe Mail::Message do
       expect(mail.parts[0].parts[0].mime_type).to eq "text/plain"
       expect(mail.parts[0].parts[1].mime_type).to eq "text/html"
       expect(mail.parts[1].mime_type).to eq "image/png"
+    end
+
+    it "should allow overwriting sort order" do
+      mail = Mail.new
+      mail.body.set_sort_order([])
+      mail.attachments['image.png'] = "\302\302\302\302"
+      p = Mail::Part.new(:content_type => 'multipart/alternative')
+      p.add_part(Mail::Part.new(:content_type => 'text/plain', :body => 'PLAIN TEXT'))
+      p.add_part(Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT'))
+      mail.add_part(p)
+      mail.encoded
+      expect(mail.parts[0].mime_type).to eq "image/png"
+      expect(mail.parts[1].mime_type).to eq "multipart/alternative"
+      expect(mail.parts[1].parts[0].mime_type).to eq "text/plain"
+      expect(mail.parts[1].parts[1].mime_type).to eq "text/html"
     end
   end
 


### PR DESCRIPTION
So I tried to build the following email:

```rb
mail = Mail.new do
  # FIXME: This does not work.
  body.set_sort_order []

  part do |p|
    p.text_part { body 'Hello world!' }
    p.html_part { body 'Hello <b>world</b>!' }
  end

  attachments['README.txt'] = 'some text'
end
```

An alternative part (plain + HTML) followed by a .txt attachment.

The resulting email was structured this way:

```
multipart/mixed
  text/plain (attachment)
  multipart/alternative
    text/plain
    text/html
```

Starting with the attachment looked like a bug to me, so I dug a bit. I found about `Mail::Body#sort_parts!` and the default `@part_sort_order`, so I tried disabling the sorting altogether by passing `Mail::Body#set_sort_order` an empty array (see `FIXME` comment above).

It did not work, because `Mail::Message#ready_to_send!` does a hard-coded `parts.sort!` with the default order, effectively making `Mail::Body#set_sort_order` useless.

This patch contains the fix. The example above now produces the following structure:

```
multipart/mixed
  multipart/alternative
    text/plain
    text/html
  text/plain (attachment)
```