### PR TITLE
add use_args option to SendMail delivery method

### DIFF
--- a/lib/mail/network/delivery_methods/sendmail.rb
+++ b/lib/mail/network/delivery_methods/sendmail.rb
@@ -40,9 +40,21 @@ module Mail
   class Sendmail
     include Mail::CheckDeliveryParams
 
+    class DeliveryError < StandardError
+    end
+
     def initialize(values)
+
+      arguments = "-i"
+
+      if values[:use_args]
+        arguments = ["-i"]
+      end
+
       self.settings = { :location       => '/usr/sbin/sendmail',
-                        :arguments      => '-i' }.merge(values)
+                        :arguments      => arguments,
+                        :use_args => false }.merge(values)
+
     end
 
     attr_accessor :settings
@@ -50,11 +62,39 @@ module Mail
     def deliver!(mail)
       smtp_from, smtp_to, message = check_delivery_params(mail)
 
-      from = "-f #{self.class.shellquote(smtp_from)}"
-      to = smtp_to.map { |_to| self.class.shellquote(_to) }.join(' ')
+      if self.settings[:use_args]
 
-      arguments = "#{settings[:arguments]} #{from} --"
-      self.class.call(settings[:location], arguments, to, message)
+        if RUBY_VERSION < '1.9.0'
+          raise ArgumentError.new(":use_args not supported by ruby version")
+        end
+
+        exec_array = [settings[:location]]
+        exec_array.concat(settings[:arguments])
+        exec_array << "-f"
+        exec_array << smtp_from
+        exec_array << "--"
+        exec_array.concat(smtp_to)
+        self.class.exec_call(exec_array, message)
+      else
+        from = "-f #{self.class.shellquote(smtp_from)}"
+        to = smtp_to.map { |_to| self.class.shellquote(_to) }.join(' ')
+
+        arguments = "#{settings[:arguments]} #{from} --"
+        self.class.call(settings[:location], arguments, to, message)      
+      end
+
+    end
+
+    def self.exec_call(exec_array, encoded_message)
+      IO.popen exec_array, "w+", :err => :out do |io|
+        io.puts ::Mail::Utilities.to_lf(encoded_message)
+        io.flush
+      end
+
+
+      if $?.exitstatus != 0
+        raise DeliveryError.new("Bad Exit Status: #{$?.exitstatus}")
+      end
     end
 
     def self.call(path, arguments, destinations, encoded_message)


### PR DESCRIPTION
Fix for https://github.com/mikel/mail/issues/897

add use_args option to SendMail delivery method

if use_args is true then SendMail will invoke
the sendmail binary using execv style argument
passing instead of shell style argument passing.

this fixes issues where email addresses are
corrupted by shell escaping. this is an option
because it breaks compatibility when the
:arguments option is specified because the
:arguments option previously took a string of
arguments while when passing execv style we need
to take the option as an array of arguments.

this also breaks compatibility with the previous
behaviour because it now raises an error when
sendmail generates a non-zero exit code.

it also breaks compatibility with the previous
behaviour because use_args will not work with
older ruby versions. older ruby versions don't
support redirected stderr from popen and this is
probably why shell style argument passing was
originally used.
