### PR TITLE
Handle whitespace better when unfolding subject.

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -2,6 +2,7 @@
 
 Bugs:
 * #978 - Fix for invalid chars being left in a string for invalid b_value from encoding (kjg)
+* #980 - Allow consecutive simple spaces in a subject header. (aselder)
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -232,12 +232,13 @@ module Mail
     #  that is immediately followed by WSP.  Each header field should be
     #  treated in its unfolded form for further syntactic and semantic
     #  evaluation.
-    def unfold(string)
-      string.gsub(/[\r\n \t]+/m, ' ')
+    def unfold(name, value)
+      regex = name == 'Subject' ? /\s*\r\n\s+/m : /[\r\n \t]+/m
+      value.gsub(regex, ' ')
     end
 
     def create_field(name, value, charset)
-      value = unfold(value) if value.is_a?(String)
+      value = unfold(name, value) if value.is_a?(String)
 
       begin
         new_field(name, value, charset)

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -435,7 +435,18 @@ describe Mail::Header do
       header = Mail::Header.new("To: Mikel,\r\n   Lindsaar,     Bob")
       expect(header['To'].value).to eq 'Mikel, Lindsaar, Bob'
     end
+    
+    it "should not remove multiple spaces from a subject header" do
+      header = Mail::Header.new("Subject: Mikel,   Lindsaar,     Bob")
+      expect(header['Subject'].value).to eq 'Mikel,   Lindsaar,     Bob'
+    end
 
+    it "should remove multiple spaces from a subject header following a new line" do
+      header = Mail::Header.new("subject: Mikel,\r\n   Lindsaar,     Bob")
+      expect(header['Subject'].value).to eq 'Mikel, Lindsaar,     Bob'
+    end
+
+    
     it "should handle a crazy long folded header" do
       header_text =<<HERE
 Received: from [127.0.220.158] (helo=fg-out-1718.google.com)


### PR DESCRIPTION
When unfolding a subject only remove whitespace on either side of a CRLF.

Multiple consecutive spaces in a subject could have meaning to user of the library.

This also fixes a change in behavior from Mail 2.5.x to Mail 2.6.x. In Mail 2.5.x, consecutive simple spaces were not touched.

This is a fix for issue #980 