### PR TITLE
Fix encoding issue introduced by #956

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -233,11 +233,11 @@ module Mail
       # Using String#encode is better performing than Regexp
 
       def self.to_lf(input)
-        input.kind_of?(String) ? input.to_str.encode(:universal_newline => true) : ''
+        input.kind_of?(String) ? input.to_str.encode(input.encoding, :universal_newline => true) : ''
       end
 
       def self.to_crlf(input)
-        input.kind_of?(String) ? input.to_str.encode(:universal_newline => true).encode!(:crlf_newline => true) : ''
+        input.kind_of?(String) ? input.to_str.encode(input.encoding, :universal_newline => true).encode!(input.encoding, :crlf_newline => true) : ''
       end
 
     else

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -452,6 +452,16 @@ describe "Utilities Module" do
       expect(Mail::Utilities.to_lf("\r \n\r\n")).to eq "\n \n\n"
     end
 
+    if defined?(Encoding)
+      it "should not change the encoding of the string" do
+        saved_default_internal = Encoding.default_internal
+        Encoding.default_internal = "UTF-8"
+        ascii_string = "abcd".force_encoding("ASCII-8BIT")
+        expect(Mail::Utilities.to_lf(ascii_string).encoding).to eq(Encoding::ASCII_8BIT)
+        Encoding.default_internal = saved_default_internal
+      end
+    end
+
     describe "to_lf method on String" do
       it "should leave lf as lf" do
         expect(Mail::Utilities.to_lf("\n")).to eq "\n"
@@ -505,6 +515,16 @@ describe "Utilities Module" do
       it "should handle japanese characters" do
         string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
         expect(Mail::Utilities.to_crlf(string)).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
+      end
+
+      if defined?(Encoding)
+        it "should not change the encoding of the string" do
+          saved_default_internal = Encoding.default_internal
+          Encoding.default_internal = "UTF-8"
+          ascii_string = "abcd".force_encoding("ASCII-8BIT")
+          expect(Mail::Utilities.to_crlf(ascii_string).encoding).to eq(Encoding::ASCII_8BIT)
+          Encoding.default_internal = saved_default_internal
+        end
       end
 
     end


### PR DESCRIPTION
#956 changes the implementation of `Mail::Utilities#to_lf` and `#to_crlf` to use `String#encode` for better performance.

[The variant of String#encode used translates the string to `Encoding.default_internal`.
](http://ruby-doc.org/core-2.2.0/String.html#method-i-encode)
>The last form returns a copy of str transcoded to Encoding.default_internal.

In most rails apps this is set to "UTF-8". This can result in the encoding of the string being different than expected after being passed through these methods.

Instead, let's use the second form of `String#encode` in which we specify the encoding used is the same as the input string.

Benchmark shows no degradation in performance:
```ruby
CRLF = "\r\n"
CRLF_REGEX = Regexp.new("(?<!\r)\n|\r(?!\n)")

string = "\n\r\n\n" * 10_000

Benchmark.bm do |x|
  x.report('encode last form:') do
    10_000.times do
      string.encode(:universal_newline => true).encode!(:crlf_newline => true)
    end
  end

  x.report('encode second form:') do
    10_000.times do
      string.encode(string.encoding, :universal_newline => true).encode!(string.encoding, :crlf_newline => true)
    end
  end
end
```

results:
```
       user     system      total        real
encode last form:  9.240000   0.410000   9.650000 (  9.706578)
encode second form:  8.950000   0.230000   9.180000 (  9.218603)
```