### PR TITLE
Cache the expensive only_us_ascii? check

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -269,7 +269,8 @@ module Mail
     end
 
     def only_us_ascii?
-      !(raw_source =~ /[^\x01-\x7f]/)
+      return @only_us_ascii if defined?(@only_us_ascii)
+      @only_us_ascii = !(raw_source =~ /[^\x01-\x7f]/)
     end
     
     def empty?


### PR DESCRIPTION
Is this safe to do?

In my benchmarks I'm seeing from 15-20% speed improvement when building emails with a 40KB html part and 30-40% speed improvement when building emails with large attachments.