### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/lib/mail/constants.rb
+++ b/lib/mail/constants.rb
@@ -12,7 +12,7 @@ module Mail
     control      = %Q|\x00-\x1f\x7f-\xff|
 
     if control.respond_to?(:force_encoding)
-      control = control.force_encoding(Encoding::BINARY)
+      control = control.dup.force_encoding(Encoding::BINARY)
     end
 
     CRLF          = /\r\n/

--- a/lib/mail/fields/unstructured_field.rb
+++ b/lib/mail/fields/unstructured_field.rb
@@ -143,7 +143,7 @@ module Mail
       while !words.empty?
         limit = 78 - prepend
         limit = limit - 7 - encoding.length if should_encode
-        line = ""
+        line = String.new
         first_word = true
         while !words.empty?
           break unless word = words.first.dup

--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -204,7 +204,7 @@ module Mail
                            content-id content-disposition content-location]
 
     def encoded
-      buffer = ''
+      buffer = String.new
       buffer.force_encoding('us-ascii') if buffer.respond_to?(:force_encoding)
       fields.each do |field|
         buffer << field.encoded


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Roda's specs
to pass.  There may well be other changes that are required.