### PR TITLE
Allow overriding default Net::POP3 read_timeout value

### DIFF
--- a/lib/mail/network/retriever_methods/pop3.rb
+++ b/lib/mail/network/retriever_methods/pop3.rb
@@ -41,7 +41,8 @@ module Mail
                         :user_name            => nil,
                         :password             => nil,
                         :authentication       => nil,
-                        :enable_ssl           => false }.merge!(values)
+                        :enable_ssl           => false,
+                        :read_timeout         => nil }.merge!(values)
     end
     
     attr_accessor :settings
@@ -128,6 +129,7 @@ module Mail
     
       pop3 = Net::POP3.new(settings[:address], settings[:port], false)
       pop3.enable_ssl(OpenSSL::SSL::VERIFY_NONE) if settings[:enable_ssl]
+      pop3.read_timeout = settings[:read_timeout] if settings[:read_timeout]
       pop3.start(settings[:user_name], settings[:password])
     
       yield pop3

--- a/spec/mail/network/retriever_methods/pop3_spec.rb
+++ b/spec/mail/network/retriever_methods/pop3_spec.rb
@@ -217,4 +217,23 @@ describe "POP3 Retriever" do
 
   end
 
+  describe "read_timeout option" do
+
+    it "should override the POP3 default read_timeout" do
+      Mail.defaults do
+        retriever_method :pop3, { :address             => "localhost",
+                                  :port                => 995,
+                                  :user_name           => nil,
+                                  :password            => nil,
+                                  :enable_ssl          => true,
+                                  :read_timeout        => 200 }
+      end
+
+      Mail.retriever_method.send(:start) do |pop3|
+        expect(pop3.read_timeout).to eq 200
+      end
+    end
+
+  end
+
 end

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -67,7 +67,8 @@ describe "Mail" do
                                                  :user_name            => nil,
                                                  :password             => nil,
                                                  :authentication       => nil,
-                                                 :enable_ssl           => true  })
+                                                 :enable_ssl           => true,
+                                                 :read_timeout         => nil })
     end
 
     it "should allow us to overwrite anything we need on SMTP" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -168,6 +168,8 @@ end
 class MockPOP3
   @@start = false
 
+  attr_accessor :read_timeout
+
   def initialize
     @@popmails = []
     20.times do |i|


### PR DESCRIPTION
**Problem:** Net::POP3 uses a default `read_timeout` of 60 seconds which can be overridden using [read_timeout=](http://ruby-doc.org/stdlib-2.0.0/libdoc/net/pop/rdoc/Net/POP3.html#method-i-read_timeout-3D) method. On an application I work we deal with mailboxes having a large volume of emails and large attachments. Sometimes, depending on the traffic we may get a `Net::ReadTimeout` error when hitting the 60 seconds limit.

This PR allows specifying the `read_timeout` configuration for Net::POP3 by passing in the `:read_timeout` configuration when specifying the retriever.

```ruby
Mail.defaults do
  retriever_method :pop3, { 
    :address             => "localhost",
    :port                => 995,
    :user_name           => "username",
    :password            => "Secret!",
    :enable_ssl          => true,
    :read_timeout        => 200 }
end
```

Regarding the spec, I used `send` to invoke a private method. I saw it being used for some other specs so I figured it could be fine. Is there a better way to test this or it's already good?

Thank you,
Fabio