### PR TITLE
RFC-1342 decode fix

### DIFF
--- a/lib/mail/constants.rb
+++ b/lib/mail/constants.rb
@@ -34,7 +34,7 @@ module Mail
     PHRASE_UNSAFE = /[#{Regexp.quote aspecial}#{control}]/n
     TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{sp}]/n
     ENCODED_VALUE = /\=\?([^?]+)\?([QB])\?[^?]*?\?\=/mi
-    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)(?:\r\n[\x9\x20]+|\n[\x9\x20]*|[\x9\x20]+)/mi
+    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)/mi
 
     EMPTY          = ''
     SPACE          = ' '

--- a/lib/mail/constants.rb
+++ b/lib/mail/constants.rb
@@ -34,7 +34,7 @@ module Mail
     PHRASE_UNSAFE = /[#{Regexp.quote aspecial}#{control}]/n
     TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{sp}]/n
     ENCODED_VALUE = /\=\?([^?]+)\?([QB])\?[^?]*?\?\=/mi
-    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)/mi
+    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)(?:\r\n[\x9\x20]+|\n[\x9\x20]*|[\x9\x20]+)/mi
 
     EMPTY          = ''
     SPACE          = ' '

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -262,7 +262,7 @@ module Mail
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      [ str.split(FULL_ENCODED_VALUE).join ]
+      [ str.split(/(\?=)\s*(=\?)/).join ]
     end
   end
 end

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -262,25 +262,7 @@ module Mail
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      results = []
-      previous_encoding = nil
-      lines = str.split(FULL_ENCODED_VALUE)
-      lines.each_slice(2) do |unencoded, encoded|
-        if encoded
-          encoding = value_encoding_from_string(encoded)
-          if encoding == previous_encoding && unencoded.blank?
-            results.last << encoded
-          else
-            results << unencoded unless unencoded == EMPTY
-            results << encoded
-          end
-          previous_encoding = encoding
-        else
-          results << unencoded
-        end
-      end
-
-      results
+      [ str.split(FULL_ENCODED_VALUE).join ]
     end
   end
 end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -154,7 +154,7 @@ describe Mail::Encodings do
       expect(Mail::Encodings.value_decode(string)).to eq(string)
     end
 
-    it "should collapse adjacent words" do
+    it "should parse adjacent encoded-words separated by linear white-space" do
       string = "=?utf-8?B?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?=\n =?utf-8?B?0LXQtdCy?="
       result = "новый сотрудник — дорофеев"
       expect(Mail::Encodings.value_decode(string)).to eq(result)


### PR DESCRIPTION
For obvious reasons Base64 can't be collapsed without first decoding and re-encoding (which defeats the purpose of performance gains by collapsing in the first place, if that was the original intent.) Quoted-Printable could be collapsed, but, is there truly any gain in performance based on the amount of additional processing (loops, logical comparisons, regex comparisons, etc...) that is necessary to collapse it in the first place?