### PR TITLE
Fix for nil content-type in 2.5

### DIFF
--- a/lib/mail/parts_list.rb
+++ b/lib/mail/parts_list.rb
@@ -44,7 +44,7 @@ module Mail
   private
 
     def get_order_value(part, order)
-      if part.respond_to?(:content_type)
+      if part.respond_to?(:content_type) && !part[:content_type].nil?
         order.index(part[:content_type].string.downcase) || 10000
       else
         10000

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -17,4 +17,21 @@ describe "PartsList" do
     p << 'text/html'
     p.sort!(order)
   end
+
+  it "should not fail if we do not have a content_type" do
+    p = Mail::PartsList.new
+    order = ['text/plain', 'text/html']
+
+    no_content_type_part = Mail::Part.new
+    plain_text_part      = Mail::Part.new
+    html_text_part       = Mail::Part.new
+
+    no_content_type_part.content_type = nil
+    html_text_part.content_type       = 'text/html'
+
+    p << no_content_type_part
+    p << plain_text_part
+    p << html_text_part
+    p.sort!(order).should eq [plain_text_part, html_text_part, no_content_type_part]
+  end
 end


### PR DESCRIPTION
I've encountered some emails which have a content-type but it is nil, which causes a NoMethodError on line 48. Replacing this with the built-in method `to_s` will produce an empty string instead of an error, allowing this to pass silently. I have included a spec to demonstrate this behavior.

I understand this has been fixed in newer versions of this gem (2.6), but for other reasons we must continue using 2.5-stable and as such this is a PR to that branch.