### PR TITLE
Use Kernel#warn instead of $stderr.puts

### DIFF
--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -246,7 +246,7 @@ module Mail
         Mail::Multibyte.mb_chars(match_data[2].to_s).strip.to_s
       ]
     rescue
-      $stderr.puts "WARNING: Could not parse (and so ignoring) '#{raw_field}'"
+      warn "WARNING: Could not parse (and so ignoring) '#{raw_field}'"
     end
 
     # 2.2.3. Long Header Fields

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -213,7 +213,7 @@ module Mail
     self.default_charset = 'UTF-8'
 
     def register_for_delivery_notification(observer)
-      $stderr.puts("Message#register_for_delivery_notification is deprecated, please call Mail.register_observer instead")
+      warn("Message#register_for_delivery_notification is deprecated, please call Mail.register_observer instead")
       Mail.register_observer(observer)
     end
 
@@ -1415,7 +1415,7 @@ module Mail
     end
 
     def has_transfer_encoding? # :nodoc:
-      $stderr.puts(":has_transfer_encoding? is deprecated in Mail 1.4.3.  Please use has_content_transfer_encoding?\n#{caller}")
+      warn(":has_transfer_encoding? is deprecated in Mail 1.4.3.  Please use has_content_transfer_encoding?\n#{caller}")
       has_content_transfer_encoding?
     end
 
@@ -1465,7 +1465,7 @@ module Mail
         # has not specified an encoding explicitly.
         if @defaulted_charset && !body.raw_source.ascii_only? && !self.attachment?
           warning = "Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect.\n"
-          $stderr.puts(warning)
+          warn(warning)
         end
         header[:content_type].parameters['charset'] = @charset
       end
@@ -1479,18 +1479,18 @@ module Mail
         header[:content_transfer_encoding] = '7bit'
       else
         warning = "Non US-ASCII detected and no content-transfer-encoding defined.\nDefaulting to 8bit, set your own if this is incorrect.\n"
-        $stderr.puts(warning)
+        warn(warning)
         header[:content_transfer_encoding] = '8bit'
       end
     end
 
     def add_transfer_encoding # :nodoc:
-      $stderr.puts(":add_transfer_encoding is deprecated in Mail 1.4.3.  Please use add_content_transfer_encoding\n#{caller}")
+      warn(":add_transfer_encoding is deprecated in Mail 1.4.3.  Please use add_content_transfer_encoding\n#{caller}")
       add_content_transfer_encoding
     end
 
     def transfer_encoding # :nodoc:
-      $stderr.puts(":transfer_encoding is deprecated in Mail 1.4.3.  Please use content_transfer_encoding\n#{caller}")
+      warn(":transfer_encoding is deprecated in Mail 1.4.3.  Please use content_transfer_encoding\n#{caller}")
       content_transfer_encoding
     end
 
@@ -1500,7 +1500,7 @@ module Mail
     end
 
     def message_content_type
-      $stderr.puts(":message_content_type is deprecated in Mail 1.4.3.  Please use mime_type\n#{caller}")
+      warn(":message_content_type is deprecated in Mail 1.4.3.  Please use mime_type\n#{caller}")
       mime_type
     end
 
@@ -1532,7 +1532,7 @@ module Mail
 
     # Returns the content type parameters
     def mime_parameters
-      $stderr.puts(':mime_parameters is deprecated in Mail 1.4.3, please use :content_type_parameters instead')
+      warn(':mime_parameters is deprecated in Mail 1.4.3, please use :content_type_parameters instead')
       content_type_parameters
     end
 
@@ -1808,7 +1808,7 @@ module Mail
     end
 
     def encode!
-      $stderr.puts("Deprecated in 1.1.0 in favour of :ready_to_send! as it is less confusing with encoding and decoding.")
+      warn("Deprecated in 1.1.0 in favour of :ready_to_send! as it is less confusing with encoding and decoding.")
       ready_to_send!
     end
 

--- a/lib/mail/part.rb
+++ b/lib/mail/part.rb
@@ -21,7 +21,7 @@ module Mail
     
     def inline_content_id
       # TODO: Deprecated in 2.2.2 - Remove in 2.3
-      $stderr.puts("Part#inline_content_id is deprecated, please call Part#cid instead")
+      warn("Part#inline_content_id is deprecated, please call Part#cid instead")
       cid
     end
     

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -294,3 +294,9 @@ class Net::IMAP
     MockIMAP.new
   end
 end
+
+module Kernel
+  def warn(m)
+    $stderr.puts(m)
+  end
+end


### PR DESCRIPTION
Kernel#warn is the standard way to issue warning messages from
ruby code.  Using it allows applications using mail to override
Kernel#warn to handle warnings in a custom manner. In Ruby 2.5+,
Kernel#warn will also call Warning.warn, unifying all ruby warning
handling.