### PR TITLE
SMTP security: prevent command injection via To/From addresses

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,8 @@
 == HEAD
 
+Security:
+* #1097 – SMTP security: prevent command injection via To/From addresses. (jeremy)
+
 Features:
 * #804 - Configurable SMTP open_timeout and read_timeout. (ankane)
 * #853 - `Mail::Message#set_sort_order` overrides the default message part sort order. (rafbm)

--- a/lib/mail/network/delivery_methods/file_delivery.rb
+++ b/lib/mail/network/delivery_methods/file_delivery.rb
@@ -2,7 +2,6 @@
 require 'mail/check_delivery_params'
 
 module Mail
-  
   # FileDelivery class delivers emails into multiple files based on the destination
   # address.  Each file is appended to if it already exists.
   # 
@@ -14,22 +13,20 @@ module Mail
   # Make sure the path you specify with :location is writable by the Ruby process
   # running Mail.
   class FileDelivery
-    include Mail::CheckDeliveryParams
-
     if RUBY_VERSION >= '1.9.1'
       require 'fileutils'
     else
       require 'ftools'
     end
 
+    attr_accessor :settings
+
     def initialize(values)
       self.settings = { :location => './mails' }.merge!(values)
     end
-    
-    attr_accessor :settings
-    
+
     def deliver!(mail)
-      check_delivery_params(mail)
+      Mail::CheckDeliveryParams.check(mail)
 
       if ::File.respond_to?(:makedirs)
         ::File.makedirs settings[:location]
@@ -41,6 +38,5 @@ module Mail
         ::File.open(::File.join(settings[:location], File.basename(to.to_s)), 'a') { |f| "#{f.write(mail.encoded)}\r\n\r\n" }
       end
     end
-    
   end
 end

--- a/lib/mail/network/delivery_methods/sendmail.rb
+++ b/lib/mail/network/delivery_methods/sendmail.rb
@@ -38,17 +38,15 @@ module Mail
   #
   #   mail.deliver!
   class Sendmail
-    include Mail::CheckDeliveryParams
+    attr_accessor :settings
 
     def initialize(values)
       self.settings = { :location       => '/usr/sbin/sendmail',
                         :arguments      => '-i' }.merge(values)
     end
 
-    attr_accessor :settings
-
     def deliver!(mail)
-      smtp_from, smtp_to, message = check_delivery_params(mail)
+      smtp_from, smtp_to, message = Mail::CheckDeliveryParams.check(mail)
 
       from = "-f #{self.class.shellquote(smtp_from)}"
       to = smtp_to.map { |_to| self.class.shellquote(_to) }.join(' ')

--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -74,7 +74,7 @@ module Mail
   # 
   #   mail.deliver!
   class SMTP
-    include Mail::CheckDeliveryParams
+    attr_accessor :settings
 
     def initialize(values)
       self.settings = { :address              => "localhost",
@@ -93,12 +93,10 @@ module Mail
                       }.merge!(values)
     end
 
-    attr_accessor :settings
-
     # Send the message via SMTP.
     # The from and to attributes are optional. If not set, they are retrieve from the Message.
     def deliver!(mail)
-      smtp_from, smtp_to, message = check_delivery_params(mail)
+      smtp_from, smtp_to, message = Mail::CheckDeliveryParams.check(mail)
 
       smtp = Net::SMTP.new(settings[:address], settings[:port])
       if settings[:tls] || settings[:ssl]
@@ -128,7 +126,6 @@ module Mail
         self
       end
     end
-    
 
     private
 

--- a/lib/mail/network/delivery_methods/smtp_connection.rb
+++ b/lib/mail/network/delivery_methods/smtp_connection.rb
@@ -38,7 +38,7 @@ module Mail
   # 
   #   mail.deliver!
   class SMTPConnection
-    include Mail::CheckDeliveryParams
+    attr_accessor :smtp, :settings
 
     def initialize(values)
       raise ArgumentError.new('A Net::SMTP object is required for this delivery method') if values[:connection].nil?
@@ -46,17 +46,13 @@ module Mail
       self.settings = values
     end
 
-    attr_accessor :smtp
-    attr_accessor :settings
-
     # Send the message via SMTP.
     # The from and to attributes are optional. If not set, they are retrieve from the Message.
     def deliver!(mail)
-      smtp_from, smtp_to, message = check_delivery_params(mail)
+      smtp_from, smtp_to, message = Mail::CheckDeliveryParams.check(mail)
       response = smtp.sendmail(message, smtp_from, smtp_to)
 
       settings[:return_response] ? response : self
     end
-
   end
 end

