### PR TITLE
Fix quote-handling regression from Ragel upgrade

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -11,6 +11,8 @@ Bugs:
 * #996 - Fix that multipart/mixed emails with a delivery-status part could be interpreted as bounces. (kjg)
 * #998 - Fix header parameter parsing (such as attachment names) for values encoded with a blank charset or language code. (kjg)
 * #1003 - Fix decoding some b encoded headers on specific rubies that don't account for lack of base64 padding (kjg)
+* #929 - Fix double-quoting in display names (garethrees)
+* #1017 - Fix double-quoting in display names (garethrees)
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/lib/mail/parsers/address_lists_parser.rb
+++ b/lib/mail/parsers/address_lists_parser.rb
@@ -92,7 +92,7 @@ module Mail::Parsers
         # version.
         when :angle_addr_s
           if qstr
-            address.display_name = qstr
+            address.display_name = unescape(qstr)
             qstr = nil
           elsif phrase_e
             address.display_name = s[phrase_s..phrase_e].strip

--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -72,10 +72,23 @@ module Mail
     #  unqoute(string) #=> 'This is "a string"'
     def unquote( str )
       if str =~ /^"(.*?)"$/
-        $1.gsub(/\\(.)/, '\1')
+        unescape($1)
       else
         str
       end
+    end
+
+    # Removes any \-escaping.
+    #
+    # Example:
+    #
+    #  string = 'This is \"a string\"'
+    #  unescape(string) #=> 'This is "a string"'
+    #
+    #  string = '"This is \"a string\""'
+    #  unescape(string) #=> '"This is "a string""'
+    def unescape( str )
+      str.gsub(/\\(.)/, '\1')
     end
 
     # Wraps a string in parenthesis and escapes any that are in the string itself.

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -614,6 +614,45 @@ describe Mail::Address do
                                          :raw          => '=?UTF-8?B?8J+RjQ==?= <=?UTF-8?B?8J+RjQ==?=@=?UTF-8?B?8J+RjQ==?=.emoji>'})
       end
 
+      it 'should handle |"Mikel \"quotes\" Lindsaar" <test@lindsaar.net>|' do
+        address = Mail::Address.new('"Mikel \"quotes\" Lindsaar" <test@lindsaar.net>')
+        expect(address).to break_down_to({
+                                         :name         => 'Mikel "quotes" Lindsaar',
+                                         :display_name => 'Mikel "quotes" Lindsaar',
+                                         :address      => 'test@lindsaar.net',
+                                         :comments     => nil,
+                                         :domain       => 'lindsaar.net',
+                                         :local        => 'test',
+                                         :format       => '"Mikel \"quotes\" Lindsaar" <test@lindsaar.net>',
+                                         :raw          => '"Mikel \"quotes\" Lindsaar" <test@lindsaar.net>'})
+      end
+
+      it 'should handle |"Mikel \" Lindsaar" <test@lindsaar.net>|' do
+        address = Mail::Address.new('"Mikel \" Lindsaar" <test@lindsaar.net>')
+        expect(address).to break_down_to({
+                                         :name         => 'Mikel " Lindsaar',
+                                         :display_name => 'Mikel " Lindsaar',
+                                         :address      => 'test@lindsaar.net',
+                                         :comments     => nil,
+                                         :domain       => 'lindsaar.net',
+                                         :local        => 'test',
+                                         :format       => '"Mikel \" Lindsaar" <test@lindsaar.net>',
+                                         :raw          => '"Mikel \" Lindsaar" <test@lindsaar.net>'})
+      end
+
+      it 'should handle |"Mikel \"quotes\" (and comments) Lindsaar" (comment1)<test(comment2)@lindsaar.net(comment3)>|' do
+        address = Mail::Address.new('"Mikel \"quotes\" (and comments) Lindsaar" (comment1)<test(comment2)@lindsaar.net(comment3)>')
+        expect(address).to break_down_to({
+                                         :name         => 'Mikel "quotes" (and comments) Lindsaar',
+                                         :display_name => 'Mikel "quotes" (and comments) Lindsaar',
+                                         :address      => 'test(comment2)@lindsaar.net',
+                                         :comments     => ['comment1', 'comment2', 'comment3'],
+                                         :domain       => 'lindsaar.net',
+                                         :local        => 'test(comment2)',
+                                         :format       => '"Mikel \"quotes\" (and comments) Lindsaar" <test(comment2)@lindsaar.net> (comment1 comment2 comment3)',
+                                         :raw          => '"Mikel \"quotes\" (and comments) Lindsaar" (comment1)<test(comment2)@lindsaar.net(comment3)>'})
+      end
+
       it "should expose group" do
         struct = Mail::Parsers::AddressStruct.new(nil, nil, nil, nil, nil, nil, "GROUP", nil)
         address = Mail::Address.new(struct)

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -244,6 +244,23 @@ describe "Utilities Module" do
     end
   end
 
+  describe "unescaping phrases" do
+    it "should not modify a string with no backslashes" do
+      expect(unescape('This is a string')).to eq 'This is a string'
+    end
+
+    it "should not modify a quoted string with no backslashes" do
+      expect(unescape('"This is a string"')).to eq '"This is a string"'
+    end
+
+    it "should remove backslash escaping from a string" do
+      expect(unescape('This is \"a string\"')).to eq 'This is "a string"'
+    end
+
+    it "should remove backslash escaping from a quoted string" do
+      expect(unescape('"This is \"a string\""')).to eq '"This is "a string""'
+    end
+  end
 
   describe "parenthesizing phrases" do
     it "should parenthesize a phrase" do


