### PR TITLE
Decode UTF-7 field values.

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -2,6 +2,7 @@
 
 Features:
 * #853 - `Mail::Message#set_sort_order` overrides the default message part sort order. (rafbm)
+* #650 - UTF-7 charset support. (johngrimes)
 
 Performance:
 * #1059 - Switch from mime-types to mini_mime for a much smaller memory footprint. (SamSaffron)

--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -277,6 +277,5 @@ module Mail
         value.respond_to?(:empty?) ? value.empty? : !value
       end
     end
-
   end
 end

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -104,6 +104,12 @@ describe Mail::UnstructuredField do
       expect(@field.decoded).to eq string
     end
 
+    it "should decode a utf-7(B) encoded unstructured field" do
+      string = "=?UTF-7?B?JkFPUS0mLSZBT1EtJi0mQU9RLQ==?="
+      @field = Mail::UnstructuredField.new("References", string)
+      @field.decoded.should eq 'ä&ä&ä'
+    end
+
     if !'1.9'.respond_to?(:force_encoding)
       it "shouldn't get fooled into encoding on 1.8 due to an unrelated Encoding constant" do
         begin


### PR DESCRIPTION
Implementation from Ruby stdlib Net::IMAP.

Closes #650.