### PR TITLE
Rfc 1342 fix

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,6 @@
 == HEAD
 
+* Strip valid RFC-1342 separator characters between non-matching encoded-words (Caleb W. Corliss)
 * Make the gem compatible with Rubinius (Robin Dupret)
 * #808 - Mail::Field correctly responds_to? the methods of its instantiated field (thegcat)
 * #772 - normalize encoding matchers (grosser)

--- a/lib/mail/constants.rb
+++ b/lib/mail/constants.rb
@@ -34,7 +34,7 @@ module Mail
     PHRASE_UNSAFE = /[#{Regexp.quote aspecial}#{control}]/n
     TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{sp}]/n
     ENCODED_VALUE = /\=\?([^?]+)\?([QB])\?[^?]*?\?\=/mi
-    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)/mi
+    FULL_ENCODED_VALUE = /(=\?[A-Za-z0-9\-]+\?[QB]\?[\x21-\x7E&&[^\?]]*?\?=)/mi
 
     EMPTY          = ''
     SPACE          = ' '

--- a/lib/mail/constants.rb
+++ b/lib/mail/constants.rb
@@ -34,7 +34,7 @@ module Mail
     PHRASE_UNSAFE = /[#{Regexp.quote aspecial}#{control}]/n
     TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{sp}]/n
     ENCODED_VALUE = /\=\?([^?]+)\?([QB])\?[^?]*?\?\=/mi
-    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)(?:\r\n[\x9\x20]+|\n[\x9\x20]*|[\x9\x20]+)/mi
+    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)/mi
 
     EMPTY          = ''
     SPACE          = ' '

--- a/lib/mail/constants.rb
+++ b/lib/mail/constants.rb
@@ -34,7 +34,7 @@ module Mail
     PHRASE_UNSAFE = /[#{Regexp.quote aspecial}#{control}]/n
     TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{sp}]/n
     ENCODED_VALUE = /\=\?([^?]+)\?([QB])\?[^?]*?\?\=/mi
-    FULL_ENCODED_VALUE = /(=\?[A-Za-z0-9\-]+\?[QB]\?[\x21-\x7E&&[^\?]]*?\?=)/mi
+    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)/mi
 
     EMPTY          = ''
     SPACE          = ' '

