### PR TITLE
2-5-stable CI: modernize Travis build: cache, bump versions, drop superfluous args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,29 @@
 language: ruby
+sudo: false
+cache: bundler
+
+bundler_args: --without local_development
+
+script: bundle exec rake
+
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
   - ruby-head
-  - jruby-18mode
-  - jruby-19mode
+  - jruby
+  - jruby-9.0.5.0
   - jruby-head
-  - rbx-18mode
-  - rbx-19mode
+  - rbx-2
+
 matrix:
   allow_failures:
-    - rvm: ruby-head    # green, but unstable
-    - rvm: jruby-head   # green, but unstable
-    - rvm: rbx-18mode   # seems to be running 1.9 mode instead!?
-    - rvm: rbx-19mode   # segfaulting in String#ascii_only?
-before_install:
-  - gem update bundler
+    - rvm: ruby-head
+    - rvm: jruby-9.0.5.0
+    - rvm: jruby-head
+    - rvm: rbx-2
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,14 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem "rake", "< 11.0" if RUBY_VERSION < '1.9.3'
+
 gem "treetop", "~> 1.4.10"
 gem "mime-types", "~> 1.16"
 gem "tlsmail" if RUBY_VERSION <= '1.8.6'
 
 gem 'jruby-openssl', :platform => :jruby
 
-group :test do
-  gem "ruby-debug", :platform => :mri_18
+# For gems not required to run tests
+group :local_development, :test do
 end

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Built from my experience with TMail, it is designed to be a pure ruby
 implementation that makes generating, sending and parsing emails a no
 brainer.
 
-It is also designed form the ground up to work with Ruby 1.9.  This is because
-Ruby 1.9 handles text encodings much more magically than Ruby 1.8.x and so
-these features have been taken full advantage of in this library allowing
-Mail to handle a lot more messages more cleanly than TMail.  Mail does run on
-Ruby 1.8.x... it's just not as fun to code.
+It is also designed form the ground up to work with the more modern versions
+of Ruby.  This is because Ruby > 1.9 handles text encodings much more wonderfully
+than Ruby 1.8.x and so these features have been taken full advantage of in this
+library allowing Mail to handle a lot more messages more cleanly than TMail.
+Mail does run on Ruby 1.8.x... it's just not as fun to code.
 
 Finally, Mail has been designed with a very simple object oriented system
 that really opens up the email messages you are parsing, if you know what
@@ -44,14 +44,15 @@ Compatibility
 
 Every Mail commit is tested by Travis on the [following platforms](https://github.com/mikel/mail/blob/master/.travis.yml)
 
-* ruby-1.8.7-p370 [ i686 ]
-* ruby-1.9.2-p290 [ x86_64 ]
-* ruby-1.9.3-p327 [ x86_64 ]
-* ruby-2.0.0-rc1 [ x86_64 ]
-* jruby-1.6.8 [ x86_64 ]
-* jruby-1.7.0 [ x86_64 ]
-* rbx-d18 [ x86_64 ]
-* rbx-d19 [ x86_64 ]
+* ruby-1.8.7 [ i686 ]
+* ruby-1.9.2 [ x86_64 ]
+* ruby-1.9.3 [ x86_64 ]
+* ruby-2.0.0 [ x86_64 ]
+* ruby-2.1.2 [ x86_64 ]
+* ruby-head [ x86_64 ]
+* jruby [ x86_64 ]
+* jruby-head [ x86_64 ]
+* rbx-2 [ x86_64 ]
 
 Discussion
 ----------

--- a/test.rb
+++ b/test.rb
@@ -1,6 +1,5 @@
 require 'rubygems'
 require 'mail'
-require 'ruby-debug'
 
 smtp = { :address => 'mail.fiendz.org', :port => 587, :domain => 'fiendz.org', :user_name => 'test@fiendz.org', :password => 'foobar', :enable_starttls_auto => true, :openssl_verify_mode => 'none' }
 Mail.defaults { delivery_method :smtp, smtp }


### PR DESCRIPTION
* rake requires 1.9.3 starting with v11.0.0
* drop ruby-debug dev dep
* ignore rbx-2 segfaults
* allow jruby-9.0.5.0 failures, needs work