### PR TITLE
CI: freshen test version on each Ruby release line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - ruby-head
   - jruby
   - jruby-9.0.5.0
+  - jruby-9.1.6.0
   - jruby-head
   - rbx-2
 
@@ -75,6 +76,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
     - rvm: jruby-head
     - rvm: rbx-2
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,14 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
-gem "tlsmail", "~> 0.0.1" if RUBY_VERSION <= "1.8.6"
-gem "jruby-openssl", :platforms => :jruby
-gem "rake", "< 11.0", :platforms => :ruby_18
-gem "mime-types", "< 3", :platforms => :ruby_19
+gem 'tlsmail', '~> 0.0.1' if RUBY_VERSION <= '1.8.6'
+gem 'jruby-openssl', :platforms => :jruby
+gem 'rake', '< 11.0', :platforms => :ruby_18
+gem 'rdoc', '< 4.3', :platforms => [ :ruby_18, :ruby_19 ]
+gem 'mime-types', '< 2.0', :platforms => [ :ruby_18, :ruby_19 ]
 
 # For gems not required to run tests
 group :local_development, :test do
-  gem "appraisal", "~> 1.0" unless RUBY_VERSION <= "1.8.7"
+  gem 'appraisal', '~> 1.0' unless RUBY_VERSION < '1.9'
 end

--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ Every Mail commit is tested by Travis on the [following platforms](https://githu
 * ruby-1.9.2 [ x86_64 ]
 * ruby-1.9.3 [ x86_64 ]
 * ruby-2.0.0 [ x86_64 ]
-* ruby-2.1.2 [ x86_64 ]
+* ruby-2.1.10 [ x86_64 ]
+* ruby-2.2.6 [ x86_64 ]
+* ruby-2.3.3 [ x86_64 ]
 * ruby-head [ x86_64 ]
 * jruby [ x86_64 ]
+* jruby-9.1.6.0 [ x86_64 ]
 * jruby-head [ x86_64 ]
 * rbx-2 [ x86_64 ]
 

--- a/gemfiles/mime_types_1.16.gemfile
+++ b/gemfiles/mime_types_1.16.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 1.16"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.0.gemfile
+++ b/gemfiles/mime_types_2.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.0.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.1.gemfile
+++ b/gemfiles/mime_types_2.1.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.1.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.2.gemfile
+++ b/gemfiles/mime_types_2.2.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.2.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.3.gemfile
+++ b/gemfiles/mime_types_2.3.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.3.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.4.gemfile
+++ b/gemfiles/mime_types_2.4.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.4.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.5.gemfile
+++ b/gemfiles/mime_types_2.5.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.5.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.6.gemfile
+++ b/gemfiles/mime_types_2.6.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.6.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.6_columnar.gemfile
+++ b/gemfiles/mime_types_2.6_columnar.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.6.0", :require => "mime/types/columnar"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_2.99.gemfile
+++ b/gemfiles/mime_types_2.99.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 2.99.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_3.0.gemfile
+++ b/gemfiles/mime_types_3.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", "~> 3.0.0"
 
 group :local_development, :test do

--- a/gemfiles/mime_types_edge.gemfile
+++ b/gemfiles/mime_types_edge.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "jruby-openssl", :platforms => :jruby
 gem "rake", "< 11.0", :platforms => :ruby_18
+gem "rdoc", "< 4.3", :platforms => [:ruby_18, :ruby_19]
 gem "mime-types", :github => "mime-types/ruby-mime-types"
 
 group :local_development, :test do


### PR DESCRIPTION
* Stick to rdoc < 4.3 on Ruby 1.8 since 4.3.0 goes 1.9.3+ only
* Bump Ruby versions for Travis