### PR TITLE
failing spec for non-ascii local address

### DIFF
--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -12,6 +12,10 @@ describe Mail::Address do
       }.not_to raise_error
     end
 
+    it "should accept non-ascii characters" do
+      expect(Mail::Address.new('Dude <düde@somewhere.com>').address).to eq 'düde@somewhere.com'
+    end
+
     it "should allow us to instantiate an empty address object and call to_s" do
       expect(Mail::Address.new.to_s).to eq ''
     end
@@ -88,7 +92,7 @@ describe Mail::Address do
       encoded = '=?ISO-8859-1?Q?Jan_Kr=FCtisch?= <jan@krutisch.de>'
       expect(Mail::Address.new(encoded).display_name).to eq 'Jan Krütisch'
     end
-    
+
     it "should allow nil display name" do
       a = Mail::Address.new
       expect(a.display_name).to be_nil

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -80,6 +80,15 @@ describe Mail::Message do
       end
     end
 
+    it 'should handle non-ascii characters in email fields' do
+      mail = Mail.new do
+        from 'Düde <düde@somewhere.com>'
+      end
+      expect(mail.from).to contain_exactly('düde@somewhere.com')
+      expect(mail.header['From'].value).to eq('Düde <düde@somewhere.com>')
+      expect(mail.header['From'].addresses.first).to eq('düde@somewhere.com')
+    end
+
     it 'should be able to parse an email missing an encoding' do
       Mail.read(fixture('emails', 'error_emails', 'must_supply_encoding.eml'))
     end

--- a/spec/mail/parsers/address_lists_parser_spec.rb
+++ b/spec/mail/parsers/address_lists_parser_spec.rb
@@ -3,6 +3,14 @@
 require 'spec_helper'
 
 describe "AddressListsParser" do
+
+  context 'email with non-ascii characters' do
+    let(:text){ 'Dude <düde@somewhere.com>' }
+    subject{ Mail::Parsers::AddressListsParser.parse(text) }
+
+    it{ is_expected.not_to be_nil }
+  end
+
   it "should parse an address" do
     text = 'Mikel Lindsaar <test@lindsaar.net>, Friends: test2@lindsaar.net, Ada <test3@lindsaar.net>;'
     a = Mail::Parsers::AddressListsParser


### PR DESCRIPTION
the `AddressListsParser` can't seem to handle non-ASCII characters. I wrote a failing spec to demonstrate. I don't know Ragel at all, so having a hard time to pinpoint where this could be fixed (or if it's even a bug at all). ~~Issue: https://github.com/mikel/mail/issues/1088~~ Issue: https://github.com/mikel/mail/issues/39

```shell
Failures:

  1) AddressListsParser email with non-ascii characters
     Failure/Error: raise Mail::Field::ParseError.new(Mail::AddressList, data, "Only able to parse up to #{data[0..p]}")
```

```shell
     Mail::Field::ParseError:
       Mail::AddressList can not parse |Dude <düde@somewhere.com>|
       Reason was: Only able to parse up to Dude <dü
     # ./lib/mail/parsers/address_lists_parser.rb:15336:in `parse'
     # ./spec/mail/parsers/address_lists_parser_spec.rb:9:in `block (3 levels) in <top (required)>'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:295:in `block (2 levels) in let'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:157:in `block (3 levels) in fetch_or_store'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:157:in `fetch'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:157:in `block (2 levels) in fetch_or_store'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-support-3.5.0/lib/rspec/support/reentrant_mutex.rb:23:in `synchronize'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:156:in `block in fetch_or_store'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:155:in `fetch'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:155:in `fetch_or_store'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:295:in `block in let'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/memoized_helpers.rb:119:in `is_expected'
     # ./spec/mail/parsers/address_lists_parser_spec.rb:11:in `block (3 levels) in <top (required)>'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /usr/local/lib/ruby/gems/2.4.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'

Finished in 3.45 seconds (files took 0.69263 seconds to load)
1618 examples, 1 failure, 8 pending

Failed examples:

rspec ./spec/mail/parsers/address_lists_parser_spec.rb:11 # AddressListsParser email with non-ascii characters
```