### PR TITLE
Allow reading body_encoding without passing nil

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1247,7 +1247,7 @@ module Mail
       end
     end
 
-    def body_encoding(value)
+    def body_encoding(value = nil)
       if value.nil?
         body.encoding
       else


### PR DESCRIPTION
I assume that a default value of `nil` was forgotten when this method was added, since I expect `message.body_encoding` to return the desired value similar to `message.body`.
