### PR TITLE
Allowed Mail::Address.new to accept non US ASCII strings

### DIFF
--- a/lib/mail/parsers/address_lists_parser.rb
+++ b/lib/mail/parsers/address_lists_parser.rb
@@ -14051,6 +14051,7 @@ self.en_main = 1334;
     def self.parse(data)
       address_list = AddressListStruct.new([], [])
       return address_list if Mail::Utilities.blank?(data)
+      data = Mail::Encodings.encode_non_usascii(data, 'utf-8')
 
       phrase_s = phrase_e = qstr_s = qstr = comment_s = nil
       group_name_s = domain_s = group_name = nil

--- a/spec/mail/parsers/address_lists_parser_spec.rb
+++ b/spec/mail/parsers/address_lists_parser_spec.rb
@@ -9,6 +9,12 @@ describe "AddressListsParser" do
     expect(a.parse(text)).not_to be_nil
   end
 
+  it "should parse an address list that contains non US ASCII text" do
+    text  = 'test.muñiz@lindsaar.net'
+    a = Mail::Parsers::AddressListsParser
+    expect { a.parse(text) }.not_to raise_error
+  end
+
   it "should parse an address list separated by semicolons" do
     text = 'Mikel Lindsaar <test@lindsaar.net>; Friends: test2@lindsaar.net; Ada <test3@lindsaar.net>;'
     a = Mail::Parsers::AddressListsParser


### PR DESCRIPTION
Currently, if you instantiate an address list with a non US ASCII character you get a parse error. This PR fixes that problem by calling `Mail::Encodings.encode_non_usascii` _before_ Ragel tries to parse the address.
