### PR TITLE
Fix that Address#display_name and others flip-flopped between encoded/decoded formatting

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -46,6 +46,9 @@ Bugs:
 * #1023 - Fix double-quoting in display names. (garethrees)
 * #1032 - Fix that comparing messages changed their raw Message-ID to their parsed message_id. (bobjflong)
 * #1074 - Fix that the first address in a list is dropped when a subsequent address has non-US-ASCII characters. (domininik)
+* #1107 - Fix Address#display_name and other formatting flip-flopping between
+encoded and decoded forms depending on whether #encoded or #decoded was called
+last. (jeremy)
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -88,7 +88,16 @@ describe Mail::Address do
       encoded = '=?ISO-8859-1?Q?Jan_Kr=FCtisch?= <jan@krutisch.de>'
       expect(Mail::Address.new(encoded).display_name).to eq 'Jan Krütisch'
     end
-    
+
+    it "doesn't get stuck on decode or encode output mode" do
+      a = Mail::Address.new('=?ISO-8859-1?Q?Jan_Kr=FCtisch?= <jan@krutisch.de>')
+      expect(a.display_name).to eq 'Jan Krütisch'
+
+      # Ignore result, ensure it doesn't flip format mode
+      a.encoded
+      expect(a.display_name).to eq 'Jan Krütisch'
+    end
+
     it "should allow nil display name" do
       a = Mail::Address.new
       expect(a.display_name).to be_nil


### PR DESCRIPTION
Due to using an `@output_type` ivar to pass state between formatting methods. Fixed by explictly passing as an argument.

Fixes #960