### PR TITLE
Re-raise errors in the Message object, fixup message_id inspection

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -11,6 +11,7 @@ Bugs:
 * #996 - Fix that multipart/mixed emails with a delivery-status part could be interpreted as bounces. (kjg)
 * #998 - Fix header parameter parsing (such as attachment names) for values encoded with a blank charset or language code. (kjg)
 * #1003 - Fix decoding some b encoded headers on specific rubies that don't account for lack of base64 padding (kjg)
+* #1031 - Fix silent failures when parsing fields in the Message object
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -356,11 +356,11 @@ module Mail
     #  m1 == m2 #=> false
     def ==(other)
       return false unless other.respond_to?(:encoded)
-
       if self.message_id && other.message_id
         self.encoded == other.encoded
       else
-        self_message_id, other_message_id = self.message_id, other.message_id
+        self_message_id = header[:message_id] ? header[:message_id].value : nil
+        other_message_id = other.header[:message_id] ? other.header[:message_id].value : nil
         begin
           self.message_id, other.message_id = '<temp@test>', '<temp@test>'
           self.encoded == other.encoded
@@ -1194,7 +1194,7 @@ module Mail
       if val
         header[sym] = val
       else
-        header[sym].default if header[sym]
+        check_errors_and_return_default(header[sym])
       end
     end
 
@@ -2161,6 +2161,15 @@ module Mail
 
     def decode_body_as_text
       Encodings.transcode_charset decode_body, charset, 'UTF-8'
+    end
+
+    def check_errors_and_return_default(result_value)
+      return unless result_value
+      if !Utilities.blank?(result_value.errors)
+        error = result_value.errors.first[-1]
+        raise error
+      end
+      result_value.default
     end
   end
 end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -30,6 +30,11 @@ describe Mail::Message do
       expect(Mail::Message.new(basic_email).class).to eq Mail::Message
     end
 
+    it "should instantiate with a string and fail loudly on bad fields" do
+      bad_email = "To: user1@example.org, user2@example.org."
+      expect { Mail::Message.new(bad_email).to }.to raise_error(Mail::Field::ParseError)
+    end
+
     it "should allow us to pass it a block" do
       mail = Mail::Message.new do
         from 'mikel@me.com'
@@ -1987,7 +1992,7 @@ describe Mail::Message do
       before do
         @mail = Mail.new do
           in_reply_to '<1234@test.lindsaar.net>'
-          message_id '5678@test.lindsaar.net'
+          message_id '<5678@test.lindsaar.net>'
         end
       end
 


### PR DESCRIPTION
Fixes https://github.com/mikel/mail/issues/1031

Pulling a bad attribute from a message now re-raises the exception.

``` ruby
Mail::Message.new(bad_email).to
```

This surfaced a bug with message_ids. In https://github.com/bobjflong/mail/blob/ba70362b27a4bcbd020bb632b4e1e2461f29cbcd/lib/mail/message.rb#L368 the original message ids are reset after a comparison. However this reset was using the parsed form instead of the actual header value. This surfaced in specs such as https://github.com/bobjflong/mail/blob/ba70362b27a4bcbd020bb632b4e1e2461f29cbcd/spec/mail/message_spec.rb#L1580.

eg. before comparison:

| Headers |  |
| --- | --- |
| message_id | `<foo@bar.com>` |

after comparison:

| Headers |  |
| --- | --- |
| message_id | `foo@bar.com` |

``` ruby
> m1 = Mail.new("To: mikel@test.lindsaar.net\r\nSubject: Yo!\r\n\r\nHello there")
> m2 = Mail.new("To: mikel@test.lindsaar.net\r\nMessage-ID: <1234@test.lindsaar.net>\r\nSubject: Yo!\r\n\r\nHello there")

> message_id = m2.header[:message_id].value
"<1234@test.lindsaar.net>"
> m1 == m2
true
> message_id == m2.header[:message_id].value
false
```
