### PR TITLE
require mime/types/columnar if available for large memory savings

### DIFF
--- a/lib/mail.rb
+++ b/lib/mail.rb
@@ -6,7 +6,13 @@ module Mail # :doc:
 
   require 'uri'
   require 'net/smtp'
-  require 'mime/types'
+
+  begin
+    # Use mime/types/columnar if available, for reduced memory usage
+    require 'mime/types/columnar'
+  rescue LoadError
+    require 'mime/types'
+  end
 
   if RUBY_VERSION <= '1.8.6'
     begin


### PR DESCRIPTION
This drops the memory footprint of mail from about 19MB to 3MB.

This shouldn't be merged until after mime-types 2.6.1 is released, as mime-types 2.6 has a bug when using the columnar store where it only considers the first extension for a mime type.