### PR TITLE
Added support for timeouts

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -9,6 +9,7 @@
 * #865 - Allow a body with an invalid encoding to be round tripped (kjg)
 * #868 - Use the Ruby19.charset_encoder when decoding message bodies (kjg)
 * #866 - Support decoding message bodies with non-Ruby-standard charsets (jeremy)
+* #804 - Support for timeouts
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -86,7 +86,9 @@ module Mail
                         :enable_starttls_auto => true,
                         :openssl_verify_mode  => nil,
                         :ssl                  => nil,
-                        :tls                  => nil
+                        :tls                  => nil,
+                        :open_timeout         => nil,
+                        :read_timeout         => nil
                       }.merge!(values)
     end
 
@@ -107,6 +109,8 @@ module Mail
           smtp.enable_starttls_auto(ssl_context)
         end
       end
+      smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]
+      smtp.read_timeout = settings[:read_timeout] if settings[:read_timeout]
 
       response = nil
       smtp.start(settings[:domain], settings[:user_name], settings[:password], settings[:authentication]) do |smtp_obj|

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -152,7 +152,7 @@ describe Mail::Message do
         @smtp_settings = { :address=>"smtp.somewhere.net",
           :port=>"587", :domain=>"somewhere.net", :user_name=>"someone@somewhere.net",
           :password=>"password", :authentication=>:plain, :enable_starttls_auto => true,
-          :openssl_verify_mode => nil, :ssl=>nil, :tls=>nil }
+          :openssl_verify_mode => nil, :ssl=>nil, :tls=>nil, :open_timeout=>nil, :read_timeout=>nil }
         @yaml_mail.delivery_method :smtp, @smtp_settings
       end
 

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -15,7 +15,9 @@ describe "SMTP Delivery Method" do
                                :enable_starttls_auto => true,
                                :openssl_verify_mode  => nil,
                                :tls                  => nil,
-                               :ssl                  => nil
+                               :ssl                  => nil,
+                               :open_timeout         => nil,
+                               :read_timeout         => nil
                                 }
     end
     MockSMTP.clear_deliveries

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -46,7 +46,9 @@ describe "Mail" do
                                                 :enable_starttls_auto => true,
                                                 :openssl_verify_mode  => nil,
                                                 :ssl                  => nil,
-                                                :tls                  => nil })
+                                                :tls                  => nil,
+                                                :open_timeout         => nil,
+                                                :read_timeout         => nil })
     end
 
     it "should set the retriever method" do


### PR DESCRIPTION
Hey, thanks for all the work you've done on this popular gem!

This PR adds open and read timeouts to the SMTP delivery method as requested in #804.  I couldn't find a great way to write specs with `MockSMTP`, but I was able to [test it here](https://github.com/ankane/the-ultimate-guide-to-timeouts-in-ruby/compare/mail).  Let me know if you have ideas.
