### PR TITLE
Fix encoding multiple addresses when noninitial address contains non-usascii chars

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -178,9 +178,8 @@ module Mail
 
     def Encodings.encode_non_usascii(address, charset)
       return address if address.ascii_only? or charset.nil?
-      us_ascii = %Q{\x00-\x7f}
-      # Encode any non usascii strings embedded inside of quotes
-      address = address.gsub(/(".*?[^#{us_ascii}].*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
+      # Encode all strings embedded inside of quotes
+      address = address.gsub(/(".*?")/) { |s| Encodings.b_value_encode(unquote(s), charset) }
       # Then loop through all remaining items and encode as needed
       tokens = address.split(/\s/)
       map_with_index(tokens) do |word, i|

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -767,9 +767,21 @@ describe Mail::Encodings do
       expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 
+    it "should encode multiple addresses correctly when noninitial address contains non-usascii chars" do
+      raw     = '"Mikel Lindr" <mikel@test.lindsaar.net>, "あdあ" <ada@test.lindsaar.net>'
+      encoded = 'Mikel Lindr <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
+    end
+
     it "should encode multiple unquoted addresses correctly" do
       raw     = 'Mikel Lindsああr <mikel@test.lindsaar.net>, あdあ <ada@test.lindsaar.net>'
       encoded = 'Mikel =?UTF-8?B?TGluZHPjgYLjgYJy?= <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
+      expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
+    end
+
+    it "should encode multiple unquoted addresses correctly when noninitial address contains non-usascii chars" do
+      raw     = 'Mikel Lindsar <mikel@test.lindsaar.net>, あdあ <ada@test.lindsaar.net>'
+      encoded = 'Mikel Lindsar <mikel@test.lindsaar.net>, =?UTF-8?B?44GCZOOBgg==?= <ada@test.lindsaar.net>'
       expect(Mail::Encodings.encode_non_usascii(raw, 'utf-8')).to eq encoded
     end
 


### PR DESCRIPTION
Previous logic of `Encodings.encode_non_usascii` method used the incorrect regular expression `/(".*?[^\x00-\x7F].*?")/` to find all strings containing non-usascii chars. It matched everything which was before the non-usascii char, even it was a separate address (!).
This resulted in encoding the whole matched group and losing this address (and as consequence not sending an email to this address at all).

One of the possible solutions would be to change the regexp and exclude the quotation mark at the beginning: `("[^"]*?[^\x00-\x7F].*?")` but the regexp can be even more simplified basing on the fact that `Encodings.b_value_encode` does not encode ascii only strings,
so it does not matter if the string passed to it contains the non-usascii chars or not.
The simplified regexp can just match any string which is between the quotation marks: `/(".*?")/`