### PR TITLE
Use the unicode replacement character

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,7 @@ Features:
 * #853 - `Mail::Message#set_sort_order` overrides the default message part sort order. (rafbm)
 * #650 - UTF-7 charset support. (johngrimes)
 * #1065 - Require STARTTLS using :enable_starttls. (bk2204)
+* #1002 - Replace invalid encoded characters with the unicode replacement char instead of empty string. (kjg)
 
 Performance:
 * #1059 - Switch from mime-types to mini_mime for a much smaller memory footprint. (SamSaffron)

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -186,7 +186,7 @@ describe "mail encoding" do
     expect(mail.parts[0].content_type).to eq "text/html; charset=ISO-8859-1"
   end
 
-  it "should skip invalid characters" do
+  it "should handle invalid characters" do
     m = Mail.new
     m['Subject'] = Mail::SubjectField.new("=?utf-8?Q?Hello_=96_World?=")
     if RUBY_VERSION > '1.9'
@@ -196,10 +196,14 @@ describe "mail encoding" do
     end
   end
 
-  it "should skip characters of unknown and invalid encoding" do
+  it "should replace characters of unknown and invalid encoding" do
     m = Mail.new
     m['Subject'] = Mail::SubjectField.new("Hello=?UNKNOWN?B?4g==?=")
-    expect(m.subject).to eq "Hello"
+    if RUBY_VERSION > '1.9'
+      expect(m.subject).to eq "Hello�"
+    else
+      expect(m.subject).to eq "Hello"
+    end
   end
 
   if RUBY_VERSION > '1.9'

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -316,7 +316,7 @@ describe Mail::Encodings do
 
     it "should treat unrecognized charsets as binary" do
       if RUBY_VERSION >= "1.9"
-        expect(Mail::Encodings.value_decode("=?ISO-FOOO?Q?Morten_R=F8verdatt=E9r?=")).to eq "Morten Rverdattr"
+        expect(Mail::Encodings.value_decode("=?ISO-FOOO?Q?Morten_R=F8verdatt=E9r?=")).to eq "Morten R�verdatt�r"
       end
     end
   end


### PR DESCRIPTION
instead of an empty string so that it is clear that there was some sort of
encoding issue as opposed silently dropping data

(as discussed in #978)
