### PR TITLE
Fix example for Main::Utilities#dasherize method

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -175,7 +175,7 @@ module Mail
     # Example:
     #
     #  string = :resent_from_field
-    #  dasherize ( string ) #=> 'resent_from_field'
+    #  dasherize( string ) #=> 'resent-from-field'
     def dasherize( str )
       str.to_s.tr(UNDERSCORE, HYPHEN)
     end


### PR DESCRIPTION
Hello, I found error in documentation. Real example from irb:
```
>> class Test
>> include Mail::Utilities
>> end
=> Test
>> t = Test.new
=> #<Test:0x007fd8d1d34418>
>> t.dasherize :test_string
=> "test-string" 
```