### PR TITLE
Allow string assignment for text_part and html_part

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1669,6 +1669,8 @@ module Mail
     def html_part=(msg)
       # Assign the html part and set multipart/alternative if there's a text part.
       if msg
+        msg = Mail::Part.new(:body => msg) unless msg.kind_of?(Mail::Message)
+
         @html_part = msg
         @html_part.content_type = 'text/html' unless @html_part.has_content_type?
         add_multipart_alternate_header if text_part
@@ -1691,6 +1693,8 @@ module Mail
     def text_part=(msg)
       # Assign the text part and set multipart/alternative if there's an html part.
       if msg
+        msg = Mail::Part.new(:body => msg) unless msg.kind_of?(Mail::Message)
+
         @text_part = msg
         @text_part.content_type = 'text/plain' unless @text_part.has_content_type?
         add_multipart_alternate_header if html_part
@@ -2023,7 +2027,7 @@ module Mail
       raw_string = raw_source.to_s
       if match_data = raw_source.to_s.match(/\AFrom\s(#{TEXT}+)#{CRLF}/m)
         set_envelope(match_data[1])
-        self.raw_source = raw_string.sub(match_data[0], "") 
+        self.raw_source = raw_string.sub(match_data[0], "")
       end
     end
 

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -144,6 +144,13 @@ describe "MIME Emails" do
         expect(mail.text_part).to eq text_mail
       end
 
+      it "should convert strings assigned to the text part into Mail::Part objects with sensible defaults" do
+        mail = Mail.new
+        mail.text_part = 'This is text'
+        expect(mail.text_part.body).to eq 'This is text'
+        expect(mail.text_part.content_type).to eq 'text/plain'
+      end
+
       it "should not assign a nil text part" do
         mail = Mail.new
         mail.text_part = nil
@@ -155,6 +162,13 @@ describe "MIME Emails" do
         html_mail = Mail.new("<b>This is HTML</b>")
         mail.html_part = html_mail
         expect(mail.html_part).to eq html_mail
+      end
+
+      it "should convert strings assigned to the html part into Mail::Part objects with sensible defaults" do
+        mail = Mail.new
+        mail.html_part = "<b>This is HTML</b>"
+        expect(mail.html_part.body).to eq "<b>This is HTML</b>"
+        expect(mail.html_part.content_type).to eq "text/html"
       end
 
       it "should not assign a nil html part" do


### PR DESCRIPTION
As a newcomer to this gem, when I tried to create a multipart message, my first attempt looked like this:

```
mail = Mail.new
mail.text_part = 'Some text'
mail.html_part = '<b>Some text</b>'
```

This, of course, doesn't work, because the two setters above are expecting to receive Mail::Message objects. I didn't like the two alternatives currently available, `mail.text_part = Mail::Part.new(body: 'Some text')` and `mail.text_part { body 'Some text' }`, because the first is too verbose and the second prohibits access to instance variables/methods from outside of Mail, so I added the two lines of code to make the above behave as expected.