### PR TITLE
Add setting suppress_encoding to BccField

### DIFF
--- a/lib/mail/fields/bcc_field.rb
+++ b/lib/mail/fields/bcc_field.rb
@@ -43,9 +43,21 @@ module Mail
       self
     end
     
-    # Bcc field should never be :encoded
+    def self.suppress_encoding=(suppress_encoding)
+      @suppress_encoding = suppress_encoding
+    end
+
+    def self.suppress_encoding
+      defined?(@suppress_encoding) ? @suppress_encoding : self.suppress_encoding = true
+    end
+
+    # Bcc field should not be :encoded by default
     def encoded
-      ''
+      if self.class.suppress_encoding
+        ''
+      else
+        do_encode(CAPITALIZED_FIELD)
+      end
     end
     
     def decoded

--- a/lib/mail/fields/bcc_field.rb
+++ b/lib/mail/fields/bcc_field.rb
@@ -43,20 +43,20 @@ module Mail
       self
     end
     
-    def self.suppress_encoding=(suppress_encoding)
-      @suppress_encoding = suppress_encoding
+    def include_in_headers=(include_in_headers)
+      @include_in_headers = include_in_headers
     end
 
-    def self.suppress_encoding
-      defined?(@suppress_encoding) ? @suppress_encoding : self.suppress_encoding = true
+    def include_in_headers
+      defined?(@include_in_headers) ? @include_in_headers : self.include_in_headers = false
     end
 
     # Bcc field should not be :encoded by default
     def encoded
-      if self.class.suppress_encoding
-        ''
-      else
+      if include_in_headers
         do_encode(CAPITALIZED_FIELD)
+      else
+        ''
       end
     end
     

--- a/spec/mail/fields/bcc_field_spec.rb
+++ b/spec/mail/fields/bcc_field_spec.rb
@@ -73,9 +73,21 @@ describe Mail::BccField do
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
     
-    it "should return nothing on encoded as Bcc should not be in the mail" do
+    it "should return nothing by default on encoded as Bcc should not be in the mail" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq ""
+    end
+
+    it "should return the encoded line for one address when no longer suppressing" do
+      Mail::BccField.suppress_encoding = false
+      t = Mail::BccField.new('sam@me.com')
+      expect(t.encoded).to eq "Bcc: sam@me.com\r\n"
+    end
+    
+    it "should return the encoded line when no longer suppressing" do
+      Mail::BccField.suppress_encoding = false
+      t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
+      expect(t.encoded).to eq "Bcc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     
     it "should return the decoded line" do

--- a/spec/mail/fields/bcc_field_spec.rb
+++ b/spec/mail/fields/bcc_field_spec.rb
@@ -78,15 +78,15 @@ describe Mail::BccField do
       expect(t.encoded).to eq ""
     end
 
-    it "should return the encoded line for one address when no longer suppressing" do
-      Mail::BccField.suppress_encoding = false
+    it "should return the encoded line for one address when requested to include in headers" do
       t = Mail::BccField.new('sam@me.com')
+      t.include_in_headers = true
       expect(t.encoded).to eq "Bcc: sam@me.com\r\n"
     end
     
-    it "should return the encoded line when no longer suppressing" do
-      Mail::BccField.suppress_encoding = false
+    it "should return the encoded line when requested to include in headers" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
+      t.include_in_headers = true
       expect(t.encoded).to eq "Bcc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
     


### PR DESCRIPTION
This pull request addresses issue #864.

Add suppress_encoding to BccField to enable encoding the bcc field. By default, the Bcc field is still not encoded for reasons listed in #426 and thus this does not break backwards compatibility.

Tested under:
1.9.3-p551
2.1.5
2.2.0
jruby-1.7.18