### PR TITLE
Fix documentation on Address.comments methods [skip ci]

### DIFF
--- a/lib/mail/elements/address.rb
+++ b/lib/mail/elements/address.rb
@@ -117,11 +117,15 @@ module Mail
       Encodings.decode_encode(strip_all_comments(get_domain), @output_type) if get_domain
     end
 
-    # Returns an array of comments that are in the email, or an empty array if there
+    # Returns an array of comments that are in the email, or nil if there
     # are no comments
     #
     #  a = Address.new('Mikel Lindsaar (My email address) <mikel@test.lindsaar.net>')
     #  a.comments #=> ['My email address']
+    #
+    #  b = Address.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
+    #  b.comments #=> nil
+
     def comments
       parse unless @parsed
       get_comments.map { |c| c.squeeze(SPACE) } unless get_comments.empty?


### PR DESCRIPTION
Currently the documentation on the method `comments` says it will return an empty array
if there is not comments on `Mail::Address`. This is not accurate on current implementation
and confirmed also on current test ( mail/spec/mail/elements/address_spec.rb#213 - "email addresses from the wild") where we expect `nil` if the address has no comments