### PR TITLE
Fix #844 some old mailer client use 'uuencode'

### DIFF
--- a/lib/mail/encodings/unix_to_unix.rb
+++ b/lib/mail/encodings/unix_to_unix.rb
@@ -1,6 +1,6 @@
 module Mail
   module Encodings
-    module UnixToUnix
+    class UnixToUnix
       NAMES = ["uuencode", "x-uuencode"]
 
       def self.decode(str)

--- a/lib/mail/encodings/unix_to_unix.rb
+++ b/lib/mail/encodings/unix_to_unix.rb
@@ -1,7 +1,7 @@
 module Mail
   module Encodings
     module UnixToUnix
-      NAME = "x-uuencode"
+      NAMES = ["uuencode", "x-uuencode"]
 
       def self.decode(str)
         str.sub(/\Abegin \d+ [^\n]*\n/, '').unpack('u').first
@@ -11,7 +11,9 @@ module Mail
         [str].pack("u")
       end
 
-      Encodings.register(NAME, self)
+      NAMES.each do |used_name|
+        Encodings.register(used_name, self)
+      end
     end
   end
 end


### PR DESCRIPTION
Handle 'uuencode' by registering UnixToUnix (same as 'x-uuencode')
