### PR TITLE
New method AttachmentsList.add(attachment)

### DIFF
--- a/lib/mail/attachments_list.rb
+++ b/lib/mail/attachments_list.rb
@@ -81,6 +81,16 @@ module Mail
       @parts_list << attachment
     end
 
+    # Append an already created Mail::Part object to list
+    # useful when copying attachments from other mails
+    def add(attachment)
+      if attachment.kind_of?(Mail::Part)
+        @parts_list << attachment
+      else
+        raise "Only instances of Mail::Part can be directly added to attachments"
+      end
+    end
+
     # Uses the mime type to try and guess the encoding, if it is a binary type, or unknown, then we
     # set it to binary, otherwise as set to plain text
     def guess_encoding


### PR DESCRIPTION
I added a new function to the AttachmentsList class to manipulate attachments without decode/encode and rewriting id's etc.

We are using the Mail gem for a message router and need everytime to copy the original attachments. 

Instead of re-creating that attachments like

```ruby
mail_in = Mail.read_from_string(mail_source)
mail_out = Mail.new
# copy attachments
mail_in.attachments.each do |a| 
  mail_out.attachments[a.filename] = { 
    :mime_type => a.mime_type, 
    :encoding => a.content_transfer_encoding,
    :content_id => a.content_id,
    :content_disposition => a.content_disposition,
    :content => a.decoded
  } 
end
```

now you just can append the already processed attachment from original message.

```ruby
mail_in = Mail.read_from_string(mail_source)
mail_out = Mail.new
# copy attachments
mail_in.attachments.each { |a| mail_out.attachments.add(a) }
```

Hopefully this change makes sense for you.

Looking for your feedback
Tom
