### PR TITLE
fix issue calling .to_s multiple times corrupts message body

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1815,11 +1815,15 @@ module Mail
     # all headers, attachments, etc.  This is an encoded email in US-ASCII,
     # so it is able to be directly sent to an email server.
     def encoded
-      ready_to_send!
-      buffer = header.encoded
-      buffer << "\r\n"
-      buffer << body.encoded(content_transfer_encoding)
-      buffer
+      if @buffer
+        @buffer
+      else
+        ready_to_send!
+        @buffer = header.encoded
+        @buffer << "\r\n"
+        @buffer << body.encoded(content_transfer_encoding)
+        @buffer
+      end
     end
 
     def without_attachments!


### PR DESCRIPTION
I have discovered a bug with calling message.to_s when the body of the message contains non-latin characters.

I first reported the error in [ankane/ahoy_email's issues](https://github.com/ankane/ahoy_email/issues/50) where I detailed the buggy behaviour.

I've created a work around but I'm not sure if it's the best approach. Anyway it works for me. Thanks for your time.