### PR TITLE
fix new warning in ruby 2.4

### DIFF
--- a/lib/mail/fields/common/address_container.rb
+++ b/lib/mail/fields/common/address_container.rb
@@ -8,7 +8,7 @@ module Mail
       super(list)
     end
 
-    def << (address)
+    def <<(address)
       @field << address
     end
 


### PR DESCRIPTION
This fixes the following warning.

```
/home/travis/build/mikel/mail/lib/mail/fields/common/address_container.rb:11: warning: parentheses after method name is interpreted as
/home/travis/build/mikel/mail/lib/mail/fields/common/address_container.rb:11: warning: an argument list, not a decomposed argument
```

Ref: https://github.com/ruby/ruby/commit/65e27c8b138d6959608658ffce2fa761842b8d24