### PR TITLE
Relax RSpec dependency

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('bundler', '>= 1.0.3')
   s.add_development_dependency('rake', '> 0.8.7')
-  s.add_development_dependency('rspec', '~> 3.0.0')
+  s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rdoc')
 
   s.files = %w(README.md MIT-LICENSE CONTRIBUTING.md CHANGELOG.rdoc Dependencies.txt Gemfile Rakefile TODO.rdoc) + Dir.glob("lib/**/*")


### PR DESCRIPTION
The test suite is passing just fine with RSpec 3.2 (testing with Ruby 2.2).