### PR TITLE
Add module Mail when loading AddressListsParser in AddressList

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -16,6 +16,7 @@ Bugs:
 * #789 - Fix encoding collapsing not dealing with multiple encodings in 1 line (grosser)
 * #808 - Mail::Field correctly responds_to? the methods of its instantiated field (thegcat)
 * #849 - Handle calling Part#inline? when the Content-Disposition field couldn't be parsed (kjg)
+* #867 - Add module Mail when loading AddressListsParser in AddressList (salrepe)
 * #874 – Stay under 1000-char SMTP line length limits (pushrax)
 * #877 - Make Mail::Field == other take the field value into account (kjg)
 * #907 - Mail::ContentDispositionField should work with nil value (kjg)

--- a/lib/mail/elements/address_list.rb
+++ b/lib/mail/elements/address_list.rb
@@ -4,24 +4,24 @@ module Mail
 
     # Mail::AddressList is the class that parses To, From and other address fields from
     # emails passed into Mail.
-    # 
+    #
     # AddressList provides a way to query the groups and mailbox lists of the passed in
     # string.
-    # 
+    #
     # It can supply all addresses in an array, or return each address as an address object.
-    # 
+    #
     # Mail::AddressList requires a correctly formatted group or mailbox list per RFC2822 or
     # RFC822.  It also handles all obsolete versions in those RFCs.
-    # 
+    #
     #  list = 'ada@test.lindsaar.net, My Group: mikel@test.lindsaar.net, Bob <bob@test.lindsaar.net>;'
     #  a = AddressList.new(list)
     #  a.addresses    #=> [#<Mail::Address:14943130 Address: |ada@test.lindsaar.net...
     #  a.group_names  #=> ["My Group"]
     def initialize(string)
       @addresses_grouped_by_group = nil
-      @address_list = Parsers::AddressListsParser.new.parse(string)
+      @address_list = Mail::Parsers::AddressListsParser.new.parse(string)
     end
-    
+
     # Returns a list of address objects from the parsed line
     def addresses
       @addresses ||= @address_list.addresses.map do |address_data|
@@ -32,7 +32,7 @@ module Mail
     def addresses_grouped_by_group
       addresses.select(&:group).group_by(&:group)
     end
-    
+
     # Returns the names as an array of strings of all groups
     def group_names # :nodoc:
       @address_list.group_names


### PR DESCRIPTION
We have had issues with this class, it looks like randomly it is not loading fine the class AddressListsParser from AddressList. These classes are being loaded with autoload so it seems that they are not being loaded fine if the Mail module is not added, like in the other element classes when using the parsers.
This is the error raised:

```
Message: uninitialized constant Mail::Parsers::AddressListsParser
Backtrace: /data/filer/current/vendor/bundle/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/ext/module.rb:36:in `const_missing'
/bundle/ruby/1.9.1/gems/mail-2.6.3/lib/mail/elements/address_list.rb:22:in `initialize'
/bundle/ruby/1.9.1/gems/mail-2.6.3/lib/mail/fields/common/common_address.rb:9:in `new'
/bundle/ruby/1.9.1/gems/mail-2.6.3/lib/mail/fields/common/common_address.rb:9:in `parse'
```

I do not know a way to test this as this is happening totally random for us.
