### PR TITLE
make Mail::ContentDispositionField work with nil value

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -9,6 +9,7 @@
 * #865 - Allow a body with an invalid encoding to be round tripped (kjg)
 * #868 - Use the Ruby19.charset_encoder when decoding message bodies (kjg)
 * #866 - Support decoding message bodies with non-Ruby-standard charsets (jeremy)
+* #907 - Mail::ContentDispositionField should work with nil value (kjg)
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/fields/content_disposition_field.rb
+++ b/lib/mail/fields/content_disposition_field.rb
@@ -3,10 +3,10 @@ require 'mail/fields/common/parameter_hash'
 
 module Mail
   class ContentDispositionField < StructuredField
-    
+
     FIELD_NAME = 'content-disposition'
     CAPITALIZED_FIELD = 'Content-Disposition'
-    
+
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       ensure_filename_quoted(value)
@@ -14,13 +14,13 @@ module Mail
       self.parse
       self
     end
-    
+
     def parse(val = value)
       unless val.blank?
         @element = Mail::ContentDispositionElement.new(val)
       end
     end
-    
+
     def element
       @element ||= Mail::ContentDispositionElement.new(value)
     end
@@ -28,10 +28,10 @@ module Mail
     def disposition_type
       element.disposition_type
     end
-    
+
     def parameters
       @parameters = ParameterHash.new
-      element.parameters.each { |p| @parameters.merge!(p) }
+      element.parameters.each { |p| @parameters.merge!(p) } unless element.parameters.nil?
       @parameters
     end
 
@@ -41,7 +41,7 @@ module Mail
         @filename = parameters['filename']
       when !parameters['name'].blank?
         @filename = parameters['name']
-      else 
+      else
         @filename = nil
       end
       @filename
@@ -56,7 +56,7 @@ module Mail
       end
       "#{CAPITALIZED_FIELD}: #{disposition_type}" + p
     end
-    
+
     def decoded
       if parameters.length > 0
         p = "; #{parameters.decoded}"

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -77,6 +77,11 @@ describe Mail::ContentDispositionField do
       c = Mail::ContentDispositionField.new('Content-Disposition: ')
       expect(c.disposition_type).not_to be_nil
     end
-  end
 
+    it "handles nil value" do
+      c = Mail::ContentDispositionField.new(nil, 'utf-8')
+      expect(c.parameters).to be_a( Mail::ParameterHash )
+      expect(c.parameters).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
I've been running into an issue where a content disposition field fails to fully parse due to the filename being in an unspecified encoding. When this happens the ContentDispositionField ends up being crated with a nil value and then when .parameters is called on the field, it raises an error. Instead the parameters should just be empty.