### PR TITLE
Fix broken parsing when Active Support was loaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ rvm:
 env:
   global:
     - JRUBY_OPTS="--server -J-Xms1500m -J-Xmx1500m -J-XX:+UseConcMarkSweepGC -J-XX:-UseGCOverheadLimit -J-XX:+CMSClassUnloadingEnabled"
+  matrix:
+    - MBCHARS=activesupport
+    - MBCHARS=builtin
 
 matrix:
   allow_failures:
@@ -35,4 +38,5 @@ matrix:
     - rvm: jruby-head
     - rvm: rbx-2
     - rvm: rbx-3
+    - env: MBCHARS=activesupport
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,16 @@ source 'https://rubygems.org'
 
 gemspec
 
+# For testing against ActiveSupport::Multibyte::Chars
+if RUBY_VERSION < '1.9.3'
+  gem 'activesupport', '< 4'
+  gem 'i18n', '< 0.7'
+elsif RUBY_VERSION < '2.2.2'
+  gem 'activesupport', '< 5'
+else
+  gem 'activesupport', :git => 'https://github.com/rails/rails'
+end
+
 gem 'tlsmail', '~> 0.0.1' if RUBY_VERSION <= '1.8.6'
 gem 'jruby-openssl', :platforms => :jruby
 

--- a/lib/mail.rb
+++ b/lib/mail.rb
@@ -31,12 +31,7 @@ module Mail # :doc:
   require 'mail/core_extensions/smtp'
   require 'mail/indifferent_hash'
 
-  # Only load our multibyte extensions if AS is not already loaded
-  if defined?(ActiveSupport)
-    require 'active_support/inflector'
-  else
-    require 'mail/multibyte'
-  end
+  require 'mail/multibyte'
 
   require 'mail/constants'
   require 'mail/utilities'

--- a/lib/mail/multibyte.rb
+++ b/lib/mail/multibyte.rb
@@ -1,25 +1,23 @@
 # encoding: utf-8
 # frozen_string_literal: true
+require 'mail/multibyte/chars'
+
 module Mail #:nodoc:
   module Multibyte
-    require 'mail/multibyte/exceptions'
-    require 'mail/multibyte/chars'
-    require 'mail/multibyte/unicode'
+    # Raised when a problem with the encoding was found.
+    class EncodingError < StandardError; end
 
-    # The proxy class returned when calling mb_chars. You can use this accessor to configure your own proxy
-    # class so you can support other encodings. See the Mail::Multibyte::Chars implementation for
-    # an example how to do this.
-    #
-    # Example:
-    #   Mail::Multibyte.proxy_class = CharsForUTF32
-    def self.proxy_class=(klass)
-      @proxy_class = klass
+    class << self
+      # The proxy class returned when calling mb_chars. You can use this accessor to configure your own proxy
+      # class so you can support other encodings. See the Mail::Multibyte::Chars implementation for
+      # an example how to do this.
+      #
+      # Example:
+      #   Mail::Multibyte.proxy_class = CharsForUTF32
+      attr_accessor :proxy_class
     end
 
-    # Returns the current proxy class
-    def self.proxy_class
-      @proxy_class ||= Mail::Multibyte::Chars
-    end
+    self.proxy_class = Mail::Multibyte::Chars
 
     if RUBY_VERSION >= "1.9"
       # == Multibyte proxy

--- a/lib/mail/multibyte/chars.rb
+++ b/lib/mail/multibyte/chars.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
+require 'mail/multibyte/unicode'
 
 module Mail #:nodoc:
   module Multibyte #:nodoc:

--- a/lib/mail/multibyte/exceptions.rb
+++ b/lib/mail/multibyte/exceptions.rb
@@ -1,9 +1,0 @@
-# encoding: utf-8
-# frozen_string_literal: true
-
-module Mail #:nodoc:
-  module Multibyte #:nodoc:
-    # Raised when a problem with the encoding was found.
-    class EncodingError < StandardError; end
-  end
-end

--- a/spec/environment.rb
+++ b/spec/environment.rb
@@ -14,3 +14,11 @@ end
 
 require 'mail'
 require 'mail/parsers'
+
+if ENV['MBCHARS'] == 'activesupport'
+  require 'active_support'
+  Mail::Multibyte.proxy_class = ActiveSupport::Multibyte::Chars
+else
+  require 'mail/multibyte/chars'
+  Mail::Multibyte.proxy_class = Mail::Multibyte::Chars
+end

--- a/spec/mail/multibyte_spec.rb
+++ b/spec/mail/multibyte_spec.rb
@@ -1,18 +1,16 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
+require 'mail/multibyte/chars'
 
-describe "multibyte/chars" do
-  Chars = Mail::Multibyte::Chars
-
+describe Mail::Multibyte::Chars do
   it "should upcase" do
-    chars = Chars.new('Laurent, où sont les tests ?')
+    chars = described_class.new('Laurent, où sont les tests ?')
     expect(chars.upcase).to eq("LAURENT, OÙ SONT LES TESTS ?")
   end
 
   it "should downcase" do
-    chars = Chars.new('VĚDA A VÝZKUM')
+    chars = described_class.new('VĚDA A VÝZKUM')
     expect(chars.downcase).to eq("věda a výzkum")
   end
 end
-

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -71,17 +71,11 @@ describe "Utilities Module" do
         expect(quote_atom(Mail::Multibyte.mb_chars('.abc'))).to eq '".abc"'
       end
 
-      it "should work with mb_chars" do
-        expect(quote_atom(Mail::Multibyte.mb_chars('?=abc'))).to eq '?=abc'
-        expect(quote_atom(Mail::Multibyte.mb_chars('.abc'))).to eq '".abc"'
-      end
-
-      it "should quote white space" do
+      it "should quote mb_chars white space" do
         expect(quote_atom(Mail::Multibyte.mb_chars('ab abc'))).to eq '"ab abc"'
         expect(quote_atom(Mail::Multibyte.mb_chars("a\sb\ta\r\nbc"))).to eq %{"a\sb\ta\r\nbc"}
       end
     end
-
   end
 
   describe "quoting phrases" do
@@ -161,7 +155,6 @@ describe "Utilities Module" do
       result = 'This is a string'
       expect(unparen(test)).to eq result
     end
-
   end
 
   describe "unescaping brackets" do
@@ -189,7 +182,6 @@ describe "Utilities Module" do
       result = 'This is a string'
       expect(unbracket(test)).to eq(result)
     end
-
   end
 
   describe "quoting phrases" do


### PR DESCRIPTION
Since #1095 moved from `String#mb_chars` to `Mail::Multibyte.mb_chars`,
but `mail/multibyte` was only required if Active Support wasn't loaded.

Now always requires Mail::Multibyte, ~~sets proxy_class to AS::MB::Chars
if available~~, and runs CI against both chars classes.

AS::MB::Chars now only consumes a string if its encoding is UTF-8, whereas Mail's old import of Chars checks whether the string is ASCII but UTF-8 compatible. This leads to a couple regressions, so using it as a Chars proxy class is not enabled yet.

Fixes #1108.