--- a/lib/mail/constants.rb
+++ b/lib/mail/constants.rb
@@ -34,7 +34,7 @@ module Mail
     PHRASE_UNSAFE = /[#{Regexp.quote aspecial}#{control}]/n
     TOKEN_UNSAFE  = /[#{Regexp.quote tspecial}#{control}#{sp}]/n
     ENCODED_VALUE = /\=\?([^?]+)\?([QB])\?[^?]*?\?\=/mi
-    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)/mi
+    FULL_ENCODED_VALUE = /(\=\?[^?]+\?[QB]\?[^?]*?\?\=)(?:\r\n[\x9\x20]+|\n[\x9\x20]*|[\x9\x20]+)/mi
 
     EMPTY          = ''
     SPACE          = ' '

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -262,7 +262,7 @@ module Mail
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      [ str.split(FULL_ENCODED_VALUE).join ]
+      [ str.split(/(\?=)\s*(=\?)/).join ]
     end
   end
 end

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -262,25 +262,7 @@ module Mail
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      results = []
-      previous_encoding = nil
-      lines = str.split(FULL_ENCODED_VALUE)
-      lines.each_slice(2) do |unencoded, encoded|
-        if encoded
-          encoding = value_encoding_from_string(encoded)
-          if encoding == previous_encoding && unencoded.blank?
-            results.last << encoded
-          else
-            results << unencoded unless unencoded == EMPTY
-            results << encoded
-          end
-          previous_encoding = encoding
-        else
-          results << unencoded
-        end
-      end
-
-      results
+      [ str.split(FULL_ENCODED_VALUE).join ]
     end
   end
 end

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -268,7 +268,7 @@ module Mail
       lines.each_slice(2) do |unencoded, encoded|
         if encoded
           if previous_encoding && unencoded.blank?
-            results.last << encoded
+            results << encoded
           else
             results << unencoded unless unencoded == EMPTY
             results << encoded

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -257,12 +257,31 @@ module Mail
       str[ENCODED_VALUE, 1]
     end
 
-    # When the encoded string consists of multiple lines, lines with the same
-    # encoding (Q or B) can be joined together.
+    # Split header line into proper encoded and unencoded parts.
     #
     # String has to be of the format =?<encoding>?[QB]?<string>?=
     def Encodings.collapse_adjacent_encodings(str)
-      [ str.split(/(\?=)\s*(=\?)/).join ]
+      results = []
+      previous_encoding = false
+      
+      lines = str.split(FULL_ENCODED_VALUE)
+      lines.each_slice(2) do |unencoded, encoded|
+        if encoded
+          if previous_encoding && unencoded.blank?
+            results.last << encoded
+          else
+            results << unencoded unless unencoded == EMPTY
+            results << encoded
+          end
+          
+          previous_encoding = true
+        else
+          results << unencoded
+          previous_encoding = false
+        end
+      end
+      
+      results
     end
   end
 end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -899,7 +899,7 @@ describe Mail::Encodings do
       convert "A=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=B", ["A", "=?iso-2022-jp?B?X=?=", "=?iso-2022-jp?B?Y=?=", "B"]
     end
     
-    it "splits adjacent encodings  without unencoded into separate parts" do
+    it "splits adjacent encodings without unencoded into separate parts" do
       convert "=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=", ["=?iso-2022-jp?B?X=?=", "=?iso-2022-jp?B?Y=?="]
     end
 
@@ -912,7 +912,11 @@ describe Mail::Encodings do
     end
     
     it "does not keep the separator character between two different encodings" do
-      convert "=?iso-2022-jp?B?X=?=\n=?utf-8?Q?Y=?=", ["=?iso-2022-jp?B?X=?=", "=?utf-8?Q?Y=?="]
+      rfc_1342_newline_separators = ["\x0A", "\x20"]
+      
+      rfc_1342_newline_separators.each do |rfc_1342_separator|
+        convert "=?iso-2022-jp?B?X=?=#{rfc_1342_separator}=?utf-8?Q?Y=?=", ["=?iso-2022-jp?B?X=?=", "=?utf-8?Q?Y=?="]
+      end
     end
   end
 

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -910,6 +910,10 @@ describe Mail::Encodings do
     it "does not join different encodings" do
       convert "A=?iso-2022-jp?B?X=?==?utf-8?B?Y=?=B", ["A", "=?iso-2022-jp?B?X=?=", "=?utf-8?B?Y=?=", "B"]
     end
+    
+    it "does not keep the separator character between two different encodings" do
+      convert "=?iso-2022-jp?B?X=?=\n=?utf-8?Q?Y=?=", ["=?iso-2022-jp?B?X=?=", "=?utf-8?Q?Y=?="]
+    end
   end
 
   describe ".pick_encoding" do

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -895,12 +895,12 @@ describe Mail::Encodings do
       convert "A=?iso-2022-jp?B?X=?=B", ["A", "=?iso-2022-jp?B?X=?=", "B"]
     end
 
-    it "joins adjacent encodings" do
-      convert "A=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=B", ["A", "=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=", "B"]
+    it "splits adjacent encodings into separate parts" do
+      convert "A=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=B", ["A", "=?iso-2022-jp?B?X=?=", "=?iso-2022-jp?B?Y=?=", "B"]
     end
-
-    it "joins adjacent encodings without unencoded" do
-      convert "=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=", ["=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?="]
+    
+    it "splits adjacent encodings  without unencoded into separate parts" do
+      convert "=?iso-2022-jp?B?X=?==?iso-2022-jp?B?Y=?=", ["=?iso-2022-jp?B?X=?=", "=?iso-2022-jp?B?Y=?="]
     end
 
     it "does not join encodings when separated by unencoded" do

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -154,7 +154,7 @@ describe Mail::Encodings do
       expect(Mail::Encodings.value_decode(string)).to eq(string)
     end
 
-    it "should collapse adjacent words" do
+    it "should parse adjacent encoded-words separated by linear white-space" do
       string = "=?utf-8?B?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?=\n =?utf-8?B?0LXQtdCy?="
       result = "новый сотрудник — дорофеев"
       expect(Mail::Encodings.value_decode(string)).to eq(result)


### PR DESCRIPTION
Adjacent encoded-words with different character sets or encodings would inadvertently leave valid separator characters (space \x20 or newline \x0A) as an unencoded part.  These characters, per the RFC-1342 spec (page 3-4, "Use of encoded-words in message headers") should not be displayed.

This fix is only for adjacent encoded-words and does not strip the separator character (linear white-space or newline character) following encoded words that are then followed by a "word", "text", "ctext", or "special" (which per the spec should be stripped unless the separator is a newline that comes at the end of the field.)
