### PR TITLE
Implement enforcing STARTTLS mode.

### DIFF
--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -83,6 +83,7 @@ module Mail
                         :user_name            => nil,
                         :password             => nil,
                         :authentication       => nil,
+                        :enable_starttls      => nil,
                         :enable_starttls_auto => true,
                         :openssl_verify_mode  => nil,
                         :ssl                  => nil,
@@ -101,6 +102,10 @@ module Mail
       if settings[:tls] || settings[:ssl]
         if smtp.respond_to?(:enable_tls)
           smtp.enable_tls(ssl_context)
+        end
+      elsif settings[:enable_starttls]
+        if smtp.respond_to?(:enable_starttls)
+          smtp.enable_starttls(ssl_context)
         end
       elsif settings[:enable_starttls_auto]
         if smtp.respond_to?(:enable_starttls_auto)

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -153,7 +153,7 @@ describe Mail::Message do
         @smtp_settings = { :address=>"smtp.somewhere.net",
           :port=>"587", :domain=>"somewhere.net", :user_name=>"someone@somewhere.net",
           :password=>"password", :authentication=>:plain, :enable_starttls_auto => true,
-          :openssl_verify_mode => nil, :ssl=>nil, :tls=>nil }
+          :enable_starttls => nil, :openssl_verify_mode => nil, :ssl=>nil, :tls=>nil }
         @yaml_mail.delivery_method :smtp, @smtp_settings
       end
 

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -45,6 +45,7 @@ describe "Mail" do
                                                 :password             => nil,
                                                 :authentication       => nil,
                                                 :enable_starttls_auto => true,
+                                                :enable_starttls      => nil,
                                                 :openssl_verify_mode  => nil,
                                                 :ssl                  => nil,
                                                 :tls                  => nil })
@@ -219,6 +220,27 @@ describe "Mail" do
       message.deliver!
 
       expect(MockSMTP.security).to eq :enable_starttls_auto
+    end
+
+    it 'should allow forcing STARTTLS' do
+      message = Mail.new do
+        from 'mikel@test.lindsaar.net'
+        to 'ada@test.lindsaar.net'
+        subject 'Re: No way!'
+        body 'Yeah sure'
+        delivery_method :smtp, { :address         => "localhost",
+                                 :port            => 25,
+                                 :domain          => 'localhost.localdomain',
+                                 :user_name       => nil,
+                                 :password        => nil,
+                                 :authentication  => nil,
+                                 :enable_starttls => true  }
+
+      end
+
+      message.deliver!
+
+      expect(MockSMTP.security).to eq :enable_starttls
     end
   end
 

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -208,6 +208,18 @@ describe "Mail" do
       expect(MockSMTP.deliveries[0][2]).to eq ["ada@test.lindsaar.net"]
     end
 
+    it 'should default to automatically detecting STARTTLS' do
+      message = Mail.new do
+        from 'mikel@test.lindsaar.net'
+        to 'ada@test.lindsaar.net'
+        subject 'Re: No way!'
+        body 'Yeah sure'
+      end
+
+      message.deliver!
+
+      expect(MockSMTP.security).to eq :enable_starttls_auto
+    end
   end
 
   describe "deliveries" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,6 +117,17 @@ class MockSMTP
     end
   end
 
+  def enable_starttls(context = nil)
+    if context && context.kind_of?(OpenSSL::SSL::SSLContext)
+      @@security = :enable_starttls
+      true
+    elsif context
+      raise TypeError,
+        "wrong argument (#{context.class})! "+
+        "(Expected kind of OpenSSL::SSL::SSLContext)"
+    end
+  end
+
   def enable_starttls_auto(context = :dummy_ssl_context)
     @@security = :enable_starttls_auto
     true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,10 @@ class MockSMTP
     @@deliveries
   end
 
+  def self.security
+    @@security
+  end
+
   def initialize
     @@deliveries = []
   end
@@ -95,11 +99,16 @@ class MockSMTP
     @@deliveries = []
   end
 
+  def self.clear_security
+    @@security = nil
+  end
+
   # in the standard lib: net/smtp.rb line 577
   #   a TypeError is thrown unless this arg is a
   #   kind of OpenSSL::SSL::SSLContext
   def enable_tls(context = nil)
     if context && context.kind_of?(OpenSSL::SSL::SSLContext)
+      @@security = :enable_tls
       true
     elsif context
       raise TypeError,
@@ -109,6 +118,7 @@ class MockSMTP
   end
 
   def enable_starttls_auto(context = :dummy_ssl_context)
+    @@security = :enable_starttls_auto
     true
   end
 


### PR DESCRIPTION
Add an option to always require STARTTLS over SMTP.  This prevents
sending of mail over an unencrypted connection if a third party has
obscured the STARTTLS header (as some firewalls do).

Fixes #521 and fixes #694.