### PR TITLE
Fix deprecated warnings in Ruby 2.4.0+

### DIFF
--- a/lib/mail/attachments_list.rb
+++ b/lib/mail/attachments_list.rb
@@ -30,7 +30,7 @@ module Mail
     # mail.attachments['test.png'].filename #=> 'test.png'
     # mail.attachments[1].filename          #=> 'test.jpg'
     def [](index_value)
-      if index_value.is_a?(Fixnum)
+      if index_value.is_a?(Integer)
         self.fetch(index_value)
       else
         self.select { |a| a.filename == index_value }.first

--- a/lib/mail/multibyte/chars.rb
+++ b/lib/mail/multibyte/chars.rb
@@ -269,12 +269,12 @@ module Mail #:nodoc:
           @wrapped_string[*args] = replace_by
         else
           result = Unicode.u_unpack(@wrapped_string)
-          if args[0].is_a?(Fixnum)
+          if args[0].is_a?(Integer)
             raise IndexError, "index #{args[0]} out of string" if args[0] >= result.length
             min = args[0]
             max = args[1].nil? ? min : (min + args[1] - 1)
             range = Range.new(min, max)
-            replace_by = [replace_by].pack('U') if replace_by.is_a?(Fixnum)
+            replace_by = [replace_by].pack('U') if replace_by.is_a?(Integer)
           elsif args.first.is_a?(Range)
             raise RangeError, "#{args[0]} out of range" if args[0].min >= result.length
             range = args[0]

--- a/lib/mail/network/retriever_methods/test_retriever.rb
+++ b/lib/mail/network/retriever_methods/test_retriever.rb
@@ -25,7 +25,7 @@ module Mail
       emails_index.reverse! if options[:what] == :last
       emails_index = case count = options[:count]
         when :all then emails_index
-        when Fixnum then emails_index[0, count]
+        when Integer then emails_index[0, count]
         else
           raise 'Invalid count option value: ' + count.inspect
       end


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-preview3.

`warning: constant ::Fixnum is deprecated`

Thanks.