### PR TITLE
Avoid violating RFC 2821 line length limits

### DIFF
--- a/lib/mail/encodings/8bit.rb
+++ b/lib/mail/encodings/8bit.rb
@@ -26,7 +26,7 @@ module Mail
       end
 
       # Per RFC 2821 4.5.3.1, SMTP lines may not be longer than 1000 octets including the <CRLF>.
-      def self.should_transport?(str)
+      def self.compatible_input?(str)
         !str.lines.find { |line| line.length > 998 }
       end
 

--- a/lib/mail/encodings/8bit.rb
+++ b/lib/mail/encodings/8bit.rb
@@ -25,7 +25,7 @@ module Mail
         1.0
       end
 
-      # Per RFC 2921 4.5.3.1, SMTP lines may not be longer than 1000 octets including the <CRLF>.
+      # Per RFC 2821 4.5.3.1, SMTP lines may not be longer than 1000 octets including the <CRLF>.
       def self.should_transport?(str)
         !str.lines.find { |line| line.length > 998 }
       end

--- a/lib/mail/encodings/8bit.rb
+++ b/lib/mail/encodings/8bit.rb
@@ -25,6 +25,11 @@ module Mail
         1.0
       end
 
+      # Per RFC 2921 4.5.3.1, SMTP lines may not be longer than 1000 octets including the <CRLF>.
+      def self.should_transport?(str)
+        !str.lines.find { |line| line.length > 998 }
+      end
+
       Encodings.register(NAME, self) 
     end
   end

--- a/lib/mail/encodings/base64.rb
+++ b/lib/mail/encodings/base64.rb
@@ -28,7 +28,7 @@ module Mail
       end
 
       # Base64 inserts newlines automatically and cannot violate the SMTP spec.
-      def self.should_transport?(str)
+      def self.compatible_input?(str)
         true
       end
 

--- a/lib/mail/encodings/base64.rb
+++ b/lib/mail/encodings/base64.rb
@@ -27,6 +27,11 @@ module Mail
         4.0/3
       end
 
+      # Base64 inserts newlines automatically and cannot violate the SMTP spec.
+      def self.should_transport?(str)
+        true
+      end
+
       Encodings.register(NAME, self)      
     end
   end

--- a/lib/mail/encodings/quoted_printable.rb
+++ b/lib/mail/encodings/quoted_printable.rb
@@ -32,7 +32,7 @@ module Mail
       end
 
       # QP inserts newlines automatically and cannot violate the SMTP spec.
-      def self.should_transport?(str)
+      def self.compatible_input?(str)
         true
       end
 

--- a/lib/mail/encodings/quoted_printable.rb
+++ b/lib/mail/encodings/quoted_printable.rb
@@ -30,7 +30,12 @@ module Mail
         total = (str.bytesize - c)*3 + c
         total.to_f/str.bytesize
       end
-        
+
+      # QP inserts newlines automatically and cannot violate the SMTP spec.
+      def self.should_transport?(str)
+        true
+      end
+
       private
 
       Encodings.register(NAME, self)

--- a/lib/mail/encodings/transfer_encoding.rb
+++ b/lib/mail/encodings/transfer_encoding.rb
@@ -32,30 +32,30 @@ module Mail
       end
 
       def self.get_best_compatible(source_encoding, str)
-        if self.can_transport?(source_encoding) && self.should_transport?(str) then
-            source_encoding
+        if self.can_transport?(source_encoding) && self.should_transport?(str)
+          source_encoding
         else
-            choices = []
-            Encodings.get_all.each do |enc|
-                choices << enc if self.can_transport? enc and enc.can_encode? source_encoding
+          choices = Encodings.get_all.select do |enc|
+            self.can_transport?(enc) && enc.can_encode?(source_encoding)
+          end
+
+          best = nil
+          best_cost = 100
+
+          choices.each do |enc|
+            # If the current choice cannot be transported safely,
+            # give priority to other choices but allow it to be used as a fallback.
+            this_cost = enc.should_transport?(str) ? enc.cost(str) : 99
+
+            if this_cost < best_cost
+              best_cost = this_cost
+              best = enc
+            elsif this_cost == best_cost
+              best = enc if enc::PRIORITY < best::PRIORITY
             end
+          end
 
