### PR TITLE
Do not suggest nonsensical OpenSSL verify modes

### DIFF
--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -45,9 +45,8 @@ module Mail
   # hostname or update the certificate authorities trusted by your ruby. If
   # that isn't possible, you can control this behavior with
   # an :openssl_verify_mode setting. Its value may be either an OpenSSL
-  # verify mode constant (OpenSSL::SSL::VERIFY_NONE), or a string containing
-  # the name of an OpenSSL verify mode (none, peer, client_once,
-  # fail_if_no_peer_cert).
+  # verify mode constant (OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER), or a string containing
+  # the name of an OpenSSL verify mode (none, peer).
   #
   # === Others 
   # 


### PR DESCRIPTION
`SSL_set_verify(3)` explains:

```
SSL_VERIFY_FAIL_IF_NO_PEER_CERT
  Server mode: if the client did not return a certificate, the TLS/SSL handshake is immediately terminated with a "handshake failure" alert.  This flag must
  be used together with SSL_VERIFY_PEER.

  Client mode: ignored

SSL_VERIFY_CLIENT_ONCE
  Server mode: only request a client certificate on the initial TLS/SSL handshake. Do not ask for a client certificate again in case of a renegotiation.
  This flag must be used together with SSL_VERIFY_PEER.

  Client mode: ignored
```

The SMTP connection here uses an OpenSSL socket in client mode, suggesting invalid flags is rather misleading.
