### PR TITLE
Don't let ActiveSupport exist after loading unicode tables.

### DIFF
--- a/lib/mail/multibyte/active_support_shim.rb
+++ b/lib/mail/multibyte/active_support_shim.rb
@@ -1,0 +1,7 @@
+unless defined?(ActiveSupport)
+  module ActiveSupport
+    module ShimInsertedByMail; end
+
+    Multibyte = Mail::Multibyte
+  end
+end

--- a/spec/mail/multibyte_spec.rb
+++ b/spec/mail/multibyte_spec.rb
@@ -13,5 +13,8 @@ describe "multibyte/chars" do
     chars = Chars.new('VĚDA A VÝZKUM')
     expect(chars.downcase).to eq("věda a výzkum")
   end
-end
 
+  it "has no ActiveSupport defined" do
+    expect(defined? ActiveSupport).to be_falsey
+  end
+end


### PR DESCRIPTION
This hopefully fixes #933, but it feels rather hackish. I guess the old code was dodgy as well, so.. 

Maybe someone comes up with a better solution.