-            best = nil
-            best_cost = 100
-
-            choices.each do |enc|
-                # If the current choice cannot be transported safely,
-                # give priority to other choices but allow it to be used as a fallback.
-                this_cost = enc.should_transport?(str) ? enc.cost(str) : 99
-
-                if this_cost < best_cost then
-                    best_cost = this_cost
-                    best = enc
-                elsif this_cost == best_cost then 
-                    best = enc if enc::PRIORITY < best::PRIORITY
-                end
-            end
-            best
+          best
         end
       end
 

--- a/lib/mail/encodings/transfer_encoding.rb
+++ b/lib/mail/encodings/transfer_encoding.rb
@@ -23,7 +23,7 @@ module Mail
         raise "Unimplemented"
       end
 
-      def self.should_transport?(str)
+      def self.compatible_input?(str)
         true
       end
 
@@ -32,7 +32,7 @@ module Mail
       end
 
       def self.get_best_compatible(source_encoding, str)
-        if self.can_transport?(source_encoding) && self.should_transport?(str)
+        if self.can_transport?(source_encoding) && self.compatible_input?(str)
           source_encoding
         else
           choices = Encodings.get_all.select do |enc|
@@ -45,7 +45,7 @@ module Mail
           choices.each do |enc|
             # If the current choice cannot be transported safely,
             # give priority to other choices but allow it to be used as a fallback.
-            this_cost = enc.cost(str) if enc.should_transport?(str)
+            this_cost = enc.cost(str) if enc.compatible_input?(str)
 
             if !best_cost || (this_cost && this_cost < best_cost)
               best_cost = this_cost

--- a/lib/mail/encodings/transfer_encoding.rb
+++ b/lib/mail/encodings/transfer_encoding.rb
@@ -23,22 +23,31 @@ module Mail
         raise "Unimplemented"
       end
 
+      def self.should_transport?(str)
+        true
+      end
+
       def self.to_s
         self::NAME
       end
 
       def self.get_best_compatible(source_encoding, str)
-        if self.can_transport? source_encoding then
-            source_encoding 
+        if self.can_transport?(source_encoding) && self.should_transport?(str) then
+            source_encoding
         else
             choices = []
             Encodings.get_all.each do |enc|
                 choices << enc if self.can_transport? enc and enc.can_encode? source_encoding
             end
-            best = nil 
+
+            best = nil
             best_cost = 100
+
             choices.each do |enc|
-                this_cost = enc.cost str
+                # If the current choice cannot be transported safely,
+                # give priority to other choices but allow it to be used as a fallback.
+                this_cost = enc.should_transport?(str) ? enc.cost(str) : 99
+
                 if this_cost < best_cost then
                     best_cost = this_cost
                     best = enc

--- a/lib/mail/encodings/transfer_encoding.rb
+++ b/lib/mail/encodings/transfer_encoding.rb
@@ -40,14 +40,14 @@ module Mail
           end
 
           best = nil
-          best_cost = 100
+          best_cost = nil
 
           choices.each do |enc|
             # If the current choice cannot be transported safely,
             # give priority to other choices but allow it to be used as a fallback.
-            this_cost = enc.should_transport?(str) ? enc.cost(str) : 99
+            this_cost = enc.cost(str) if enc.should_transport?(str)
 
-            if this_cost < best_cost
+            if !best_cost || (this_cost && this_cost < best_cost)
               best_cost = this_cost
               best = enc
             elsif this_cost == best_cost

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1366,6 +1366,14 @@ describe Mail::Message do
           expect(mail.to_s).to match(%r{Content-Transfer-Encoding: 7bit})
         end
 
+        it "should use QP transfer encoding for 7bit text with lines longer than 998 octets" do
+          body = "a" * 999
+          mail = Mail.new
+          mail.charset = "UTF-8"
+          mail.body = body
+          expect(mail.to_s).to match(%r{Content-Transfer-Encoding: quoted-printable})
+        end
+
         it "should use QP transfer encoding for 8bit text with only a few 8bit characters" do
           body = "Maxfeldstraße 5, 90409 Nürnberg"
           mail = Mail.new


### PR DESCRIPTION
Fixes #316.

RFC 2821 specifies that SMTP lines must not be longer than 1000 characters. In this case, quoted-printable or base64 should be used rather than 8bit or 7bit.

In Shopify we are running into an issue where user-written templates are generating long HTML lines, which causes Postfix to split them automatically at the 998-char boundary. Occasionally a URL or something important is split, leading to broken HTML rendering.