### PR TITLE
Use the Ruby19.charset_encoder when decoding message bodies

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -7,6 +7,7 @@
 * #775 - avoid failed encodings / stop bad charsets early (grosser)
 * #849 - Handle calling Part#inline? when the Content-Disposition field couldn't be parsed (kjg)
 * #865 - Allow a body with an invalid encoding to be round tripped (kjg)
+* #868 - Use the Ruby19.charset_encoder when decoding message bodies (kjg)
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2155,10 +2155,8 @@ module Mail
           require 'iconv'
           return Iconv.conv("UTF-8//TRANSLIT//IGNORE", charset, body_text)
         else
-          if encoding = Encoding.find(charset) rescue nil
-            body_text.force_encoding(encoding)
-            return body_text.encode(Encoding::UTF_8, :undef => :replace, :invalid => :replace, :replace => '')
-          end
+          Mail::Ruby19.charset_encoder.encode(body_text, charset)
+          return body_text.encode(Encoding::UTF_8, :undef => :replace, :invalid => :replace, :replace => '')
         end
       end
       body_text

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1480,18 +1480,33 @@ describe Mail::Message do
       "Am=E9rica"
     end
 
-    before(:each) do
-      @message = Mail.new(message_with_iso_8859_1_charset)
+    def with_encoder(encoder)
+      old, Mail::Ruby19.charset_encoder = Mail::Ruby19.charset_encoder, encoder
+      yield
+    ensure
+      Mail::Ruby19.charset_encoder = old
     end
 
+    let(:message){
+      Mail.new(message_with_iso_8859_1_charset)
+    }
+
     it "should be decoded using content type charset" do
-      expect(@message.decoded).to eq "América"
+      expect(message.decoded).to eq "América"
     end
 
     it "should respond true to text?" do
-      expect(@message.text?).to eq true
+      expect(message.text?).to eq true
     end
 
+    if RUBY_VERSION > "1.9"
+      it "uses the Ruby19 charset encoder" do
+        with_encoder(Mail::Ruby19::BestEffortCharsetEncoder.new) do
+          message = Mail.new("Content-Type: text/plain;\r\n charset=windows-1258\r\nContent-Transfer-Encoding: base64\r\n\r\nSGkglg==\r\n")
+          expect(message.decoded).to eq("Hi –")
+        end
+      end
+    end
   end
 
   describe "helper methods" do


### PR DESCRIPTION
To maintain consistency with param decoding