### PR DESCRIPTION
Came across a regression in how quotes are handled in display names
after upgrading mysociety/alaveteli from Mail 2.5.4 to 2.6.x, similar to
issues #929 and #1017.

This commit fixes #929 and #1017.

I've included a spec similar to that demonstrated in #1017 and one that
mirrors the spec that highlighted the regression in mysociety/alaveteli.

Also included a spec to cover a quoted display name containing
backslash-escaped double quotes and parenthesis, with comments inside and
outside the address section.

I haven't included a spec for the failure example in #929, because I think that
`Mail::FromField` should expect the `Mail::Address` to be correct. The
spec for #1017 also covers the example in #929.

It would be great to see this released in the `2.6.x` series. The commit cherry-picks cleanly to the `2-6-stable` branch.

---
## Finding the regression

I used git bisect to figure out which commit introduced the bug. I'd just upgraded from `2.5.4` to `2.6.4`, so I knew it was somewhere between there.

``` sh
git bisect start
#2.6.4
git bisect good 0227973b83f488ca9ab87461d83d7eb7cf665c88
#2.5.4
git bisect bad 86101c6843a47c1c5444ffdc533ac8677e1f7045

bundle --quiet
git bisect run bundle exec ~/mail_bisect
```

Here's the test I was running…

``` sh
#!/bin/bash
bundle > /dev/null 2>&1

# A bit hacky, but does the job
/home/vagrant/.rbenv/shims/ruby <<-EOF
require '/code/mail/lib/mail'

str = '"Mikel \" Lindsaar" <test@lindsaar.net>'
address = Mail::Address.new('"Mikel \" Lindsaar" <test@lindsaar.net>')

if address.format == str
  exit 0
else
  exit 1
end
EOF
```

…and here's the bisect output, pointing at 2da7c7985c221272f6451b27ab8b41e84e0a6804 as being the offending commit:

```
running bundle exec /home/vagrant/mail_bisect
Bisecting: 75 revisions left to test after this (roughly 6 steps)
[133ac26fefbd215f77496628af4896f886f424c8] Merge pull request #636 from jzinn/patch-1
running bundle exec /home/vagrant/mail_bisect
Bisecting: 36 revisions left to test after this (roughly 5 steps)
[bdb11d20bd4cba062b8cca4914ffea355da1d3cd] Merge pull request #576 from srawlins/add-rdoc-exclude-to-gemspec
running bundle exec /home/vagrant/mail_bisect
Bisecting: 18 revisions left to test after this (roughly 4 steps)
[dd89a6fa8b8af1f51d012434e54ba06cf2ae3255] Updating CHANGELOG
running bundle exec /home/vagrant/mail_bisect
Bisecting: 9 revisions left to test after this (roughly 3 steps)
[aaaac219deab053e64fdfe6c03f70a4ef016fc2f] Merge branch 'pure_ruby_ragel_parser' of git://github.com/bpot/mail into bpot-pure_ruby_ragel_parser
running bundle exec /home/vagrant/mail_bisect
Bisecting: 4 revisions left to test after this (roughly 2 steps)
[ab2af8c99c39055e7a26bfd7a72cbb42e34ee38c] common.rl: use clearer .* in dot_atom_text, instead of (.+)?
running bundle exec /home/vagrant/mail_bisect
Bisecting: 1 revision left to test after this (roughly 1 step)
[c6b656c230692ce048b27dd0af84f883a545d375] AddressListsParser: Don't add an extra address to the address list when it ends with a space.
running bundle exec /home/vagrant/mail_bisect
Bisecting: 0 revisions left to test after this (roughly 0 steps)
[2da7c7985c221272f6451b27ab8b41e84e0a6804] Replace Treetop parser with a Ragel based parser
running bundle exec /home/vagrant/mail_bisect
2da7c7985c221272f6451b27ab8b41e84e0a6804 is the first bad commit
commit 2da7c7985c221272f6451b27ab8b41e84e0a6804
Author: Bob Potter <bobby.potter@gmail.com>
Date:   Mon Jan 7 18:40:55 2013 -0600

    Replace Treetop parser with a Ragel based parser

:100644 100644 5c66e374a85607536878ed053b449b8881215cf1 87515b677a58c7568be0488739d7ead84abdf489 M      Gemfile
:040000 040000 adcb1908e068b4757f7dde88dd76d4af2ec2f60b 4959b72cdb14f94f77dea737aa05a8a4fa0bb7db M      lib
:100644 100644 07c8ff9d332960312f810ebc2fc13adc39793dac a0c6568783567129e3984560382c68d96c8bfbbe M      mail.gemspec
:040000 040000 4ab53c797d99999375c0e8d5f7cd0e04b6805596 5a2f224407a2ebe41ceba37ab73f0258293e5d91 M      reference
:040000 040000 ea53d75476823259ad0581e3eb307d289ffc1c69 5c8e71c8f98c37425b273f8355afe41eaa0bcf8a M      spec
bisect run success
```

I've attached two patches that apply passing specs for the examples provided in #929 and #1017.

[mail-929.patch.txt](https://github.com/mikel/mail/files/437019/mail-929.patch.txt)
[mail-1017-spec.patch.txt](https://github.com/mikel/mail/files/437020/mail-1017-spec.patch.txt)
