### PR TITLE
Name from Content-Type is deprecated, use Content-Disposition

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2136,10 +2136,10 @@ module Mail
       content_disp_name = header[:content_disposition].filename rescue nil
       content_loc_name  = header[:content_location].location rescue nil
       case
-      when content_type && content_type_name
-        filename = content_type_name
       when content_disposition && content_disp_name
         filename = content_disp_name
+      when content_type && content_type_name
+        filename = content_type_name
       when content_location && content_loc_name
         filename = content_loc_name
       else

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -237,7 +237,7 @@ describe "reading emails with attachments" do
 
     it "should use the content-type filename or name over the content-disposition filename" do
       mail = Mail.read(fixture(File.join('emails', 'attachment_emails', 'attachment_content_disposition.eml')))
-      expect(mail.attachments[0].filename).to eq 'hello.rb'
+      expect(mail.attachments[0].filename).to eq 'api.rb'
     end
 
     it "should decode an attachment" do

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -378,13 +378,13 @@ describe "MIME Emails" do
       it "should return an array of attachments" do
         mail = Mail.read(fixture('emails', 'attachment_emails', 'attachment_content_disposition.eml'))
         expect(mail.attachments.length).to eq 1
-        expect(mail.attachments.first.filename).to eq 'hello.rb'
+        expect(mail.attachments.first.filename).to eq 'api.rb'
       end
 
       it "should return an array of attachments" do
         mail = Mail.read(fixture('emails', 'mime_emails', 'raw_email_with_nested_attachment.eml'))
         expect(mail.attachments.length).to eq 2
-        expect(mail.attachments[0].filename).to eq 'byo-ror-cover.png'
+        expect(mail.attachments[0].filename).to eq 'truncated.png'
         expect(mail.attachments[1].filename).to eq 'smime.p7s'
       end
 


### PR DESCRIPTION
It _appears_ that content-disposition is expected to override content-type when choosing an attachment name. The preference for content-type is causing strange behavior in cases where the email headers look something like this:

```
Content-Type: application/octet-stream; name="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
Content-Transfer-Encoding: 7bit
Content-ID: <073e5161-ac8d-487b-b7c7-e17df7ba3e3d>
Content-Disposition: attachment;
	filename="=?utf-8?B?T3JwaGFuIEV2ZW50IFRpY2tldCBEZXRhaWwgU3RhZ2luZyBSZWNvcmRzLnhsc3g=?="
```

In that case the attachment filename is `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` instead of `Orphan Event Ticket Detail Staging Records.xlsx`

----------
Looking at the RFCs it looks like the expected behavior is for content-disposition to be the preferred name. 

From https://tools.ietf.org/html/rfc2046 (section 4.5.1.):
```
   RFC 1341 also defined the use of a "NAME"
   parameter which gave a suggested file name to be used if the data
   were to be written to a file.  This has been deprecated in
   anticipation of a separate Content-Disposition header field, to be
   defined in a subsequent RFC.
```

----

The current behavior is [intentional and expected](https://github.com/mikel/mail/commit/496c1d140758a0feebc4a7f92f720e3d46c49ac8#diff-4febf0a161ac56649ad0850c5c53306aR116), but I wasn't able to find any comments on the rationale for that decision. @mikel are you able to recall?

There is already a test for this that I've updated to match the new behavior, do we need an additional test as well?

/cc @grosser 