### PR TITLE
Don't return the delivery_status_part on non report emails

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -8,6 +8,7 @@ Compatibility:
 
 Bugs:
 * #978 - Fix for invalid chars being left in a string for invalid b_value from encoding (kjg)
+* #996 - Fix issue where multipart/report helper methods returned values on multipart/mixed emails (kjg)
 * #998 - Fix header parameter parsing (such as attachment names) for values encoded with a blank charset or language code. (kjg)
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1563,6 +1563,7 @@ module Mail
 
     # returns the part in a multipart/report email that has the content-type delivery-status
     def delivery_status_part
+      return unless delivery_status_report?
       @delivery_stats_part ||= parts.select { |p| p.delivery_status_report_part? }.first
     end
 

--- a/spec/mail/multipart_report_spec.rb
+++ b/spec/mail/multipart_report_spec.rb
@@ -26,6 +26,17 @@ describe "multipart/report emails" do
       expect(mail).to be_bounced
     end
 
+    describe "delivery-status part in a non report email" do
+      let(:mail){
+        string = File.read(fixture('emails', 'multipart_report_emails', 'report_422.eml'))
+        Mail.read_from_string(string.sub("multipart/report; report-type=delivery-status;", "multipart/mixed;"))
+      }
+
+      it "does not return a delivery_status_part" do
+        expect(mail.delivery_status_part).to be_nil
+      end
+    end
+
     describe "multipart reports with more than one address" do
       it "should not crash" do
         mail1 = Mail.read(fixture('emails', 'multipart_report_emails', 'multi_address_bounce1.eml'))


### PR DESCRIPTION
Currently `Mail::Message#bounced?` will return `true` when someone happens to forward a bounce email resulting in the forwarded email properly being a multipart/mixed, but with a `message/delivery-status` part

Mail#bounced? should only be true if the top level message is a multipart/report. The same should hold true for all the multipart/report convenience methods.