### PR TITLE
rfc2046

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -139,9 +139,9 @@ module Mail
       @raw_source
     end
    
-    def get_best_encoding(target)
+    def get_best_encoding(target, allowed_encodings = Encodings.get_all)
       target_encoding = Mail::Encodings.get_encoding(target)
-      target_encoding.get_best_compatible(encoding, raw_source)
+      target_encoding.get_best_compatible(encoding, raw_source, allowed_encodings)
     end
  
     # Returns a body encoded using transfer_encoding.  Multipart always uses an

--- a/lib/mail/encodings/transfer_encoding.rb
+++ b/lib/mail/encodings/transfer_encoding.rb
@@ -32,12 +32,12 @@ module Mail
         self::NAME
       end
 
-      def self.get_best_compatible(source_encoding, str)
+      def self.get_best_compatible(source_encoding, str, allowed_encodings = Encodings.get_all)
         if self.can_transport?(source_encoding) && self.compatible_input?(str)
           source_encoding
         else
           choices = Encodings.get_all.select do |enc|
-            self.can_transport?(enc) && enc.can_encode?(source_encoding)
+            self.can_transport?(enc) && enc.can_encode?(source_encoding) && allowed_encodings.include?(enc)
           end
 
           best = nil

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2054,6 +2054,15 @@ module Mail
       body.split!(boundary)
     end
 
+    def allowed_encodings
+      case self.mime_type
+      when 'message/rfc822'
+        [Encodings::SevenBit, Encodings::EightBit, Encodings::Binary]
+      else
+        Encodings.get_all
+      end
+    end
+
     def add_encoding_to_body
       if has_content_transfer_encoding?
         @body.encoding = content_transfer_encoding
@@ -2064,7 +2073,7 @@ module Mail
         if body && body.multipart?
             self.content_transfer_encoding = @transport_encoding
         else
-            self.content_transfer_encoding = body.get_best_encoding(@transport_encoding)
+            self.content_transfer_encoding = body.get_best_encoding(@transport_encoding, allowed_encodings)
         end
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1401,6 +1401,22 @@ describe Mail::Message do
 
       end
 
+      # https://www.ietf.org/rfc/rfc2046.txt
+      # No encoding other than "7bit", "8bit", or "binary" is permitted for
+      # the body of a "message/rfc822" entity.
+      it "rfc2046" do
+        mail = Mail.new
+        mail.body << Mail::Part.new.tap do |part|
+          part.content_disposition = 'attachment; filename="test.eml"'
+          part.content_type  = 'message/rfc822'
+          part.body          = 'a' * 999
+        end
+        mail.encoded
+        
+        expect(mail.parts.count).to eq(1)
+        expect(mail.parts.last.content_transfer_encoding).to match(/7bit|8bit|binary/)
+      end
+
       describe "content-transfer-encoding" do
 
         it "should use 7bit for only US-ASCII chars" do


### PR DESCRIPTION
attached eml files can't be opened in thunderbird or outlook if they're encoded as base64

reason
https://www.ietf.org/rfc/rfc2046.txt

   It should be noted that, despite the use of the numbers "822", a
   "message/rfc822" entity isn't restricted to material in strict
   conformance to RFC822, nor are the semantics of "message/rfc822"
   objects restricted to the semantics defined in RFC822. More
   specifically, a "message/rfc822" message could well be a News article
   or a MIME message.

   No encoding other than "7bit", "8bit", or "binary" is permitted for
   the body of a "message/rfc822" entity.  The message header fields are
   always US-ASCII in any case, and data within the body can still be
   encoded, in which case the Content-Transfer-Encoding header field in
   the encapsulated message will reflect this.  Non-US-ASCII text in the
   headers of an encapsulated message can be specified using the
   mechanisms described in RFC 2047.