### PR TITLE
Use secure protocol when running bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,10 @@
 source 'https://rubygems.org'
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
+  "https://github.com/#{repo_name}.git"
+end
+
 gemspec
 
 gem 'tlsmail', '~> 0.0.1' if RUBY_VERSION <= '1.8.6'


### PR DESCRIPTION
This PR suppresses the following warnings.
```
% bundle install
The git source `git://github.com/discourse/mini_mime.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```
Refer: bundler/bundler#4127