### PR TITLE
Should not set Content-Transfer-Encoding to 7bit for 8bit files.

### DIFF
--- a/lib/mail/attachments_list.rb
+++ b/lib/mail/attachments_list.rb
@@ -87,7 +87,7 @@ module Mail
     # set it to binary, otherwise as set to plain text
     def guess_encoding
       if @mime_type && !@mime_type.binary?
-        "7bit"
+        nil
       else
         "binary"
       end

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -576,6 +576,12 @@ describe "MIME Emails" do
         mail.to_s
       end
 
+      it "should not set Content-Transfer-Encoding to 7bit for 8bit files" do
+        mail = Mail::Message.new
+        mail.add_file(fixture('attachments', 'てすと.txt'))
+        expect(mail.attachments.first.content_transfer_encoding).to be_nil
+      end
+
 
     end
 

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -579,7 +579,7 @@ describe "MIME Emails" do
       it "should not set Content-Transfer-Encoding to 7bit for 8bit files" do
         mail = Mail::Message.new
         mail.add_file(fixture('attachments', 'てすと.txt'))
-        expect(mail.attachments.first.content_transfer_encoding).to be_nil
+        expect(mail.attachments.first.content_transfer_encoding).to eq ''
       end
 
 


### PR DESCRIPTION
Mail::Message#add_file sets Content-Transfer-Encoding to 7bit even if the file is 8bit.
For example,

```ruby
m = Mail.new
m.add_file("utf8.txt")
print m
```

The above code produces the following output:

```
Date: Fri, 28 Apr 2017 10:50:22 +0900
Message-ID: <59029fdede6eb_16722af16027d69478547@lexington.mail>
Mime-Version: 1.0
Content-Type: multipart/mixed;
 boundary="--==_mimepart_59029fdec19b9_16722af16027d69478448";
 charset=UTF-8
Content-Transfer-Encoding: 7bit


----==_mimepart_59029fdec19b9_16722af16027d69478448
Content-Type: text/plain;
 charset=UTF-8;
 filename=utf8.txt
Content-Transfer-Encoding: 7bit
Content-Disposition: attachment;
 filename=utf8.txt
Content-ID: <59029fdedeb2d_16722af16027d6947863c@lexington.mail>

テストです。

----==_mimepart_59029fdec19b9_16722af16027d69478448--
```
