### PR TITLE
Stop stripping header name prefixes from header values

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -16,6 +16,7 @@ Features:
 * #1053 - Ruby 2.4.0 compatibility. Fixnum+Bignum unified as Integer. (peterkovacs)
 * #1094 - Core extensions removal: Drop `String#at`, `from`, `last` and `is_utf8?` since they are no longer used by Mail internals. (metcalf)
 * #1095 - Core extensions removal: Drop `String#mb_chars`, `not_ascii_only?`, `constantize`, `first`, `to` to avoid monkey patching the standard library. (metcalf)
+* #1111  - Mail::Field.parse API which deprecates calling Mail::Field.new with unparsed header fields. (jeremy)
 
 Performance:
 * #1059 - Switch from mime-types to mini_mime for a much smaller memory footprint. (SamSaffron)
@@ -25,6 +26,7 @@ Compatibility:
 * #535 - IMAP: fetch messages WITH IMAP FLAGS by passing a block with four args. (lawrencepit)
 * #655 - Sort attachments to the end of the parts list to work around email clients that may mistake a text attachment for the message body. (npickens)
 * #683 - SMTP: Work around Net::SMTP dot-stuffing bug with unterminated newlines on Ruby 1.8 and 1.9. (yyyc514)
+* #766 - No longer strip 'Subject: ' from legit subject lines. (grosser)
 * #982 – Faithfully preserve unfolded whitespace rather than collapsing to a single space. (jeremy)
 * #1103 – Support parsing UTF-8 headers. Implements RFC 6532. (jeremy)
 * #1106 – Limit message/rfc822 parts' transfer encoding per RFC 2046. (ahorek)

--- a/lib/mail/envelope.rb
+++ b/lib/mail/envelope.rb
@@ -12,7 +12,7 @@ module Mail
   class Envelope < StructuredField
     
     def initialize(*args)
-      super(FIELD_NAME, strip_field(FIELD_NAME, args.last))
+      super(FIELD_NAME, args.last.to_s)
     end
     
     def element

--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'mail/fields'
+require 'mail/constants'
 
 # encoding: utf-8
 module Mail
@@ -115,41 +116,62 @@ module Mail
     class SyntaxError < FieldError #:nodoc:
     end
 
-    # Accepts a string:
+    class << self
+      # Parse a field from a raw header line:
+      #
+      #  Mail::Field.parse("field-name: field data")
+      #  # => #<Mail::Field …>
+      def parse(field, charset = nil)
+        name, value = split(field)
+        if name && value
+          new name, value, charset
+        end
+      end
+
+      def split(raw_field) #:nodoc:
+        if raw_field.index(Constants::COLON)
+          name, value = raw_field.split(Constants::COLON, 2)
+          name.rstrip!
+          if name =~ /\A#{Constants::FIELD_NAME}\z/
+            [ name.rstrip, value.strip ]
+          else
+            Kernel.warn "WARNING: Ignoring unparsable header #{raw_field.inspect}: invalid header name syntax: #{name.inspect}"
+            nil
+          end
+        else
+          raw_field.strip
+        end
+      rescue => error
+        warn "WARNING: Ignoring unparsable header #{raw_field.inspect}: #{error.class}: #{error.message}"
+        nil
+      end
+    end
+
+    # Create a field by name and optional value:
     #
-    #  Field.new("field-name: field data")
+    #  Mail::Field.new("field-name", "value")
+    #  # => #<Mail::Field …>
     #
-    # Or name, value pair:
+    # Values that aren't strings or arrays are coerced to Strings with `#to_s`.
     #
-    #  Field.new("field-name", "value")
+    #  Mail::Field.new("field-name", 1234)
+    #  # => #<Mail::Field …>
     #
-    # Or a name by itself:
-    #
-    #  Field.new("field-name")
-    #
-    # Note, does not want a terminating carriage return.  Returns
-    # self appropriately parsed.  If value is not a string, then
-    # it will be passed through as is, for example, content-type
-    # field can accept an array with the type and a hash of
-    # parameters:
-    #
-    #  Field.new('content-type', ['text', 'plain', {:charset => 'UTF-8'}])
+    #  Mail::Field.new('content-type', ['text', 'plain', {:charset => 'UTF-8'}])
+    #  # => #<Mail::Field …>
     def initialize(name, value = nil, charset = 'utf-8')
       case
-      when name.index(COLON)            # Field.new("field-name: field data")
+      when name.index(COLON)
+        Kernel.warn 'Passing an unparsed header field to Mail::Field.new is deprecated and will be removed in Mail 2.8.0. Use Mail::Field.parse instead.'
+        @name, @unparsed_value = self.class.split(name)
         @charset = Utilities.blank?(value) ? charset : value
-        @name = name[FIELD_PREFIX]
-        @raw_value = name
-        @value = nil
-      when Utilities.blank?(value)   # Field.new("field-name")
+      when Utilities.blank?(value)
         @name = name
-        @value = nil
-        @raw_value = nil
+        @unparsed_value = nil
         @charset = charset
-      else                              # Field.new("field-name", "value")
+      else
         @name = name
-        @value = value
-        @raw_value = nil
+        @unparsed_value = value
         @charset = charset
       end
       @name = FIELD_NAME_MAP[@name.to_s.downcase] || @name
@@ -160,8 +182,7 @@ module Mail
     end
 
     def field
-      _, @value = split(@raw_value) if @raw_value && !@value
-      @field ||= create_field(@name, @value, @charset)
+      @field ||= create_field(@name, @unparsed_value, @charset)
     end
 
     def name
@@ -239,14 +260,26 @@ module Mail
 
     private
 
-    def split(raw_field)
-      match_data = Mail::Multibyte.mb_chars(raw_field).match(FIELD_SPLIT)
-      [
-        Mail::Multibyte.mb_chars(match_data[1].to_s).strip,
-        Mail::Multibyte.mb_chars(match_data[2].to_s).strip.to_s
-      ]
-    rescue
-      warn "WARNING: Could not parse (and so ignoring) '#{raw_field}'"
+    def create_field(name, value, charset)
+      new_field(name, value, charset)
+    rescue Mail::Field::ParseError => e
+      field = Mail::UnstructuredField.new(name, value)
+      field.errors << [name, value, e]
+      field
+    end
+
+    def new_field(name, value, charset)
+      value = unfold(value) if value.is_a?(String)
+
+      if klass = field_class_for(name)
+        klass.new(value, charset)
+      else
+        OptionalField.new(name, value, charset)
+      end
+    end
+
+    def field_class_for(name)
+      FIELDS_MAP[name.to_s.downcase]
     end
 
     # 2.2.3. Long Header Fields
