### PR TITLE
Allow blank charset or lang param hash

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -2,6 +2,7 @@
 
 Bugs:
 * #978 - Fix for invalid chars being left in a string for invalid b_value from encoding (kjg)
+* #998 - Fix for parsing of encoded header parameters (such as attachment names) containing a blank locale (kjg)
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/lib/mail/fields/common/parameter_hash.rb
+++ b/lib/mail/fields/common/parameter_hash.rb
@@ -30,7 +30,7 @@ module Mail
         super(exact || key_name)
       else # Dealing with a multiple value pair or a single encoded value pair
         string = pairs.sort { |a,b| a.first.to_s <=> b.first.to_s }.map { |v| v.last }.join('')
-        if mt = string.match(/([\w\-]+)'(\w\w)'(.*)/)
+        if mt = string.match(/([\w\-]+)?'(\w\w)?'(.*)/)
           string = mt[3]
           encoding = mt[1]
         else

--- a/spec/mail/fields/common/parameter_hash_spec.rb
+++ b/spec/mail/fields/common/parameter_hash_spec.rb
@@ -51,6 +51,24 @@ describe Mail::ParameterHash do
     expect(hash['value']).to eq "This is even more ***fun*** isn't it"
   end
 
+  it "allows for blank language" do
+    hash = Mail::ParameterHash.new
+    hash.merge!({'value*' => "us-ascii''Hello%20there"})
+    expect(hash['value']).to eq "Hello there"
+  end
+
+  it "allows for blank charset" do
+    hash = Mail::ParameterHash.new
+    hash.merge!({'value*' => "'en'Hello%20there"})
+    expect(hash['value']).to eq "Hello there"
+  end
+
+  it "allows for blank charset and language" do
+    hash = Mail::ParameterHash.new
+    hash.merge!({'value*' => "''Hello%20there"})
+    expect(hash['value']).to eq "Hello there"
+  end
+
   it "should allow us to add a value" do
     hash = Mail::ParameterHash.new
     hash['value'] = 'bob'


### PR DESCRIPTION
Allow for blank charset or lang in param hash

as specified in [RFC 2231](https://tools.ietf.org/html/rfc2231#section-4)

"Note that it is perfectly permissible to leave either the character
   set or language field blank.  Note also that the single quote
   delimiters MUST be present even when one of the field values is
   omitted.  This is done when either character set, language, or both
   are not relevant to the parameter value at hand."