### PR TITLE
Optionally yield self to block constructor

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -129,7 +129,11 @@ module Mail
       end
 
       if block_given?
-        instance_eval(&block)
+        if block.arity < 1
+          instance_eval(&block)
+        else
+          yield self
+        end
       end
 
       self

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -38,6 +38,27 @@ describe Mail::Message do
       expect(mail.to).to eq ['lindsaar@you.com']
     end
 
+    it "should optionally yield self to the passed block" do
+      class ClassThatCreatesMail
+        def initialize(from, to)
+          @from = from
+          @to = to
+        end
+
+        def create_mail
+          Mail::Message.new do |m|
+            m.from @from
+            m.to @to
+          end
+        end
+      end
+
+      mail = ClassThatCreatesMail.new('mikel@me.com', 'lindsaar@you.com').create_mail
+
+      expect(mail.from).to eq ['mikel@me.com']
+      expect(mail.to).to eq ['lindsaar@you.com']
+    end
+
     it "should initialize a body and header class even if called with nothing to begin with" do
       mail = Mail::Message.new
       expect(mail.header.class).to eq Mail::Header


### PR DESCRIPTION
Currently it's kind of a nuisance to write a class that creates mail objects, because many of the convenience methods are inside a DSL that uses instance_eval, and therefore all your instance variables and instance methods are unavailable. For instance, today the following code doesn't work:

```
class ClassThatCreatesMail
  def initialize(from, to)
    @from = from
    @to = to
  end

  def calculate_to
    @to
  end

  def create_mail
    Mail::Message.new do
      from @from
      to calculate_to
    end
  end
end
```

Neither `@from`, nor `calculate_to` are available when the block is evaluated.

This pull request optionally yields self in the block constructor, so if people are willing to tolerate a slightly less shiny DSL they can access all their instance variables and methods, like so:

```
  def create_mail
    Mail::Message.new do |m|
      m.from @from
      m.to calculate_to
    end
  end
```

Thanks, by the way, for the gem. I'm getting a lot of use out of it right now and it's saving me weeks (months?) of work...