@@ -260,28 +293,5 @@ module Mail
     def unfold(string)
       string.gsub(/#{CRLF}(#{WSP})/m, '\1')
     end
-
-    def create_field(name, value, charset)
-      value = unfold(value) if value.is_a?(String)
-
-      begin
-        new_field(name, value, charset)
-      rescue Mail::Field::ParseError => e
-        field = Mail::UnstructuredField.new(name, value)
-        field.errors << [name, value, e]
-        field
-      end
-    end
-
-    def new_field(name, value, charset)
-      lower_case_name = name.to_s.downcase
-      if field_klass = FIELDS_MAP[lower_case_name]
-        field_klass.new(value, charset)
-      else
-        OptionalField.new(name, value, charset)
-      end
-    end
-
   end
-
 end

--- a/lib/mail/fields/bcc_field.rb
+++ b/lib/mail/fields/bcc_field.rb
@@ -37,9 +37,9 @@ module Mail
     FIELD_NAME = 'bcc'
     CAPITALIZED_FIELD = 'Bcc'
     
-    def initialize(value = '', charset = 'utf-8')
+    def initialize(value = nil, charset = 'utf-8')
       @charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/cc_field.rb
+++ b/lib/mail/fields/cc_field.rb
@@ -39,7 +39,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/comments_field.rb
+++ b/lib/mail/fields/comments_field.rb
@@ -33,7 +33,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       @charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value))
+      super(CAPITALIZED_FIELD, value)
       self.parse
       self
     end

--- a/lib/mail/fields/common/common_address.rb
+++ b/lib/mail/fields/common/common_address.rb
@@ -16,20 +16,14 @@ module Mail
       @charset
     end
 
-    def encode_if_needed(val)
+    def encode_if_needed(val) #:nodoc:
       # Need to join arrays of addresses into a single value
       if val.kind_of?(Array)
         val.compact.map { |a| encode_if_needed a }.join(', ')
 
-      # Pass through UTF-8 addresses
-      elsif charset =~ /\AUTF-?8\z/i
-        val
-      elsif val.respond_to?(:encoding) && val.encoding == Encoding::UTF_8
-        val
-
-      # Encode non-UTF-8 strings
+      # Pass through UTF-8; encode non-UTF-8.
       else
-        Encodings.encode_non_usascii(val, charset)
+        utf8_if_needed(val) || Encodings.encode_non_usascii(val, charset)
       end
     end
 
@@ -110,7 +104,26 @@ module Mail
     end
   
     private
-  
+
+    if 'string'.respond_to?(:encoding)
+      # Pass through UTF-8 addresses
+      def utf8_if_needed(val)
+        if charset =~ /\AUTF-?8\z/i
+          val
+        elsif val.encoding == Encoding::UTF_8
+          val
+        elsif (utf8 = val.dup.force_encoding(Encoding::UTF_8)).valid_encoding?
+          utf8
+        end
+      end
+    else
+      def utf8_if_needed(val)
+        if charset =~ /\AUTF-?8\z/i
+          val
+        end
+      end
+    end
+
     def do_encode(field_name)
       return '' if Utilities.blank?(value)
       address_array = address_list.addresses.reject { |a| encoded_group_addresses.include?(a.encoded) }.compact.map { |a| a.encoded }

--- a/lib/mail/fields/common/common_field.rb
+++ b/lib/mail/fields/common/common_field.rb
@@ -15,7 +15,7 @@ module Mail
     def value=(value)
       @length = nil
       @element = nil
-      @value = value
+      @value = value.is_a?(Array) ? value : value.to_s
     end
 
     def value
@@ -39,14 +39,6 @@ module Mail
     end
 
     private
