### PR TITLE
Make field == other consider the value

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -10,6 +10,7 @@
 * #868 - Use the Ruby19.charset_encoder when decoding message bodies (kjg)
 * #866 - Support decoding message bodies with non-Ruby-standard charsets (jeremy)
 * #907 - Mail::ContentDispositionField should work with nil value (kjg)
+* #877 - File Mail::Field == other take the field value into account (kjg)
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -171,11 +171,13 @@ module Mail
       match_to_s(other.name, self.name)
     end
 
+    def ==( other )
+      match_to_s(other.name, self.name) && match_to_s(other.value, self.value)
+    end
+
     def responsible_for?( val )
       name.to_s.casecmp(val.to_s) == 0
     end
-
-    alias_method :==, :same
 
     def <=>( other )
       self.field_order_id <=> other.field_order_id

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -168,10 +168,12 @@ module Mail
     end
 
     def same( other )
+      return false unless other.kind_of?(self.class)
       match_to_s(other.name, self.name)
     end
 
     def ==( other )
+      return false unless other.kind_of?(self.class)
       match_to_s(other.name, self.name) && match_to_s(other.value, self.value)
     end
 

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -151,8 +151,20 @@ describe Mail::Field do
       expect(field.responsible_for?(:to)).to be_truthy
     end
 
-    it "should say it is == to another if their field and names match" do
+    it "should say it is the \"same\" as another if their field types match" do
       expect(Mail::Field.new("To: mikel").same(Mail::Field.new("To: bob"))).to be_truthy
+    end
+
+    it "should say it is not the \"same\" as another if their field types don't match" do
+      expect(Mail::Field.new("To: mikel").same(Mail::Field.new("From: mikel"))).to be_falsey
+    end
+
+    it "should say it is not the \"same\" as nil" do
+      expect(Mail::Field.new("To: mikel").same(nil)).to be_falsey
+    end
+
+    it "should say it is == to another if their field and names match" do
+      expect(Mail::Field.new("To: mikel")).to eq(Mail::Field.new("To: mikel"))
     end
 
     it "should say it is not == to another if their field names do not match" do
@@ -163,6 +175,10 @@ describe Mail::Field do
       expect(Mail::Field.new("To: mikel")).not_to eq(Mail::Field.new("To: bob"))
     end
 
+    it "should say it is not == to nil" do
+      expect(Mail::Field.new("From: mikel")).not_to eq(nil)
+    end
+
     it "should sort according to the field order" do
       list = [Mail::Field.new("To: mikel"), Mail::Field.new("Return-Path: bob")]
       expect(list.sort[0].name).to eq "Return-Path"
@@ -170,7 +186,7 @@ describe Mail::Field do
   end
 
   describe 'user defined fields' do
-    it "should say it is == to another if their field names match" do
+    it "should say it is the \"same\" as another if their field names match" do
       expect(Mail::Field.new("X-Foo: mikel").same(Mail::Field.new("X-Foo: bob"))).to be_truthy
     end
 

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -151,12 +151,16 @@ describe Mail::Field do
       expect(field.responsible_for?(:to)).to be_truthy
     end
 
-    it "should say it is == to another if their field names match" do
+    it "should say it is == to another if their field and names match" do
       expect(Mail::Field.new("To: mikel").same(Mail::Field.new("To: bob"))).to be_truthy
     end
 
     it "should say it is not == to another if their field names do not match" do
       expect(Mail::Field.new("From: mikel")).not_to eq(Mail::Field.new("To: bob"))
+    end
+
+    it "should say it is not == to another if their field names match, but not their values" do
+      expect(Mail::Field.new("To: mikel")).not_to eq(Mail::Field.new("To: bob"))
     end
 
     it "should sort according to the field order" do


### PR DESCRIPTION
The [change implementing the current behavior] (https://github.com/mikel/mail/commit/81c3e9db5d2faf30fb85f8573beb13966fb80e58) looks like it was added to combat the behavior of including [`Comparable`](http://ruby-doc.org/core-2.2.2/Comparable.html) which [defines `#==`](http://ruby-doc.org/core-2.2.2/Comparable.html#method-i-3D-3D) as more or less being `(a <=> b) == 0`. Before that change, `Mail::Header#[]=` would match on any field with the same sort order as another when setting a header to nil resulting in unexpected deletions of X-Headers.

As far as I can tell `#same` is never actually used anywhere internally, but if people are using same to mean the name of the field is the same, I didn't want to change that. However, I'm pretty sure no one really expects two fields to be equivalent based on just the name of the field. I've made this PR to implement more guessable behavior of `#==`.
