### PR TITLE
Port RSpec should usage to expect.

### DIFF
--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -107,7 +107,7 @@ describe Mail::UnstructuredField do
     it "should decode a utf-7(B) encoded unstructured field" do
       string = "=?UTF-7?B?JkFPUS0mLSZBT1EtJi0mQU9RLQ==?="
       @field = Mail::UnstructuredField.new("References", string)
-      @field.decoded.should eq 'ä&ä&ä'
+      expect(@field.decoded).to eq 'ä&ä&ä'
     end
 
     if !'1.9'.respond_to?(:force_encoding)

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -52,7 +52,7 @@ describe "PartsList" do
     p << attachment_part
     p << html_text_part
     p << plain_text_part
-    p.sort!(order).should eq [plain_text_part, html_text_part, attachment_part]
+    expect(p.sort!(order)).to eq [plain_text_part, html_text_part, attachment_part]
   end
 
   it "should have a parts reader" do


### PR DESCRIPTION
A few specs were still using the older RSpec should syntax, which caused deprecation warnings.  Port these specs to use the expect syntax instead.