### PR TITLE
Parse unicode chars in local and domain parts of addresses

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -10,7 +10,8 @@
 * #868 - Use the Ruby19.charset_encoder when decoding message bodies (kjg)
 * #866 - Support decoding message bodies with non-Ruby-standard charsets (jeremy)
 * #907 - Mail::ContentDispositionField should work with nil value (kjg)
-* #877 - File Mail::Field == other take the field value into account (kjg)
+* #877 - Make Mail::Field == other take the field value into account (kjg)
+* #910 - Mail::Address should handle b_value_encoded local and domain parts (kjg)
 
 == Version 2.6.3 - Mon Nov 3 23:53 +1100 2014 Mikel Lindsaar <mikel@reinteractive.net>
 

--- a/lib/mail/elements/address.rb
+++ b/lib/mail/elements/address.rb
@@ -102,7 +102,7 @@ module Mail
     #  a.local #=> 'mikel'
     def local
       parse unless @parsed
-      "#{@data.obs_domain_list}#{get_local.strip}" if get_local
+      Encodings.decode_encode("#{@data.obs_domain_list}#{get_local.strip}", @output_type) if get_local
     end
 
     # Returns the domain part (the right hand side of the @ sign in the email address) of
@@ -112,7 +112,7 @@ module Mail
     #  a.domain #=> 'test.lindsaar.net'
     def domain
       parse unless @parsed
-      strip_all_comments(get_domain) if get_domain
+      Encodings.decode_encode(strip_all_comments(get_domain), @output_type) if get_domain
     end
 
     # Returns an array of comments that are in the email, or an empty array if there

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -593,6 +593,19 @@ describe Mail::Address do
                                          :raw          => 'groupname+domain.com@example.com'})
       end
 
+      it "should handle |=?UTF-8?B?8J+RjQ==?= <=?UTF-8?B?8J+RjQ==?=@=?UTF-8?B?8J+RjQ==?=.emoji>|" do
+        address = Mail::Address.new('=?UTF-8?B?8J+RjQ==?= <=?UTF-8?B?8J+RjQ==?=@=?UTF-8?B?8J+RjQ==?=.emoji>')
+        expect(address).to break_down_to({
+                                         :name         => '👍',
+                                         :display_name => '👍',
+                                         :address      => '👍@👍.emoji',
+                                         :comments     => nil,
+                                         :domain       => '👍.emoji',
+                                         :local        => '👍',
+                                         :format       => '"👍" <👍@👍.emoji>',
+                                         :raw          => '=?UTF-8?B?8J+RjQ==?= <=?UTF-8?B?8J+RjQ==?=@=?UTF-8?B?8J+RjQ==?=.emoji>'})
+      end
+
       it "should expose group" do
         struct = Mail::Parsers::AddressStruct.new(nil, nil, nil, nil, nil, nil, "GROUP", nil)
         address = Mail::Address.new(struct)


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Email_address: [RFC 6531](https://tools.ietf.org/html/rfc6531) and [RFC 6532](https://tools.ietf.org/html/rfc6532) allow for unicode characters in the local part and domain part of the email address. I received one of these emails today. This PR will allow the b_value_encoded email local and domain to be parsed.