### PR TITLE
Allow the body.raw_source field to be mutated

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -35,7 +35,7 @@ module Mail
       @part_sort_order = [ "text/plain", "text/enriched", "text/html", "multipart/alternative" ]
       @parts = Mail::PartsList.new
       if Utilities.blank?(string)
-        @raw_source = ''
+        @raw_source = ''.dup
       else
         # Do join first incase we have been given an Array in Ruby 1.9
         if string.respond_to?(:join)

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -53,6 +53,11 @@ describe Mail::Body do
       expect(body.encoded).to eq "line one\r\nline two\r\n"
     end
 
+    it "should duplicate the empty raw_source string to allow it to be mutated" do
+      body = Mail::Body.new
+      expect(body.raw_source.frozen?).to eq false
+    end
+
   end
 
   describe "encoding" do


### PR DESCRIPTION
With frozen string literals the raw_source field on body can’t be mutated as it’s initialized with an empty frozen string.

This is needed for the Mailkick gem where it attempts to mutate the raw_source for all parts of the email to replace a unsubscribe string with a live token - https://github.com/ankane/mailkick/blob/master/lib/mailkick/processor.rb#L23