### PR TITLE
Ensure registered mime types are given preference for attachments

### DIFF
--- a/lib/mail/attachments_list.rb
+++ b/lib/mail/attachments_list.rb
@@ -98,8 +98,8 @@ module Mail
       if RUBY_VERSION >= '1.9'
         filename = filename.encode(Encoding::UTF_8) if filename.respond_to?(:encode)
       end
-
-      @mime_type = MIME::Types.type_for(filename).first
+      mime_types = MIME::Types.type_for(filename)
+      @mime_type = mime_types.select(&:registered?).first || mime_types.first
     end
 
   end

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -36,7 +36,7 @@ describe "Attachments" do
     end
 
     it "should use the best mime type for an extension" do
-      @mail.attachments['test.csv'] = @test_png
+      @mail.attachments['test.csv'] = @test_csv
       expect(@mail.attachments[0].mime_type).to eq 'text/csv'
     end
 

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -20,6 +20,7 @@ describe "Attachments" do
   before(:each) do
     @mail = Mail.new
     @test_png = File.open(fixture('attachments', 'test.png'), 'rb', &:read)
+    @test_csv = File.open(fixture('attachments', 'test.csv'), 'rb', &:read)
   end
 
   describe "from direct content" do
@@ -32,6 +33,11 @@ describe "Attachments" do
     it "should work out magically the mime_type" do
       @mail.attachments['test.png'] = @test_png
       expect(@mail.attachments[0].mime_type).to eq 'image/png'
+    end
+
+    it "should use the best mime type for an extension" do
+      @mail.attachments['test.csv'] = @test_png
+      expect(@mail.attachments[0].mime_type).to eq 'text/csv'
     end
 
     it "should assign the filename" do


### PR DESCRIPTION
the `mime-types` gem when used with `MIME::Types.type_for(filename)` returns an array of potential matching mime types. In the case of multiple matches for an extension when the `simplified` form of the matches do not match, the [ordering](https://github.com/mime-types/ruby-mime-types/blob/master/lib/mime/type.rb#L152) is simply lexical which can result in incorrect selections when using `.first` for example:

```
Development [3] honestbees(main)> MIME::Types.type_for('blah.csv').first.content_type
"text/comma-separated-values"
Development [4] honestbees(main)> MIME::Types.type_for('blah.csv').map {|mime| mime.registered?}
[
    [0] false,
    [1] true
]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mikel/mail/1046)
<!-- Reviewable:end -->
