### PR TITLE
Setting `mail.body = …` on a multipart message now adds a new text part instead of adding a raw MIME part

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -33,6 +33,7 @@ Compatibility:
 * #1103 – Support parsing UTF-8 headers. Implements RFC 6532. (jeremy)
 * #1106 – Limit message/rfc822 parts' transfer encoding per RFC 2046. (ahorek)
 * #1112 – Support Windows-1258 charset by parsing it as Windows-1252 in Ruby. (jeremy)
+* #1114 – Setting `mail.body = …` on a multipart message now adds a new text part instead of adding a raw MIME part. (jeremy)
 
 Bugs:
 * #539 - Fix that whitespace-only continued headers would be incorrectly parsed as the break between headers and body. (ConradIrwin)

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1258,7 +1258,6 @@ module Mail
     def body(value = nil)
       if value
         self.body = value
-#        add_encoding_to_body
       else
         process_body_raw if @body_raw
         @body
@@ -2025,11 +2024,9 @@ module Mail
         @body_raw = nil
         add_encoding_to_body
       when @body && @body.multipart?
-        @body << Mail::Part.new(value)
-        add_encoding_to_body
+        self.text_part = value
       else
         @body_raw = value
-#        process_body_raw
       end
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1724,6 +1724,18 @@ describe Mail::Message do
   end
 
   describe "nested parts" do
+    it "adds a new text part when assigning the body on an already-multipart message" do
+      mail = Mail.new do
+        part :content_type => 'foo/bar', :body => 'baz'
+      end
+
+      mail.body 'this: body is not a header'
+
+      expect(mail.parts.size).to eq(2)
+      expect(mail.text_part).not_to be_nil
+      expect(mail.text_part.decoded).to eq('this: body is not a header')
+    end
+
     it "should provide a way to instantiate a new part as you go down" do
       mail = Mail.new do
         to           'mikel@test.lindsaar.net'


### PR DESCRIPTION
Fixes super-confusing API usage where you add an attachment, then set
the body text, and end up parsing the body text as if it were a raw MIME
part.

Fixes #811. Thanks to @Venousek for diagnosis!