-
-    def strip_field(field_name, value)
-      if value.is_a?(Array)
-        value
-      else
-        value.to_s.sub(/\A#{field_name}:\s+/i, EMPTY)
-      end
-    end
 
     FILENAME_RE = /\b(filename|name)=([^;"\r\n]+\s[^;"\r\n]+)/
     def ensure_filename_quoted(value)

--- a/lib/mail/fields/content_description_field.rb
+++ b/lib/mail/fields/content_description_field.rb
@@ -11,7 +11,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
     end

--- a/lib/mail/fields/content_disposition_field.rb
+++ b/lib/mail/fields/content_disposition_field.rb
@@ -11,7 +11,7 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       value = ensure_filename_quoted(value)
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
     end

--- a/lib/mail/fields/content_id_field.rb
+++ b/lib/mail/fields/content_id_field.rb
@@ -15,9 +15,9 @@ module Mail
       if Utilities.blank?(value)
         value = generate_content_id
       else
-        value = strip_field(FIELD_NAME, value)
+        value = value.to_s
       end
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
     end

--- a/lib/mail/fields/content_location_field.rb
+++ b/lib/mail/fields/content_location_field.rb
@@ -11,7 +11,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
     end

--- a/lib/mail/fields/content_transfer_encoding_field.rb
+++ b/lib/mail/fields/content_transfer_encoding_field.rb
@@ -13,7 +13,7 @@ module Mail
       self.charset = charset
       value = '7bit' if value.to_s =~ /7-?bits?/i
       value = '8bit' if value.to_s =~ /8-?bits?/i
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
     end

--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -18,7 +18,7 @@ module Mail
         @main_type = nil
         @sub_type = nil
         @parameters = nil
-        value = strip_field(FIELD_NAME, value)
+        value = value.to_s
       end
       value = ensure_filename_quoted(value)
       super(CAPITALIZED_FIELD, value, charset)

--- a/lib/mail/fields/date_field.rb
+++ b/lib/mail/fields/date_field.rb
@@ -37,9 +37,8 @@ module Mail
       if Utilities.blank?(value)
         value = ::DateTime.now.strftime('%a, %d %b %Y %H:%M:%S %z')
       else
-        value = strip_field(FIELD_NAME, value)
-        value.to_s.gsub!(/\(.*?\)/, '')
-        value = ::DateTime.parse(value.to_s.squeeze(" ")).strftime('%a, %d %b %Y %H:%M:%S %z')
+        value = value.to_s.gsub(/\(.*?\)/, '').squeeze(' ')
+        value = ::DateTime.parse(value).strftime('%a, %d %b %Y %H:%M:%S %z')
       end
       super(CAPITALIZED_FIELD, value, charset)
     rescue ArgumentError => e

--- a/lib/mail/fields/from_field.rb
+++ b/lib/mail/fields/from_field.rb
@@ -39,7 +39,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/in_reply_to_field.rb
+++ b/lib/mail/fields/in_reply_to_field.rb
@@ -40,7 +40,7 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       value = value.join("\r\n\s") if value.is_a?(Array)
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
     end

--- a/lib/mail/fields/keywords_field.rb
+++ b/lib/mail/fields/keywords_field.rb
@@ -10,7 +10,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
 

--- a/lib/mail/fields/message_id_field.rb
+++ b/lib/mail/fields/message_id_field.rb
@@ -46,7 +46,7 @@ module Mail
         self.name = CAPITALIZED_FIELD
         self.value = generate_message_id
       else
-        super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+        super(CAPITALIZED_FIELD, value, charset)
       end
       self.parse
       self

--- a/lib/mail/fields/mime_version_field.rb
+++ b/lib/mail/fields/mime_version_field.rb
@@ -14,7 +14,7 @@ module Mail
       if Utilities.blank?(value)
         value = '1.0'
       end
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
 

--- a/lib/mail/fields/optional_field.rb
+++ b/lib/mail/fields/optional_field.rb
@@ -9,6 +9,9 @@ require 'mail/fields/unstructured_field'
 
 module Mail
   class OptionalField < UnstructuredField
-    
+    private
+      def do_encode
+        "#{wrapped_value}\r\n"
+      end
   end
 end

--- a/lib/mail/fields/received_field.rb
+++ b/lib/mail/fields/received_field.rb
@@ -28,7 +28,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
 

--- a/lib/mail/fields/references_field.rb
+++ b/lib/mail/fields/references_field.rb
@@ -40,7 +40,7 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
       value = value.join("\r\n\s") if value.is_a?(Array)
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
     end

--- a/lib/mail/fields/reply_to_field.rb
+++ b/lib/mail/fields/reply_to_field.rb
@@ -39,7 +39,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/resent_bcc_field.rb
+++ b/lib/mail/fields/resent_bcc_field.rb
@@ -39,7 +39,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/resent_cc_field.rb
+++ b/lib/mail/fields/resent_cc_field.rb
@@ -39,7 +39,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/resent_date_field.rb
+++ b/lib/mail/fields/resent_date_field.rb
@@ -17,7 +17,6 @@ module Mail
       if Utilities.blank?(value)
         value = ::DateTime.now.strftime('%a, %d %b %Y %H:%M:%S %z')
       else
-        value = strip_field(FIELD_NAME, value)
         value = ::DateTime.parse(value.to_s).strftime('%a, %d %b %Y %H:%M:%S %z')
       end
       super(CAPITALIZED_FIELD, value, charset)

--- a/lib/mail/fields/resent_from_field.rb
+++ b/lib/mail/fields/resent_from_field.rb
@@ -39,7 +39,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/resent_message_id_field.rb
+++ b/lib/mail/fields/resent_message_id_field.rb
@@ -14,7 +14,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self.parse
       self
     end

--- a/lib/mail/fields/resent_sender_field.rb
+++ b/lib/mail/fields/resent_sender_field.rb
@@ -38,7 +38,7 @@ module Mail
 
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
 

--- a/lib/mail/fields/resent_to_field.rb
+++ b/lib/mail/fields/resent_to_field.rb
@@ -39,7 +39,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/return_path_field.rb
+++ b/lib/mail/fields/return_path_field.rb
@@ -41,7 +41,7 @@ module Mail
     def initialize(value = nil, charset = 'utf-8')
       value = nil if value == '<>'
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/sender_field.rb
+++ b/lib/mail/fields/sender_field.rb
@@ -39,7 +39,7 @@ module Mail
 
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
 

--- a/lib/mail/fields/subject_field.rb
+++ b/lib/mail/fields/subject_field.rb
@@ -10,7 +10,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
     end
     
   end

--- a/lib/mail/fields/to_field.rb
+++ b/lib/mail/fields/to_field.rb
@@ -39,7 +39,7 @@ module Mail
     
     def initialize(value = nil, charset = 'utf-8')
       self.charset = charset
-      super(CAPITALIZED_FIELD, strip_field(FIELD_NAME, value), charset)
+      super(CAPITALIZED_FIELD, value, charset)
       self
     end
     

--- a/lib/mail/fields/unstructured_field.rb
+++ b/lib/mail/fields/unstructured_field.rb
@@ -32,6 +32,12 @@ module Mail
       else
         # Ensure we are dealing with a string
         value = value.to_s
+
+        # Mark UTF-8 strings parsed from ASCII-8BIT
+        if value.respond_to?(:force_encoding) && value.encoding == Encoding::ASCII_8BIT
+          utf8 = value.dup.force_encoding(Encoding::UTF_8)
+          value = utf8 if utf8.valid_encoding?
+        end
       end
 
       if charset
@@ -67,7 +73,11 @@ module Mail
     private
 
     def do_encode
-      value.nil? ? '' : "#{wrapped_value}\r\n"
+      if value && !value.empty?
+        "#{wrapped_value}\r\n"
+      else
+        ''
+      end
     end
 
     def do_decode

--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -93,14 +93,15 @@ module Mail
     #  h.fields = ['From: mikel@me.com', 'To: bob@you.com']
     def fields=(unfolded_fields)
       @fields = Mail::FieldList.new
-      warn "Warning: more than #{self.class.maximum_amount} header fields only using the first #{self.class.maximum_amount}" if unfolded_fields.length > self.class.maximum_amount
+      Kernel.warn "WARNING: More than #{self.class.maximum_amount} header fields; only using the first #{self.class.maximum_amount} and ignoring the rest" if unfolded_fields.length > self.class.maximum_amount
       unfolded_fields[0..(self.class.maximum_amount-1)].each do |field|
 
-        field = Field.new(field, nil, charset)
-        if limited_field?(field.name) && (selected = select_field_for(field.name)) && selected.any? 
-          selected.first.update(field.name, field.value)
-        else
-          @fields << field
+        if field = Field.parse(field, charset)
+          if limited_field?(field.name) && (selected = select_field_for(field.name)) && selected.any?
+            selected.first.update(field.name, field.value)
+          else
+            @fields << field
+          end
         end
       end
 

--- a/spec/mail/field_list_spec.rb
+++ b/spec/mail/field_list_spec.rb
@@ -4,17 +4,17 @@ require 'spec_helper'
 describe Mail::FieldList do
   it "should be able to add new fields" do
     fl = Mail::FieldList.new
-    fl << Mail::Field.new("To: mikel@me.com")
-    fl << Mail::Field.new("From: mikel@me.com")
+    fl << Mail::Field.parse("To: mikel@me.com")
+    fl << Mail::Field.parse("From: mikel@me.com")
     expect(fl.length).to eq 2
   end
   
   it "should be able to add new fields in the right order" do
     fl = Mail::FieldList.new
-    fl << Mail::Field.new("To: mikel@me.com")
-    fl << Mail::Field.new("From: mikel@me.com")
-    fl << Mail::Field.new("Received: from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
-    fl << Mail::Field.new("Return-Path: mikel@me.com")
+    fl << Mail::Field.parse("To: mikel@me.com")
+    fl << Mail::Field.parse("From: mikel@me.com")
+    fl << Mail::Field.parse("Received: from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
+    fl << Mail::Field.parse("Return-Path: mikel@me.com")
     expect(fl[0].field.class).to eq Mail::ReturnPathField
     expect(fl[1].field.class).to eq Mail::ReceivedField
     expect(fl[2].field.class).to eq Mail::FromField
@@ -23,11 +23,11 @@ describe Mail::FieldList do
   
   it "should add new Received items after the existing ones" do
     fl = Mail::FieldList.new
-    fl << Mail::Field.new("To: mikel@me.com")
-    fl << Mail::Field.new("From: mikel@me.com")
-    fl << Mail::Field.new("Received: from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
-    fl << Mail::Field.new("Return-Path: mikel@me.com")
-    fl << Mail::Field.new("Received: from 123.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
+    fl << Mail::Field.parse("To: mikel@me.com")
+    fl << Mail::Field.parse("From: mikel@me.com")
+    fl << Mail::Field.parse("Received: from xxx.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
+    fl << Mail::Field.parse("Return-Path: mikel@me.com")
+    fl << Mail::Field.parse("Received: from 123.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500")
     expect(fl[2].field.value).to eq 'from 123.xxxx.xxx by xxx.xxxx.xxx with ESMTP id 6AAEE3B4D23 for <xxx@xxxx.xxx>; Sun, 8 May 2005 12:30:23 -0500'
   end
   

--- a/spec/mail/fields/bcc_field_spec.rb
+++ b/spec/mail/fields/bcc_field_spec.rb
@@ -27,17 +27,11 @@ describe Mail::BccField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::BccField.new("Bcc: Mikel") }.not_to raise_error
+      expect { Mail::BccField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::BccField.included_modules).to include(Mail::CommonAddress) 
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::BccField.new('Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'Bcc'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/cc_field_spec.rb
+++ b/spec/mail/fields/cc_field_spec.rb
@@ -12,17 +12,11 @@ describe Mail::CcField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::CcField.new("Cc: Mikel") }.not_to raise_error
+      expect { Mail::CcField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
-      expect(Mail::CcField.included_modules).to include(Mail::CommonAddress) 
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::CcField.new('Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'Cc'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
+      expect(Mail::CcField.included_modules).to include(Mail::CommonAddress)
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/comments_field_spec.rb
+++ b/spec/mail/fields/comments_field_spec.rb
@@ -11,12 +11,6 @@ describe Mail::CommentsField do
   end
 
   it "should accept a string with the field name" do
-    t = Mail::CommentsField.new('Comments: this is a comment')
-    expect(t.name).to eq 'Comments'
-    expect(t.value).to eq 'this is a comment'
-  end
-
-  it "should accept a string with the field name" do
     t = Mail::CommentsField.new('this is a comment')
     expect(t.name).to eq 'Comments'
     expect(t.value).to eq 'this is a comment'

--- a/spec/mail/fields/common/common_address_spec.rb
+++ b/spec/mail/fields/common/common_address_spec.rb
@@ -7,51 +7,51 @@ describe "Mail::CommonAddress" do
   describe "address handling" do
 
     it "should give the addresses it is going to" do
-      field = Mail::ToField.new("To: test1@lindsaar.net")
+      field = Mail::ToField.new("test1@lindsaar.net")
       expect(field.addresses.first).to eq "test1@lindsaar.net"
     end
 
     it "should split up the address list into individual addresses" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, test2@lindsaar.net")
+      field = Mail::ToField.new("test1@lindsaar.net, test2@lindsaar.net")
       expect(field.addresses).to eq ["test1@lindsaar.net", "test2@lindsaar.net"]
     end
 
     it "should give the formatted addresses" do
-      field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
+      field = Mail::ToField.new("Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
       expect(field.formatted).to eq ["Mikel <test1@lindsaar.net>", "Bob <test2@lindsaar.net>"]
     end
 
     it "should give the display names" do
-      field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
+      field = Mail::ToField.new("Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
       expect(field.display_names).to eq ["Mikel", "Bob"]
     end
 
     it "should give the actual address objects" do
-      field = Mail::ToField.new("To: Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
+      field = Mail::ToField.new("Mikel <test1@lindsaar.net>, Bob <test2@lindsaar.net>")
       field.addrs.each do |addr|
         expect(addr.class).to eq Mail::Address
       end
     end
 
     it "should handle groups as well" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, group: test2@lindsaar.net, me@lindsaar.net;")
+      field = Mail::ToField.new("test1@lindsaar.net, group: test2@lindsaar.net, me@lindsaar.net;")
       expect(field.addresses).to eq ["test1@lindsaar.net", "test2@lindsaar.net", "me@lindsaar.net"]
     end
 
     it "should provide a list of groups" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
+      field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
       expect(field.group_names).to eq ["My Group"]
     end
 
     it "should provide a list of addresses per group" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
+      field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
       expect(field.groups["My Group"].length).to eq 2
       expect(field.groups["My Group"].first.to_s).to eq 'test2@lindsaar.net'
       expect(field.groups["My Group"].last.to_s).to eq 'me@lindsaar.net'
     end
 
     it "should provide a list of addresses that are just in the groups" do
-      field = Mail::ToField.new("To: test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
+      field = Mail::ToField.new("test1@lindsaar.net, My Group: test2@lindsaar.net, me@lindsaar.net;")
       expect(field.group_addresses).to eq ['test2@lindsaar.net', 'me@lindsaar.net']
     end
 

--- a/spec/mail/fields/common/common_field_spec.rb
+++ b/spec/mail/fields/common/common_field_spec.rb
@@ -70,17 +70,15 @@ describe Mail::CommonField do
 
   end
 
-  context "when including the field name" do
-    it "does not strip out content that looks identitcal to the field name" do
-      field = Mail::SubjectField.new("Subject: Subject: for your approval")
+  describe "with content that looks like the field name" do
+    it "does not strip from start" do
+      field = Mail::SubjectField.new("Subject: for your approval")
       expect(field.decoded).to eq("Subject: for your approval")
     end
-  end
 
-  context "when not including the field name" do
-    it "does not strip out content that looks identitcal to the field name" do
-      field = Mail::SubjectField.new("This is an important subject: here")
-      expect(field.decoded).to eq("This is an important subject: here")
+    it "does not strip from middle" do
+      field = Mail::SubjectField.new("for your approval subject: xyz")
+      expect(field.decoded).to eq("for your approval subject: xyz")
     end
   end
 end

--- a/spec/mail/fields/content_description_field_spec.rb
+++ b/spec/mail/fields/content_description_field_spec.rb
@@ -20,13 +20,7 @@ describe Mail::ContentDescriptionField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ContentDescriptionField.new("Content-Description: This is a description") }.not_to raise_error
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::ContentDescriptionField.new('Content-Description: This is a description')
-      expect(t.name).to eq 'Content-Description'
-      expect(t.value).to eq 'This is a description'
+      expect { Mail::ContentDescriptionField.new("This is a description") }.not_to raise_error
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -10,12 +10,6 @@ describe Mail::ContentDispositionField do
       expect { Mail::ContentDispositionField.new("attachment; filename=File") }.not_to raise_error
     end
 
-    it "should accept a string with the field name" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
-      expect(c.name).to eq 'Content-Disposition'
-      expect(c.value).to eq 'attachment; filename=File'
-    end
-
     it "should accept a string without the field name" do
       c = Mail::ContentDispositionField.new('attachment; filename=File')
       expect(c.name).to eq 'Content-Disposition'
@@ -29,54 +23,54 @@ describe Mail::ContentDispositionField do
     end
 
     it "should render encoded" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
+      c = Mail::ContentDispositionField.new('attachment; filename=File')
       expect(c.encoded).to eq "Content-Disposition: attachment;\r\n\sfilename=File\r\n"
     end
 
     it "should render encoded for inline" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: inline')
+      c = Mail::ContentDispositionField.new('inline')
       expect(c.encoded).to eq "Content-Disposition: inline\r\n"
     end
 
     it "should wrap a filename in double quotation marks only if the filename contains spaces and does not already have double quotation marks" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=This is a bad filename.txt')
+      c = Mail::ContentDispositionField.new('attachment; filename=This is a bad filename.txt')
       expect(c.value).to eq 'attachment; filename="This is a bad filename.txt"'
 
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=some.jpg')
+      c = Mail::ContentDispositionField.new('attachment; filename=some.jpg')
       expect(c.value).to eq 'attachment; filename=some.jpg'
 
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename="Bad filename but at least it is wrapped in quotes.txt"')
+      c = Mail::ContentDispositionField.new('attachment; filename="Bad filename but at least it is wrapped in quotes.txt"')
       expect(c.value).to eq 'attachment; filename="Bad filename but at least it is wrapped in quotes.txt"'
     end
 
     it "should render decoded" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
+      c = Mail::ContentDispositionField.new('attachment; filename=File')
       expect(c.decoded).to eq 'attachment; filename=File'
     end
 
     it "should render decoded inline" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: inline')
+      c = Mail::ContentDispositionField.new('inline')
       expect(c.decoded).to eq 'inline'
     end
 
     it "should handle upper and mixed case INLINE and AttachMent" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: INLINE')
+      c = Mail::ContentDispositionField.new('INLINE')
       expect(c.decoded).to eq 'inline'
-      c = Mail::ContentDispositionField.new('Content-Disposition: AttachMent')
+      c = Mail::ContentDispositionField.new('AttachMent')
       expect(c.decoded).to eq 'attachment'
     end
   end
 
   describe "instance methods" do
     it "should give its disposition type" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: attachment; filename=File')
+      c = Mail::ContentDispositionField.new('attachment; filename=File')
       expect(c.disposition_type).to eq 'attachment'
       expect(c.parameters).to eql({"filename" => 'File'})
     end
 
     # see spec/fixtures/trec_2005_corpus/missing_content_disposition.eml
     it "should accept a blank disposition type" do
-      c = Mail::ContentDispositionField.new('Content-Disposition: ')
+      c = Mail::ContentDispositionField.new('')
       expect(c.disposition_type).not_to be_nil
     end
 
@@ -89,29 +83,29 @@ describe Mail::ContentDispositionField do
 
   describe "finding a filename" do
     it "should locate a filename if there is a filename" do
-      string = %q{Content-Disposition: attachment; filename=mikel.jpg}
+      string = %q{attachment; filename=mikel.jpg}
       c = Mail::ContentDispositionField.new(string)
       expect(c.filename).to eq 'mikel.jpg'
     end
 
     it "should locate a name if there is no filename" do
-      string = %q{Content-Disposition: attachment; name=mikel.jpg}
+      string = %q{attachment; name=mikel.jpg}
       c = Mail::ContentDispositionField.new(string)
       expect(c.filename).to eq 'mikel.jpg'
     end
 
     it "should return an empty string when filename or name is empty" do
-      string = %q{Content-Disposition: attachment; filename=""}
+      string = %q{attachment; filename=""}
       c = Mail::ContentDispositionField.new(string)
       expect(c.filename).to eq ''
 
-      string = %q{Content-Disposition: attachment; name=""}
+      string = %q{attachment; name=""}
       c = Mail::ContentDispositionField.new(string)
       expect(c.filename).to eq ''
     end
 
     it "should locate an encoded name as a filename" do
-      string = %q(Content-Disposition: attachment; name*=ISO-8859-1''Eelanal%FC%FCsi%20p%E4ring.jpg)
+      string = %q(attachment; name*=ISO-8859-1''Eelanal%FC%FCsi%20p%E4ring.jpg)
       c = Mail::ContentDispositionField.new(string)
       expect(c.filename).to eq "Eelanalüüsi päring.jpg"
     end

--- a/spec/mail/fields/content_id_field_spec.rb
+++ b/spec/mail/fields/content_id_field_spec.rb
@@ -34,13 +34,6 @@ describe Mail::ContentIdField do
       expect { Mail::ContentIdField.new("<1234@test.lindsaar.net>") }.not_to raise_error
     end
 
-    it "should accept a string with the field name" do
-      c = Mail::ContentIdField.new('Content-ID: <1234@test.lindsaar.net>')
-      expect(c.name).to eq 'Content-ID'
-      expect(c.value).to eq '<1234@test.lindsaar.net>'
-      expect(c.content_id).to eq '1234@test.lindsaar.net'
-    end
-
     it "should accept a string without the field name" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
       expect(m.name).to eq 'Content-ID'

--- a/spec/mail/fields/content_location_field_spec.rb
+++ b/spec/mail/fields/content_location_field_spec.rb
@@ -11,12 +11,6 @@ describe Mail::ContentLocationField do
       expect { Mail::ContentLocationField.new("Content-Location", "7bit") }.not_to raise_error
     end
 
-    it "should accept a string with the field name" do
-      t = Mail::ContentLocationField.new('Content-Location: photo.jpg')
-      expect(t.name).to eq 'Content-Location'
-      expect(t.value).to eq 'photo.jpg'
-    end
-
     it "should accept a string without the field name" do
       t = Mail::ContentLocationField.new('photo.jpg')
       expect(t.name).to eq 'Content-Location'

--- a/spec/mail/fields/content_transfer_encoding_field_spec.rb
+++ b/spec/mail/fields/content_transfer_encoding_field_spec.rb
@@ -41,13 +41,7 @@ describe Mail::ContentTransferEncodingField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ContentTransferEncodingField.new("Content-Transfer-Encoding: 7bit") }.not_to raise_error
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::ContentTransferEncodingField.new('Content-Transfer-Encoding: 7bit')
-      expect(t.name).to eq 'Content-Transfer-Encoding'
-      expect(t.value).to eq '7bit'
+      expect { Mail::ContentTransferEncodingField.new("7bit") }.not_to raise_error
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -75,12 +75,6 @@ describe Mail::ContentTypeField do
       expect { Mail::ContentTypeField.new("<1234@test.lindsaar.net>") }.not_to raise_error
     end
 
-    it "should accept a string with the field name" do
-      c = Mail::ContentTypeField.new('Content-Type: text/plain')
-      expect(c.name).to eq 'Content-Type'
-      expect(c.value).to eq 'text/plain'
-    end
-
     it "should accept a string without the field name" do
       c = Mail::ContentTypeField.new('text/plain')
       expect(c.name).to eq 'Content-Type'
@@ -94,7 +88,7 @@ describe Mail::ContentTypeField do
     end
 
     it "should render encoded" do
-      c = Mail::ContentTypeField.new('Content-Type: text/plain')
+      c = Mail::ContentTypeField.new('text/plain')
       expect(c.encoded).to eq "Content-Type: text/plain\r\n"
     end
 
@@ -674,12 +668,12 @@ describe Mail::ContentTypeField do
   describe "handling badly formated content-type fields" do
 
     it "should handle missing sub-type on a text content type" do
-      c = Mail::ContentTypeField.new('Content-Type: text')
+      c = Mail::ContentTypeField.new('text')
       expect(c.content_type).to eq 'text/plain'
     end
 
     it "should handle missing ; after content-type" do
-      c = Mail::ContentTypeField.new('Content-Type: multipart/mixed boundary="----=_NextPart_000_000F_01C17754.8C3CAF30"')
+      c = Mail::ContentTypeField.new('multipart/mixed boundary="----=_NextPart_000_000F_01C17754.8C3CAF30"')
       expect(c.content_type).to eq 'multipart/mixed'
       expect(c.parameters['boundary']).to eq '----=_NextPart_000_000F_01C17754.8C3CAF30'
     end

--- a/spec/mail/fields/date_field_spec.rb
+++ b/spec/mail/fields/date_field_spec.rb
@@ -35,13 +35,6 @@ describe Mail::DateField do
       expect(Mail::DateField.included_modules).to include(Mail::CommonDate) 
     end
 
-    it "should accept a string with the field name" do
-      t = Mail::DateField.new('Date: 12 Aug 2009 00:00:02 GMT')
-      expect(t.name).to eq 'Date'
-      expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
-      expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
-    end
-
     it "should accept a string without the field name" do
       t = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')
       expect(t.name).to eq 'Date'

--- a/spec/mail/fields/from_field_spec.rb
+++ b/spec/mail/fields/from_field_spec.rb
@@ -10,17 +10,11 @@ describe Mail::FromField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::FromField.new("From: Mikel") }.not_to raise_error
+      expect { Mail::FromField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::FromField.included_modules).to include(Mail::CommonAddress)
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::FromField.new('From: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'From'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/in_reply_to_field_spec.rb
+++ b/spec/mail/fields/in_reply_to_field_spec.rb
@@ -17,13 +17,6 @@ describe Mail::InReplyToField do
       expect { Mail::InReplyToField.new("<1234@test.lindsaar.net>") }.not_to raise_error
     end
 
-    it "should accept a string with the field name" do
-      t = Mail::InReplyToField.new('In-Reply-To: <1234@test.lindsaar.net>')
-      expect(t.name).to eq 'In-Reply-To'
-      expect(t.value).to eq '<1234@test.lindsaar.net>'
-      expect(t.message_id).to eq '1234@test.lindsaar.net'
-    end
-
     it "should accept a string without the field name" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
       expect(t.name).to eq 'In-Reply-To'

--- a/spec/mail/fields/keywords_field_spec.rb
+++ b/spec/mail/fields/keywords_field_spec.rb
@@ -10,13 +10,7 @@ describe Mail::KeywordsField do
       expect { Mail::KeywordsField.new("this, is, email") }.not_to raise_error
     end
     
-    it "should accept a string with the field name" do
-      k = Mail::KeywordsField.new('Keywords: these are keywords, so there')
-      expect(k.name).to eq 'Keywords'
-      expect(k.value).to eq 'these are keywords, so there'
-    end
-    
-    it "should accept a string with the field name" do
+    it "should accept a string without the field name" do
       k = Mail::KeywordsField.new('these are keywords, so there')
       expect(k.name).to eq 'Keywords'
       expect(k.value).to eq 'these are keywords, so there'

--- a/spec/mail/fields/message_id_field_spec.rb
+++ b/spec/mail/fields/message_id_field_spec.rb
@@ -61,13 +61,6 @@ describe Mail::MessageIdField do
       expect { Mail::MessageIdField.new("<1234@test.lindsaar.net>") }.not_to raise_error
     end
 
-    it "should accept a string with the field name" do
-      m = Mail::MessageIdField.new('Message-ID: <1234@test.lindsaar.net>')
-      expect(m.name).to eq 'Message-ID'
-      expect(m.value).to eq '<1234@test.lindsaar.net>'
-      expect(m.message_id).to eq '1234@test.lindsaar.net'
-    end
-
     it "should accept a string without the field name" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
       expect(m.name).to eq 'Message-ID'

--- a/spec/mail/fields/mime_version_field_spec.rb
+++ b/spec/mail/fields/mime_version_field_spec.rb
@@ -87,12 +87,6 @@ describe Mail::MimeVersionField do
       expect { Mail::MimeVersionField.new("1.0") }.not_to raise_error
     end
 
-    it "should accept a string with the field name" do
-      t = Mail::MimeVersionField.new('Mime-Version: 1.0')
-      expect(t.name).to eq 'Mime-Version'
-      expect(t.value).to eq '1.0'
-    end
-
     it "should accept a string without the field name" do
       t = Mail::MimeVersionField.new('1.0')
       expect(t.name).to eq 'Mime-Version'

--- a/spec/mail/fields/received_field_spec.rb
+++ b/spec/mail/fields/received_field_spec.rb
@@ -5,21 +5,13 @@ require 'spec_helper'
 describe Mail::ReceivedField do
 
   it "should initialize" do
-    expect { Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)") }.not_to raise_error
+    expect { Mail::ReceivedField.new("from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)") }.not_to raise_error
   end
 
   it "should be able to tell the time" do
-    expect(Mail::ReceivedField.new("Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)").date_time.class).to eq DateTime
+    expect(Mail::ReceivedField.new("from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)").date_time.class).to eq DateTime
   end
 
-  it "should accept a string with the field name" do
-    t = Mail::ReceivedField.new('Received: from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
-    expect(t.name).to eq 'Received'
-    expect(t.value).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)'
-    expect(t.info).to eq 'from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>'
-    expect(t.date_time).to eq ::DateTime.parse('10 May 2005 17:26:50 +0000 (GMT)')
-  end
-  
   it "should accept a string without the field name" do
     t = Mail::ReceivedField.new('from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)')
     expect(t.name).to eq 'Received'

--- a/spec/mail/fields/references_field_spec.rb
+++ b/spec/mail/fields/references_field_spec.rb
@@ -19,13 +19,6 @@ describe Mail::ReferencesField do
     expect { Mail::ReferencesField.new("<1234@test.lindsaar.net>") }.not_to raise_error
   end
 
-  it "should accept a string with the field name" do
-    t = Mail::ReferencesField.new('References: <1234@test.lindsaar.net>')
-    expect(t.name).to eq 'References'
-    expect(t.value).to eq '<1234@test.lindsaar.net>'
-    expect(t.message_id).to eq '1234@test.lindsaar.net'
-  end
-  
   it "should accept a string without the field name" do
     t = Mail::ReferencesField.new('<1234@test.lindsaar.net>')
     expect(t.name).to eq 'References'

--- a/spec/mail/fields/reply_to_field_spec.rb
+++ b/spec/mail/fields/reply_to_field_spec.rb
@@ -10,17 +10,11 @@ describe Mail::ReplyToField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ReplyToField.new("Reply-To: Mikel") }.not_to raise_error
+      expect { Mail::ReplyToField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::ReplyToField.included_modules).to include(Mail::CommonAddress) 
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::ReplyToField.new('Reply-To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'Reply-To'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/resent_bcc_field_spec.rb
+++ b/spec/mail/fields/resent_bcc_field_spec.rb
@@ -9,17 +9,11 @@ describe Mail::ResentBccField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentBccField.new("Resent-Bcc: Mikel") }.not_to raise_error
+      expect { Mail::ResentBccField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::ResentBccField.included_modules).to include(Mail::CommonAddress) 
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::ResentBccField.new('Resent-Bcc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'Resent-Bcc'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/resent_cc_field_spec.rb
+++ b/spec/mail/fields/resent_cc_field_spec.rb
@@ -9,17 +9,11 @@ describe Mail::ResentCcField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentCcField.new("Resent-Cc: Mikel") }.not_to raise_error
+      expect { Mail::ResentCcField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::ResentCcField.included_modules).to include(Mail::CommonAddress) 
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::ResentCcField.new('Resent-Cc: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'Resent-Cc'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/resent_date_field_spec.rb
+++ b/spec/mail/fields/resent_date_field_spec.rb
@@ -15,13 +15,6 @@ describe Mail::ResentDateField do
     expect(Mail::ResentDateField.included_modules).to include(Mail::CommonDate) 
   end
 
-  it "should accept a string with the field name" do
-    t = Mail::ResentDateField.new('Resent-Date: 12 Aug 2009 00:00:02 GMT')
-    expect(t.name).to eq 'Resent-Date'
-    expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
-    expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
-  end
-  
   it "should accept a string without the field name" do
     t = Mail::ResentDateField.new('12 Aug 2009 00:00:02 GMT')
     expect(t.name).to eq 'Resent-Date'

--- a/spec/mail/fields/resent_from_field_spec.rb
+++ b/spec/mail/fields/resent_from_field_spec.rb
@@ -9,17 +9,11 @@ describe Mail::ResentFromField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentFromField.new("Resent-From: Mikel") }.not_to raise_error
+      expect { Mail::ResentFromField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::ResentFromField.included_modules).to include(Mail::CommonAddress) 
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::ResentFromField.new('Resent-From: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'Resent-From'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/resent_message_id_field_spec.rb
+++ b/spec/mail/fields/resent_message_id_field_spec.rb
@@ -8,13 +8,6 @@ describe Mail::ResentMessageIdField do
     expect { Mail::ResentMessageIdField.new("<1234@test.lindsaar.net>") }.not_to raise_error
   end
 
-  it "should accept a string with the field name" do
-    t = Mail::ResentMessageIdField.new('Resent-Message-ID: <1234@test.lindsaar.net>')
-    expect(t.name).to eq 'Resent-Message-ID'
-    expect(t.value).to eq '<1234@test.lindsaar.net>'
-    expect(t.message_id).to eq '1234@test.lindsaar.net'
-  end
-  
   it "should accept a string without the field name" do
     t = Mail::ResentMessageIdField.new('<1234@test.lindsaar.net>')
     expect(t.name).to eq 'Resent-Message-ID'

--- a/spec/mail/fields/resent_sender_field_spec.rb
+++ b/spec/mail/fields/resent_sender_field_spec.rb
@@ -9,17 +9,11 @@ describe Mail::ResentSenderField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentSenderField.new("Resent-Sender: Mikel") }.not_to raise_error
+      expect { Mail::ResentSenderField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::ResentSenderField.included_modules).to include(Mail::CommonAddress) 
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::ResentSenderField.new('Resent-Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'Resent-Sender'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/resent_to_field_spec.rb
+++ b/spec/mail/fields/resent_to_field_spec.rb
@@ -9,17 +9,11 @@ describe Mail::ResentToField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::ResentToField.new("Resent-To: Mikel") }.not_to raise_error
+      expect { Mail::ResentToField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::ResentToField.included_modules).to include(Mail::CommonAddress) 
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::ResentToField.new('Resent-To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'Resent-To'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
     end
 
     it "should accept a string without the field name" do

--- a/spec/mail/fields/return_path_field_spec.rb
+++ b/spec/mail/fields/return_path_field_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 
 describe Mail::ReturnPathField do
   it "should allow you to specify a field" do
-    rp = Mail::ReturnPathField.new('Return-Path: mikel@test.lindsaar.net')
+    rp = Mail::ReturnPathField.new('mikel@test.lindsaar.net')
     expect(rp.address).to eq 'mikel@test.lindsaar.net'
   end
   
   it "should encode the addr_spec in <>" do
-    rp = Mail::ReturnPathField.new('Return-Path: mikel@test.lindsaar.net')
+    rp = Mail::ReturnPathField.new('mikel@test.lindsaar.net')
     expect(rp.encoded).to eq "Return-Path: <mikel@test.lindsaar.net>\r\n"
   end
 

--- a/spec/mail/fields/sender_field_spec.rb
+++ b/spec/mail/fields/sender_field_spec.rb
@@ -9,17 +9,11 @@ describe Mail::SenderField do
   describe "initialization" do
 
     it "should initialize" do
-      expect { Mail::SenderField.new("Sender: Mikel") }.not_to raise_error
+      expect { Mail::SenderField.new("Mikel") }.not_to raise_error
     end
 
     it "should mix in the CommonAddress module" do
       expect(Mail::SenderField.included_modules).to include(Mail::CommonAddress)
-    end
-
-    it "should accept a string with the field name" do
-      t = Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>')
-      expect(t.name).to eq 'Sender'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>'
     end
 
     it "should accept a string without the field name" do
@@ -30,7 +24,7 @@ describe Mail::SenderField do
 
     it "should reject headers with multiple mailboxes" do
       pending 'Sender accepts an address list now, but should only accept a single address'
-      expect { Mail::SenderField.new('Sender: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>') }.to raise_error(Mail::Field::ParseError)
+      expect { Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>') }.to raise_error(Mail::Field::ParseError)
     end
   end
 

--- a/spec/mail/fields/to_field_spec.rb
+++ b/spec/mail/fields/to_field_spec.rb
@@ -17,12 +17,6 @@ describe Mail::ToField do
       expect(Mail::ToField.included_modules).to include(Mail::CommonAddress) 
     end
 
-    it "should accept a string with the field name" do
-      t = Mail::ToField.new('To: Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
-      expect(t.name).to eq 'To'
-      expect(t.value).to eq 'Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>'
-    end
-
     it "should accept a string without the field name" do
       t = Mail::ToField.new('Mikel Lindsaar <mikel@test.lindsaar.net>, "Bob Smith" <bob@me.com>')
       expect(t.name).to eq 'To'

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -76,7 +76,7 @@ describe Mail::UnstructuredField do
     end
 
     it "should just add the CRLF at the end of the line" do
-      @field = Mail::SubjectField.new("Subject: =?utf-8?Q?testing_testing_=D6=A4?=")
+      @field = Mail::SubjectField.new("=?utf-8?Q?testing_testing_=D6=A4?=")
       result = "Subject: =?UTF-8?Q?testing_testing_=D6=A4?=\r\n"
       expect(@field.encoded).to eq result
       expect(@field.decoded).to eq "testing testing \326\244"

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -647,18 +647,16 @@ TRACEHEADER
     end
 
     it "should limit amount of parsed headers" do
-      old_maximum_amount = Mail::Header.maximum_amount
+      Mail::Header.maximum_amount, old_max = 10, Mail::Header.maximum_amount
+      $VERBOSE, old_verbose = nil, $VERBOSE
+
       begin
-        Mail::Header.maximum_amount = 10
-        begin
-          $VERBOSE, old_verbose = nil, $VERBOSE
-          header = Mail::Header.new("X-SubscriberID: 345\n" * 11)
-          expect(header.fields.size).to eq(10)
-        ensure
-          $VERBOSE = old_verbose
-        end
+        expect(Kernel).to receive(:warn).with(match(/10 header fields/))
+        header = Mail::Header.new("X-SubscriberID: 345\n" * 11)
+        expect(header.fields.size).to eq(10)
       ensure
-        Mail::Header.maximum_amount = old_maximum_amount
+        $VERBOSE = old_verbose
+        Mail::Header.maximum_amount = old_max
       end
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -121,7 +121,7 @@ describe Mail::Message do
     it "should be able to parse every email example we have without raising an exception" do
       emails = Dir.glob( fixture('emails/**/*') ).delete_if { |f| File.directory?(f) }
 
-      allow($stderr).to receive(:puts) # Don't want to get noisy about any warnings
+      allow(Kernel).to receive(:warn) # Don't want to get noisy about any warnings
       errors = false
       expected_failures = []
       emails.each do |email|
@@ -153,7 +153,7 @@ describe Mail::Message do
     end
 
     it "should raise a warning (and keep parsing) on having an incorrectly formatted header" do
-      expect($stderr).to receive(:puts).with("WARNING: Could not parse (and so ignoring) 'quite Delivered-To: xxx@xxx.xxx'")
+      expect(Kernel).to receive(:warn).with('WARNING: Ignoring unparsable header "quite Delivered-To: xxx@xxx.xxx": invalid header name syntax: "quite Delivered-To"').once
       Mail.read(fixture('emails', 'plain_emails', 'raw_email_incorrect_header.eml')).to_s
     end
 


### PR DESCRIPTION
Fixes mail with a legit "Subject: subject: foo" header. We'd split that
into a subject field with a "subject: foo" value. When we instantiate
the SubjectField and pass that value, we'd strip the leading "subject: "
from it again! So we'd end up with a "foo" subject.

This fixes the issue at the cost of some obscure backward compatibility.

1. If you instantiate internal header fields directly, bypassing
Mail::Field, then using them to parse raw headers will now fail.
This will now be treated as a literal value:
```ruby
    Mail::ToField.new('To: foo@example.com')
    # => Mail::Field::IncompleteParseError: Mail::AddressList can not parse |To: foo@example.com|: Only able to parse up to "To: foo@example.com"
```
Instead, use Mail::Field.parse:
```ruby
    Mail::Field.parse('To: foo@example.com')
    # => #<Mail::ToField …>
```
2. If you parse fields by instantiating Mail::Field.new with a raw header,
it'll now warn you with a deprecation error. That behavior will go away in
Mail 2.8.0.
```ruby
    Mail::Field.new('To: foo@example.com')
    WARNING: Passing an unparsed header field to Mail::Field.new is deprecated and will be removed in Mail 2.8.0. Use Mail::Field.parse instead.
    # => #<Mail::Field 0x7fa401026910 @charset="utf-8" @name="To" @value="foo">
```
Instead, use Mail::Field.parse:
```ruby
    Mail::Field.parse('To: foo@example.com')
    # => #<Mail::ToField …>
```
Thanks to @grosser for #766 ❤️