### PR TITLE
Pin mime-types to < 3.0 on Ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "tlsmail", "~> 0.0.1" if RUBY_VERSION <= "1.8.6"
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "mime-types", "< 3", :platforms => :ruby_19
 
 # For gems not required to run tests
 group :local_development, :test do


### PR DESCRIPTION
This closes #990. mime-types version requirement was loosened in #953,
and even properly excluded from 1.9.3 tests however the Gemfile wasn't
updated so bundle install fails on ruby 1.9.3.