### PR TITLE
Fix non-us matching.

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -179,7 +179,7 @@ module Mail
       return address if address.ascii_only? or charset.nil?
       us_ascii = %Q{\x00-\x7f}
       # Encode any non usascii strings embedded inside of quotes
-      address = address.gsub(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
+      address = address.gsub(/("[^"]*?[^#{us_ascii}][^"]*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
       # Then loop through all remaining items and encode as needed
       tokens = address.split(/\s/)
       map_with_index(tokens) do |word, i|

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -179,7 +179,9 @@ module Mail
       return address if address.ascii_only? or charset.nil?
       us_ascii = %Q{\x00-\x7f}
       # Encode any non usascii strings embedded inside of quotes
-      address = address.gsub(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
+      address = address.gsub(/(".*?.*?")/) do |q|
+        q.gsub(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
+      end
       # Then loop through all remaining items and encode as needed
       tokens = address.split(/\s/)
       map_with_index(tokens) do |word, i|

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -179,9 +179,7 @@ module Mail
       return address if address.ascii_only? or charset.nil?
       us_ascii = %Q{\x00-\x7f}
       # Encode any non usascii strings embedded inside of quotes
-      address = address.gsub(/(".*?.*?")/) do |q|
-        q.gsub(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
-      end
+      address = address.gsub(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
       # Then loop through all remaining items and encode as needed
       tokens = address.split(/\s/)
       map_with_index(tokens) do |word, i|

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -786,6 +786,12 @@ describe Mail::Encodings do
       encoded = '=?UTF-8?B?RmVsaXggQmFhcsOf?= <test@example.com>'
       expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
+
+    it "should encode multiple combo of ascii then non-ascii correctly" do
+      raw     = '"Mikel Lindsaar" <mikel@test.lindsaar.net>, "あdあ" <ada@test.lindsaar.net>'
+      encoded = '"Mikel Lindsaar" <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
+    end
   end
 
   describe "address encoding" do


### PR DESCRIPTION
The parser currently does not correctly work with non-us ascii. In particular, if a list contains multiple quoted addresses and the first one is us ascii, but a later one is not, the regular expression will not work properly.

For Example: `Mail::ToField.new('"Just Ascii" <just@ascii.com>, "Foo Bär" <x@example.com>').addrs`

This is broken upstream:
 `=> [#<Mail::Address:70340928511720 Address: |"Just Ascii\" <just@ascii.com>, \"Foo Bär" <x@example.com>| >]`

With the patch:

 `=> [#<Mail::Address:70340922281680 Address: |Just Ascii <just@ascii.com>| >, #<Mail::Address:70340922281660 Address: |"Foo Bär" <x@example.com>| >]`
