### PR TITLE
fix invalid encoding

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -97,7 +97,8 @@ module Mail
       decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
       warn "Encoding conversion failed #{$!}"
-      str.dup.force_encoding(Encoding::UTF_8)
+      decoded = str.dup.force_encoding(Encoding::UTF_8)
+      decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
     end
 
     def Ruby19.q_value_encode(str, encoding = nil)
@@ -122,7 +123,8 @@ module Mail
       decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
       warn "Encoding conversion failed #{$!}"
-      str.dup.force_encoding(Encoding::UTF_8)
+      decoded = str.dup.force_encoding(Encoding::UTF_8)
+      decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
     end
 
     def Ruby19.param_decode(str, encoding)

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -104,6 +104,14 @@ describe Mail::UnstructuredField do
       expect(@field.decoded).to eq string
     end
 
+    if '1.9'.respond_to?(:valid_encoding?)
+      it "should decode a windows-1258(Q) encoded string" do
+        string = "=?windows-1258?Q?Ceni=ECk_20161201=2Exlsx?="
+        @field = Mail::SubjectField.new(string)
+        expect(@field.decoded.valid_encoding?).to eq true
+      end
+    end
+
     if !'1.9'.respond_to?(:force_encoding)
       it "shouldn't get fooled into encoding on 1.8 due to an unrelated Encoding constant" do
         begin


### PR DESCRIPTION
error: ArgumentError (invalid byte sequence in UTF-8)

'test'.force_encoding('windows-1258').encode('UTF-8') -> Encoding conversion failed code converter not found (Windows-1258 to UTF-8)

similar issue for utf-7: https://github.com/mikel/mail/pull/650
some character may be lost this way, but I think it's better than a decoded output with invalid encoding. Another way is to map windows-1258 to windows-1252? What do you think?