### PR TITLE
Address list parser should handle /\. +/ in local part of address (WIP)

### DIFF
--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -588,6 +588,32 @@ describe Mail::Address do
                                          :raw          => 'jdoe@test.example'})
       end
 
+      it "should handle |jlucas. booth@test.example|" do
+        address = Mail::Address.new('jlucas. booth@test.example')
+        expect(address).to break_down_to({
+                                         :name         => 'jlucas.booth@test.example',
+                                         :display_name => 'jlucas.booth@test.example',
+                                         :address      => 'jlucas.booth@test.example',
+                                         :comments     => nil,
+                                         :domain       => 'test.example',
+                                         :local        => 'jlucas.booth',
+                                         :format       => 'jlucas.booth@test.example',
+                                         :raw          => 'jlucas. booth@test.example'})
+      end
+
+      it "should handle |jlucas.  booth@test.example|" do
+        address = Mail::Address.new('jlucas. booth@test.example')
+        expect(address).to break_down_to({
+                                         :name         => 'jlucas.booth@test.example',
+                                         :display_name => 'jlucas.booth@test.example',
+                                         :address      => 'jlucas.booth@test.example',
+                                         :comments     => nil,
+                                         :domain       => 'test.example',
+                                         :local        => 'jlucas.booth',
+                                         :format       => 'jlucas.booth@test.example',
+                                         :raw          => 'jlucas.  booth@test.example'})
+      end
+
       it "should handle |groupname+domain.com@example.com|" do
         address = Mail::Address.new('groupname+domain.com@example.com')
         expect(address).to break_down_to({


### PR DESCRIPTION
I couldn't come up with a solution to this problem, but I've made a PR with failing tests to show what I've found.

It looks like the gem treats an address with 1+ spaces after a `.` in the local side of an address as valid but doesn't return the correct address. Some examples:

```
Mail::Address.new("jlucas. booth@gmail.com") # => One space after a period
=> #<Mail::Address:2236832580 Address: |@gmail.com| >
Mail::Address.new("jlucas.  booth@gmail.com") # => Two+ spaces after a period
=> #<Mail::Address:2236815680 Address: |jlucas.| >
```

I couldn't get `rake ragel:generate` to work in order to make changes and see if the new parser works, so can I get some guidance on fixing this?
