### PR TITLE
An invalid body encoding should still round trip

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -6,6 +6,7 @@
 * #789 - Fix encoding collapsing not dealing with multiple encodings in 1 line (grosser)
 * #775 - avoid failed encodings / stop bad charsets early (grosser)
 * #849 - Handle calling Part#inline? when the Content-Disposition field couldn't be parsed (kjg)
+* #865 - Allow a body with an invalid encoding to be round tripped (kjg)
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -156,7 +156,7 @@ module Mail
         be = get_best_encoding(transfer_encoding)
         dec = Mail::Encodings::get_encoding(encoding)
         enc = Mail::Encodings::get_encoding(be)
-        if transfer_encoding == encoding and dec.nil?
+        if dec.nil?
             # Cannot decode, so skip normalization
             raw_source
         else

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -448,4 +448,12 @@ describe Mail::Body do
       expect(body.encoded).to eq expect
     end
   end
+
+  describe "invalid encoding" do
+    it "should round trip" do
+      body = Mail::Body.new('The Body')
+      body.encoding = 'invalid'
+      expect(body.encoded).to eq 'The Body'
+    end
+  end
 end


### PR DESCRIPTION
I don't think the `if transfer_encoding == encoding` was adding anything
because the following logic would always error if dec was nil