### PR TITLE
Add multipart email support for HasSentEmailMatcher#matching_body

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,28 @@ describe "sending an email" do
 
   it { should have_sent_email.matching_subject(/test(ing)?/) }
   it { should have_sent_email.matching_body(/h(a|e)llo/) }
+  
+  # Or if you use multipart emails...
+  
+  # ...can check if text matches on both parts, text and HTML
+  
+  it { is_expected.not_to have_sent_email.matching_body(/text|HTML/i) }
+  
+  # or same, but more explicit
+  
+  it { is_expected.not_to have_sent_email.matching_body(/text|HTML/i, :on_both_parts) }
+  
+  # ...can check if either of the two parts match by using `:on_either_part`
+   
+  it { is_expected.to have_sent_email.matching_body(/plain/i, :on_either_part) }
+  
+  # ...can only check if a match is on the text part of a multipart email by using `:on_text_part`
+  
+  it { is_expected.to have_sent_email.matching_body(/plain|non-existing/i, :on_text_part) }
+  
+  # ...and can only check if a match is on the HTML part by using `:on_html_part`
+  
+  it { is_expected.to have_sent_email.matching_body(/h1|body/i, :on_html_part) }
 
   # Can chain together modifiers
   # Note that apart from recipients, repeating a modifier overwrites old value.

--- a/lib/mail/matchers/has_sent_mail.rb
+++ b/lib/mail/matchers/has_sent_mail.rb
@@ -77,8 +77,16 @@ module Mail
         self
       end
 
-      def matching_body(body_matcher)
-        @body_matcher = body_matcher
+      def matching_body(body_matcher, multipart_match_on=nil)
+        if multipart_match_on.nil?
+          @body_matcher = body_matcher
+        else
+          multipart_match_on = multipart_match_on.to_sym
+          unless [:on_both_parts, :on_either_part, :on_text_part, :on_html_part].include?(multipart_match_on)
+            raise ArgumentError.new('Part must be one of :on_both_parts (default), :on_either_part, :on_text_part, :on_html_part')
+          end
+          @multipart_body_matcher = { :match => body_matcher, :on => multipart_match_on }
+        end
         self
       end
 
@@ -107,7 +115,8 @@ module Mail
         candidate_deliveries = deliveries
         modifiers =
           %w(sender recipients copy_recipients blind_copy_recipients subject
-          subject_matcher body body_matcher having_attachments attachments)
+          subject_matcher body body_matcher multipart_body_matcher
+          having_attachments attachments)
         modifiers.each do |modifier_name|
           next unless instance_variable_defined?("@#{modifier_name}")
           candidate_deliveries = candidate_deliveries.select{|matching_delivery| self.send("matches_on_#{modifier_name}?", matching_delivery)}
@@ -159,6 +168,31 @@ module Mail
         @body_matcher.match delivery.body.raw_source
       end
 
+      def matches_on_multipart_body_matcher?(delivery)
+        case @multipart_body_matcher[:on]
+        when :on_html_part
+          matches_on_multipart_body_matcher_html?(delivery)
+        when :on_text_part
+          matches_on_multipart_body_matcher_text?(delivery)
+        when :on_both_parts
+          matches_on_multipart_body_matcher_html?(delivery) &&
+            matches_on_multipart_body_matcher_text?(delivery)
+        when :on_either_part
+          matches_on_multipart_body_matcher_html?(delivery) ||
+            matches_on_multipart_body_matcher_text?(delivery)
+        end
+      end
+
+      def matches_on_multipart_body_matcher_html?(delivery)
+        return false unless delivery.html_part
+        @multipart_body_matcher[:match].match delivery.html_part.body.raw_source
+      end
+
+      def matches_on_multipart_body_matcher_text?(delivery)
+        return false unless delivery.text_part
+        @multipart_body_matcher[:match].match delivery.text_part.body.raw_source
+      end
+
       def explain_expectations
         result = ''
         result += "from #{@sender} " if instance_variable_defined?('@sender')
@@ -169,6 +203,7 @@ module Mail
         result += "with subject matching \"#{@subject_matcher}\" " if instance_variable_defined?('@subject_matcher')
         result += "with body \"#{@body}\" " if instance_variable_defined?('@body')
         result += "with body matching \"#{@body_matcher}\" " if instance_variable_defined?('@body_matcher')
+        result += "with multipart body matching \"#{@multipart_body_matcher[:match]}\" #{@multipart_body_matcher[:on].to_s.gsub(/_/, ' ')} " if instance_variable_defined?('@multipart_body_matcher')
         result
       end
 


### PR DESCRIPTION
This can be used to test if the body of a multipart email contains the correct text in its individual body parts.

A similar behavior was proposed by @stefanosc in issue https://github.com/mikel/mail/issues/879.

Usage:

``` Ruby
# To check if text matches on both parts, text and HTML, add `:on_both_parts` as second argument to `#matching_body`
it { is_expected.not_to have_sent_email.matching_body(/text|HTML/i, :on_both_parts) }

# To check if either of the two parts match use `:on_either_part` as second argument:
it { is_expected.to have_sent_email.matching_body(/plain/i, :on_either_part) }

# To only check if a match is on the text part of a multipart email use `:on_text_part`:
it { is_expected.to have_sent_email.matching_body(/plain|non-existing/i, :on_text_part) }

# And to only check if a match is on the HTML part use `:on_html_part`:
it { is_expected.to have_sent_email.matching_body(/h1|body/i, :on_html_part) }
```

This has been successfully tested with the following rubies:

```
   jruby-1.7.19 [ x86_64 ]
   ruby-1.8.7-head [ i686 ]
   ruby-1.9.3-p551 [ x86_64 ]
   ruby-2.1.5 [ x86_64 ]
   ruby-2.2.1 [ x86_64 ]
```
