### PR TITLE
Remove unused methods in core_extensions

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -13,6 +13,7 @@ Performance:
 
 Compatibility:
 * #655 - Sort attachments to the end of the parts list to work around email clients that may mistake a text attachment for the message body. (npickens)
+* Removed `at`, `from`, `last` and `is_utf8?` methods from String since they are not currently used anywhere in mail.
 
 Bugs:
 * #605 - Fix Mail::Address#name for nil addresses (peterkovacs)

--- a/lib/mail/core_extensions/string/access.rb
+++ b/lib/mail/core_extensions/string/access.rb
@@ -8,26 +8,6 @@
 
 class String
   unless '1.9'.respond_to?(:force_encoding)
-    # Returns the character at the +position+ treating the string as an array (where 0 is the first character).
-    #
-    # Examples:
-    #   "hello".at(0)  # => "h"
-    #   "hello".at(4)  # => "o"
-    #   "hello".at(10) # => ERROR if < 1.9, nil in 1.9
-    def at(position)
-      mb_chars[position, 1].to_s
-    end
-
-    # Returns the remaining of the string from the +position+ treating the string as an array (where 0 is the first character).
-    #
-    # Examples:
-    #   "hello".from(0)  # => "hello"
-    #   "hello".from(2)  # => "llo"
-    #   "hello".from(10) # => "" if < 1.9, nil in 1.9
-    def from(position)
-      mb_chars[position..-1].to_s
-    end
-
     # Returns the beginning of the string up to the +position+ treating the string as an array (where 0 is the first character).
     #
     # Examples:
@@ -53,31 +33,7 @@ class String
         mb_chars[0...limit].to_s
       end
     end
-
-    # Returns the last character of the string or the last +limit+ characters.
-    #
-    # Examples:
-    #   "hello".last     # => "o"
-    #   "hello".last(2)  # => "lo"
-    #   "hello".last(10) # => "hello"
-    def last(limit = 1)
-      if limit == 0
-        ''
-      elsif limit >= size
-        self
-      else
-        mb_chars[(-limit)..-1].to_s
-      end
-    end
   else
-    def at(position)
-      self[position]
-    end
-
-    def from(position)
-      self[position..-1]
-    end
-
     def to(position)
       self[0..position]
     end
@@ -89,16 +45,6 @@ class String
         self
       else
         to(limit - 1)
-      end
-    end
-
-    def last(limit = 1)
-      if limit == 0
-        ''
-      elsif limit >= size
-        self
-      else
-        from(-limit)
       end
     end
   end

--- a/lib/mail/core_extensions/string/multibyte.rb
+++ b/lib/mail/core_extensions/string/multibyte.rb
@@ -50,17 +50,6 @@ class String
         self
       end
     end
-
-    def is_utf8? #:nodoc
-      case encoding
-      when Encoding::UTF_8
-        valid_encoding?
-      when Encoding::ASCII_8BIT, Encoding::US_ASCII
-        dup.force_encoding(Encoding::UTF_8).valid_encoding?
-      else
-        false
-      end
-    end
   else
     def mb_chars
       if Mail::Multibyte.proxy_class.wants?(self)
@@ -68,12 +57,6 @@ class String
       else
         self
       end
-    end
-
-    # Returns true if the string has UTF-8 semantics (a String used for purely byte resources is unlikely to have
-    # them), returns false otherwise.
-    def is_utf8?
-      Mail::Multibyte::Chars.consumes?(self)
     end
   end
 end


### PR DESCRIPTION
The `at`, `from`, `last` and `is_utf8?` patches to String in core_extensions are not currently used by mail.

`to` is only used by `first` for Ruby < 2.0 but I kept both implementations for consistency. `first` is only used in one location and only by Ruby < 2.0 but I also kept that to keep this PR focused on removed completely unused patches.