### PR TITLE
Remove trailing new lines in header fields

### DIFF
--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -94,9 +94,8 @@ module Mail
     def fields=(unfolded_fields)
       @fields = Mail::FieldList.new
       warn "Warning: more than #{self.class.maximum_amount} header fields only using the first #{self.class.maximum_amount}" if unfolded_fields.length > self.class.maximum_amount
-      unfolded_fields[0..(self.class.maximum_amount-1)].each do |field|
-
-        field = Field.new(field, nil, charset)
+      unfolded_fields[0..(self.class.maximum_amount-1)].each do |raw_field|
+        field = Field.new(raw_field.strip, nil, charset)
         if limited_field?(field.name) && (selected = select_field_for(field.name)) && selected.any? 
           selected.first.update(field.name, field.value)
         else

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -42,6 +42,14 @@ describe Mail::Header do
     it "should say if it has a message_id field defined" do
       header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\nMessage-ID: 1234")
       expect(header).to be_has_message_id
+      expect(header.has_message_id?).to eq(true)
+    end
+
+    it "should have a message ID when the previous field has trailing new lines" do
+      header = Mail::Header.new("To: Mikel\r\nFrom: bob\r\n\r\n     \r\n     Message-ID: 1234")
+      message_id = header["Message-ID"]
+      expect(message_id).to_not eq(nil)
+      expect(message_id.value).to eq("1234")
     end
 
     it "should say if it has a content_id field defined" do


### PR DESCRIPTION
When there are trailing new lines in header fields, the field does not currently get parsed.

i.e.,
```
"To: Mikel\r\nFrom: bob\r\n\r\n     \r\n     Message-ID: 1234"
```
In the above example, `Message-ID` will not get parsed, and the resulting Mail object does not contain a message ID.