### PR TITLE
String encodings: pragmatic support for Windows-1258 charset

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -30,6 +30,7 @@ Compatibility:
 * #982 – Faithfully preserve unfolded whitespace rather than collapsing to a single space. (jeremy)
 * #1103 – Support parsing UTF-8 headers. Implements RFC 6532. (jeremy)
 * #1106 – Limit message/rfc822 parts' transfer encoding per RFC 2046. (ahorek)
+* #1112 – Support Windows-1258 charset by parsing it as Windows-1252 in Ruby. (jeremy)
 
 Bugs:
 * #539 - Fix that whitespace-only continued headers would be incorrectly parsed as the break between headers and body. (ConradIrwin)

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -42,7 +42,7 @@ module Mail
     class << self
       attr_accessor :charset_encoder
     end
-    self.charset_encoder = StrictCharsetEncoder.new
+    self.charset_encoder = BestEffortCharsetEncoder.new
 
     # Escapes any parenthesis in a string that are unescaped this uses
     # a Ruby 1.9.1 regexp feature of negative look behind


### PR DESCRIPTION
Use "best effort" charset mapper by default instead of "strict,"
allowing us to parse:
* Windows-1258 charset as Windows-1252 Ruby string encoding
* ansi_x3.110-1983 charset as ISO-8859-1 Ruby string encoding

True Windows-1258 handling is pending upstream Ruby support:
https://bugs.ruby-lang.org/issues/7742