### PR TITLE
Support decoding message bodies with non-Ruby-standard charsets

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -8,6 +8,7 @@
 * #849 - Handle calling Part#inline? when the Content-Disposition field couldn't be parsed (kjg)
 * #865 - Allow a body with an invalid encoding to be round tripped (kjg)
 * #868 - Use the Ruby19.charset_encoder when decoding message bodies (kjg)
+* #866 - Support decoding message bodies with non-Ruby-standard charsets (jeremy)
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -50,6 +50,14 @@ module Mail
       underscoreize(enc).downcase
     end
 
+    def Encodings.transcode_charset(str, from_charset, to_charset = 'UTF-8')
+      if from_charset
+        RubyVer.transcode_charset str, from_charset, to_charset
+      else
+        str
+      end
+    end
+
     # Encodes a parameter value using URI Escaping, note the language field 'en' can
     # be set using Mail::Configuration, like so:
     #

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2149,18 +2149,7 @@ module Mail
     end
 
     def decode_body_as_text
-      body_text = decode_body
-      if charset
-        if RUBY_VERSION < '1.9'
-          require 'iconv'
-          return Iconv.conv("UTF-8//TRANSLIT//IGNORE", charset, body_text)
-        else
-          Mail::Ruby19.charset_encoder.encode(body_text, charset)
-          return body_text.encode(Encoding::UTF_8, :undef => :replace, :invalid => :replace, :replace => '')
-        end
-      end
-      body_text
+      Encodings.transcode_charset decode_body, charset, 'UTF-8'
     end
-
   end
 end

--- a/lib/mail/version_specific/ruby_1_8.rb
+++ b/lib/mail/version_specific/ruby_1_8.rb
@@ -54,11 +54,15 @@ module Mail
       klass.const_get( string )
     end
 
+    def Ruby18.transcode_charset(str, from_encoding, to_encoding = 'UTF-8')
+      Iconv.conv("#{normalize_iconv_charset_encoding(to_encoding)}//IGNORE", normalize_iconv_charset_encoding(from_encoding), str)
+    end
+
     def Ruby18.b_value_encode(str, encoding)
       # Ruby 1.8 requires an encoding to work
       raise ArgumentError, "Must supply an encoding" if encoding.nil?
       encoding = encoding.to_s.upcase.gsub('_', '-')
-      [Encodings::Base64.encode(str), fix_encoding(encoding)]
+      [Encodings::Base64.encode(str), normalize_iconv_charset_encoding(encoding)]
     end
 
     def Ruby18.b_value_decode(str)
@@ -66,7 +70,7 @@ module Mail
       if match
         encoding = match[1]
         str = Ruby18.decode_base64(match[2])
-        str = Iconv.conv('UTF-8//IGNORE', fix_encoding(encoding), str)
+        str = transcode_charset(str, encoding)
       end
       str
     end
@@ -86,7 +90,7 @@ module Mail
         # Remove trailing = if it exists in a Q encoding
         string = string.sub(/\=$/, '')
         str = Encodings::QuotedPrintable.decode(string)
-        str = Iconv.conv('UTF-8//IGNORE', fix_encoding(encoding), str)
+        str = transcode_charset(str, encoding)
       end
       str
     end
@@ -103,7 +107,7 @@ module Mail
 
     private
 
-    def Ruby18.fix_encoding(encoding)
+    def Ruby18.normalize_iconv_charset_encoding(encoding)
       case encoding.upcase
       when 'UTF8', 'UTF_8'
         'UTF-8'
@@ -111,6 +115,8 @@ module Mail
         'UTF-16BE'
       when 'UTF32', 'UTF-32'
         'UTF-32BE'
+      when 'KS_C_5601-1987'
+        'CP949'
       else
         encoding
       end

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -73,6 +73,10 @@ module Mail
       klass.const_get( string )
     end
 
+    def Ruby19.transcode_charset(str, from_encoding, to_encoding = Encoding::UTF_8)
+      charset_encoder.encode(str.dup, from_encoding).encode(to_encoding, :undef => :replace, :invalid => :replace, :replace => '')
+    end
+
     def Ruby19.b_value_encode(str, encoding = nil)
       encoding = str.encoding.to_s
       [Ruby19.encode_base64(str), encoding]

--- a/spec/fixtures/emails/multi_charset/ks_c_5601-1987.eml
+++ b/spec/fixtures/emails/multi_charset/ks_c_5601-1987.eml
@@ -1,0 +1,11 @@
+Delivered-To: unknown@example.com
+Date: Wed, 28 May 2014 17:18:19 +0900 (JST)
+From: from@example.com
+To: unknown@example.com
+Subject: test
+Message-ID: <from@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="ks_c_5601-1987"
+Content-Transfer-Encoding: 8bit
+
+½ºÆ¼ÇØ

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -360,6 +360,14 @@ describe Mail::Message do
       expect(raw_message.encoding).to eq original_encoding if raw_message.respond_to?(:encoding)
     end
 
+    it "should parse sources with charsets that we know but Ruby doesn't" do
+      raw_message = File.read(fixture('emails', 'multi_charset', 'ks_c_5601-1987.eml'))
+      original_encoding = raw_message.encoding if raw_message.respond_to?(:encoding)
+      mail = Mail.new(raw_message)
+      expect(mail.decoded).to eq "스티해\n"
+      expect(raw_message.encoding).to eq original_encoding if raw_message.respond_to?(:encoding)
+    end
+
     if '1.9+'.respond_to?(:encoding)
       it "should be able to normalize CRLFs on non-UTF8 encodings" do
         File.open(fixture('emails', 'multi_charset', 'japanese_shift_jis.eml')) do |io|


### PR DESCRIPTION
We already have support for these additional charsets in message headers but didn't use the same code path for message bodies themselves.

Adds support for GB2312, ks_c_5601-1987, ISO-2022-JP-KDDI, ISO-8859-8-I, and more.