### PR TITLE
Preserve unfolded whitespace

### DIFF
--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -236,7 +236,7 @@ module Mail
     #  treated in its unfolded form for further syntactic and semantic
     #  evaluation.
     def unfold(string)
-      string.gsub(/[\r\n \t]+/m, ' ')
+      string.gsub(/#{CRLF}(#{WSP})/m, '\1')
     end
 
     def create_field(name, value, charset)

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -155,7 +155,7 @@ describe "Test emails" do
     # can be long.
     it "should handle the RFC trace example email" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example09.eml'))
-      expect(mail.received[0].info).to eq 'from x.y.test by example.net via TCP with ESMTP id ABC12345 for <mary@example.net>'
+      expect(mail.received[0].info).to eq 'from x.y.test   by example.net   via TCP   with ESMTP   id ABC12345   for <mary@example.net>'
       expect(mail.received[0].date_time).to eq ::DateTime.parse('21 Nov 1997 10:05:43 -0600')
       expect(mail.received[1].info).to eq 'from machine.example by x.y.test'
       expect(mail.received[1].date_time).to eq ::DateTime.parse('21 Nov 1997 10:01:22 -0600')
@@ -254,7 +254,7 @@ describe "Test emails" do
     it "should handle folding subject" do
       mail = Mail.read(fixture('emails', 'rfc2822', 'example14.eml'))
       expect(mail.from).to eq ["atsushi@example.com"]
-      expect(mail.subject).to eq "Re: TEST テストテスト"
+      expect(mail.subject).to eq "Re: TEST \tテストテスト"
       expect(mail.message_id).to eq '0CC5E11ED2C1D@example.com'
       expect(mail.body.decoded).to eq "Hello\n"
     end

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -431,9 +431,9 @@ describe Mail::Header do
       expect(header['To'].value).to eq 'Mikel, Lindsaar, Bob'
     end
 
-    it "should remove multiple spaces during unfolding a header" do
-      header = Mail::Header.new("To: Mikel,\r\n   Lindsaar,     Bob")
-      expect(header['To'].value).to eq 'Mikel, Lindsaar, Bob'
+    it "should preserve whitespace when unfolding a header" do
+      header = Mail::Header.new("To: Mikel,\r\n\t   Lindsaar,     Bob")
+      expect(header['To'].value).to eq "Mikel,\t   Lindsaar,     Bob"
     end
 
     it "should handle a crazy long folded header" do
@@ -445,7 +445,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\r\n"))
-      expect(header['Received'].value).to eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      expect(header['Received'].value).to eq "from [127.0.220.158] (helo=fg-out-1718.google.com)\tby smtp.totallyrandom.com with esmtp (Exim 4.68)\t(envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>)\tid 1K4JeQ-0005Nd-Ij\tfor support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700"
     end
 
     it "should convert all lonesome LFs to CRLF" do
@@ -457,7 +457,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\n"))
-      expect(header['Received'].value).to eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      expect(header['Received'].value).to eq "from [127.0.220.158] (helo=fg-out-1718.google.com)\tby smtp.totallyrandom.com with esmtp (Exim 4.68)\t(envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>)\tid 1K4JeQ-0005Nd-Ij\tfor support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700"
     end
 
     it "should convert all lonesome CRs to CRLF" do
@@ -469,7 +469,7 @@ Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
 	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
 HERE
       header = Mail::Header.new(header_text.gsub(/\n/, "\r"))
-      expect(header['Received'].value).to eq 'from [127.0.220.158] (helo=fg-out-1718.google.com) by smtp.totallyrandom.com with esmtp (Exim 4.68) (envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>) id 1K4JeQ-0005Nd-Ij for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700'
+      expect(header['Received'].value).to eq "from [127.0.220.158] (helo=fg-out-1718.google.com)\tby smtp.totallyrandom.com with esmtp (Exim 4.68)\t(envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>)\tid 1K4JeQ-0005Nd-Ij\tfor support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700"
     end
 
   end
@@ -564,7 +564,7 @@ TRACEHEADER
   describe "encoding" do
     it "should output a parsed version of itself to US-ASCII on encoded and tidy up and sort correctly" do
       encoded = Mail::Header.new("To: Mikel\r\n\sLindsaar <mikel@test.lindsaar.net>\r\nFrom: bob\r\n\s<bob@test.lindsaar.net>\r\nSubject: This is\r\n a long\r\n\s \t \t \t    badly formatted             \r\n       \t\t  \t       field").encoded
-      result = "From: bob <bob@test.lindsaar.net>\r\nTo: Mikel Lindsaar <mikel@test.lindsaar.net>\r\nSubject: This is a long badly formatted field\r\n"
+      result = "From: bob <bob@test.lindsaar.net>\r\nTo: Mikel Lindsaar <mikel@test.lindsaar.net>\r\nSubject: This is a long           badly formatted                             \r\n   field\r\n"
       if result.respond_to?(:encode!)
         result = result.dup.encode!(::Encoding::US_ASCII)
         expect(encoded.encoding).to eq ::Encoding::US_ASCII if encoded.respond_to?(:encoding)


### PR DESCRIPTION
We've long squashed repeated whitespace (space and horizontal tab) to a single space when we unfold headers. We're supposed to just remove the CRLF and leave the whitespace as-is.

This is a breaking parsing change that will leave some users with extra whitespace that was silently squished before.

Think we have some similar issues with our header folding.

Fixes #980.
