### PR TITLE
Add to the README that Ruby 2.4.0 was a tested version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Every Mail commit is tested by Travis on the [following platforms](https://githu
 * ruby-2.1.10 [ x86_64 ]
 * ruby-2.2.6 [ x86_64 ]
 * ruby-2.3.3 [ x86_64 ]
+* ruby-2.4.0 [ x86_64 ]
 * ruby-head [ x86_64 ]
 * jruby [ x86_64 ]
 * jruby-9.1.6.0 [ x86_64 ]


### PR DESCRIPTION
Follow up to #1064.