### PR TITLE
Security fix for #944 for 2.5.x: Escape brake code in fields

### DIFF
--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -188,6 +188,8 @@ module Mail
     end
 
     def create_field(name, value, charset)
+      value = value.gsub(/[\r\n \t]+/m, ' ') if value.is_a?(String)
+
       begin
         self.field = new_field(name, value, charset)
       rescue Mail::Field::ParseError => e

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -116,6 +116,11 @@ describe Mail::Field do
       field = Mail::Field.new('Subject: こんにちは', charset)
       field.charset.should eq charset
     end
+
+    it "should escape <CR> and <LF>" do
+      field = Mail::Field.new("To", "mail@\r\nexample.com")
+      field.value.should_not eq "mail@\r\nexample.com"
+    end
   end
 
   describe "error handling" do


### PR DESCRIPTION
As described in #944, there is a security problem in parsing headers.
I backported code which escapes line brakes from https://github.com/mikel/mail/blob/02be6e37e850023421901042af3ff501e649d354/lib/mail/field.rb#L238