--- a/lib/mail/network/delivery_methods/test_mailer.rb
+++ b/lib/mail/network/delivery_methods/test_mailer.rb
@@ -8,10 +8,8 @@ module Mail
   # It also provides a template of the minimum methods you require to implement
   # if you want to make a custom mailer for Mail
   class TestMailer
-    include Mail::CheckDeliveryParams
-
     # Provides a store of all the emails sent with the TestMailer so you can check them.
-    def TestMailer.deliveries
+    def self.deliveries
       @@deliveries ||= []
     end
 
@@ -26,20 +24,19 @@ module Mail
     # * length
     # * size
     # * and other common Array methods
-    def TestMailer.deliveries=(val)
+    def self.deliveries=(val)
       @@deliveries = val
     end
+
+    attr_accessor :settings
 
     def initialize(values)
       @settings = values.dup
     end
-    
-    attr_accessor :settings
 
     def deliver!(mail)
-      check_delivery_params(mail)
+      Mail::CheckDeliveryParams.check(mail)
       Mail::TestMailer.deliveries << mail
     end
-    
   end
 end

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -187,7 +187,7 @@ describe "exim delivery agent" do
         subject "Email with no sender"
         body "body"
       end
-    end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+    end.to raise_error('SMTP From address may not be blank: nil')
   end
 
   it "should raise an error if no recipient if defined" do
@@ -200,6 +200,6 @@ describe "exim delivery agent" do
         subject "Email with no recipient"
         body "body"
       end
-    end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+    end.to raise_error('SMTP To address may not be blank: []')
   end
 end

--- a/spec/mail/network/delivery_methods/file_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/file_delivery_spec.rb
@@ -101,7 +101,7 @@ describe "SMTP Delivery Method" do
           subject "Email with no sender"
           body "body"
         end
-      end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+      end.to raise_error('SMTP From address may not be blank: nil')
     end
 
     it "should raise an error if no recipient if defined" do
@@ -115,7 +115,7 @@ describe "SMTP Delivery Method" do
           subject "Email with no recipient"
           body "body"
         end
-      end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+      end.to raise_error('SMTP To address may not be blank: []')
     end
 
   end

--- a/spec/mail/network/delivery_methods/sendmail_spec.rb
+++ b/spec/mail/network/delivery_methods/sendmail_spec.rb
@@ -206,7 +206,7 @@ describe "sendmail delivery agent" do
         subject "Email with no sender"
         body "body"
       end
-    end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+    end.to raise_error('SMTP From address may not be blank: nil')
   end
 
   it "should raise an error if no recipient if defined" do
@@ -219,6 +219,6 @@ describe "sendmail delivery agent" do
         subject "Email with no recipient"
         body "body"
       end
-    end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+    end.to raise_error('SMTP To address may not be blank: []')
   end
 end

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -60,7 +60,7 @@ describe "SMTP Delivery Method" do
         subject "Email with no sender"
         body "body"
       end
-    end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+    end.to raise_error('SMTP From address may not be blank: nil')
   end
 
   it "should raise an error if no recipient if defined" do
@@ -75,6 +75,6 @@ describe "SMTP Delivery Method" do
         subject "Email with no recipient"
         body "body"
       end
-    end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+    end.to raise_error('SMTP To address may not be blank: []')
   end
 end

--- a/spec/mail/network/delivery_methods/test_mailer_spec.rb
+++ b/spec/mail/network/delivery_methods/test_mailer_spec.rb
@@ -65,7 +65,7 @@ describe "Mail::TestMailer" do
         subject "Email with no sender"
         body "body"
       end
-    end.to raise_error('An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address.')
+    end.to raise_error('SMTP From address may not be blank: nil')
   end
 
   it "should raise an error if no recipient if defined" do
@@ -78,7 +78,7 @@ describe "Mail::TestMailer" do
         subject "Email with no recipient"
         body "body"
       end
-    end.to raise_error('An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.')
+    end.to raise_error('SMTP To address may not be blank: []')
   end
 
   it "should save settings passed to initialize" do


### PR DESCRIPTION
Validate addresses passed as SMTP command arguments to prevent
injection of other SMTP commands. Disallow line breaks and very
long addresses which may cause overflows on some old SMTP servers.

Ruby 2.4 Net::SMTP already disallows addresses that contain newlines.
Enforce this validation in Mail to cover older Ruby versions and
other SMTP implementations that don't validate input.

SMTP injection whitepaper: http://www.mbsd.jp/Whitepaper/smtpi.pdf
Ruby security report: https://hackerone.com/reports/137631
OSVDB entry: https://rubysec.com/advisories/mail-OSVDB-131677