### PR TITLE
Don't mutate string in quote_phrase

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -24,13 +24,11 @@ module Mail
     def quote_phrase( str )
       if RUBY_VERSION >= '1.9'
         original_encoding = str.encoding
-        str.force_encoding('ASCII-8BIT')
-        if (PHRASE_UNSAFE === str)
-          quoted_str = dquote(str).force_encoding(original_encoding)
-          str.force_encoding(original_encoding)
-          quoted_str
+        ascii_str = str.dup.force_encoding('ASCII-8BIT')
+        if (PHRASE_UNSAFE === ascii_str)
+          dquote(ascii_str).force_encoding(original_encoding)
         else
-          str.force_encoding(original_encoding)
+          str
         end
       else
         (PHRASE_UNSAFE === str) ? dquote(str) : str

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -84,27 +84,32 @@ describe "Utilities Module" do
 
   end
 
-  if RUBY_VERSION >= '1.9'
-    describe "quoting phrases" do
+  describe "quoting phrases" do
+    it "doesn't mutate original string" do
+      input_str = "blargh".freeze
+      expect { quote_phrase(input_str) }.not_to raise_error
+    end
+
+    if RUBY_VERSION >= '1.9'
       describe "given a non-unsafe string" do
         it "should not change the encoding" do
-          input_str = String.new("blargh")
+          input_str = "blargh"
           input_str_encoding = input_str.encoding
 
-          quote_phrase(input_str)
+          result = quote_phrase(input_str)
 
-          expect(input_str.encoding).to eq input_str_encoding
+          expect(result.encoding).to eq input_str_encoding
         end
       end
 
       describe "given an unsafe string" do
         it "should not change the encoding" do
-          input_str = String.new("Bjørn")
+          input_str = "Bjørn"
           input_str_encoding = input_str.encoding
 
-          quote_phrase(input_str)
+          result = quote_phrase(input_str)
 
-          expect(input_str.encoding).to eq input_str_encoding
+          expect(result.encoding).to eq input_str_encoding
         end
       end
     end


### PR DESCRIPTION
This is a fix for issue #965  - it's not technically necessary for the mail gem to work given the changes in PR #970 - however it really doesn't make any sense for the method to be mutating the input string and then mutating it back