### PR TITLE
Cleanup Mail::Exim spec and fix Mail::Sendmail/Mail::Exim ~ escaping

### DIFF
--- a/lib/mail/network/delivery_methods/sendmail.rb
+++ b/lib/mail/network/delivery_methods/sendmail.rb
@@ -77,15 +77,18 @@ module Mail
     end
 
     # The following is an adaptation of ruby 1.9.2's shellwords.rb file,
-    # it is modified to include '+' in the allowed list to allow for
-    # sendmail to accept email addresses as the sender with a + in them.
+    # with the following modifications:
+    #
+    # - Wraps in double quotes
+    # - Allows '+' to accept email addresses with them
+    # - Allows '~' as it is not unescaped in double quotes
     def self.shellquote(address)
       # Process as a single byte sequence because not all shell
       # implementations are multibyte aware.
       #
       # A LF cannot be escaped with a backslash because a backslash + LF
       # combo is regarded as line continuation and simply ignored. Strip it.
-      escaped = address.gsub(/([^A-Za-z0-9_\s\+\-.,:\/@])/n, "\\\\\\1").gsub("\n", '')
+      escaped = address.gsub(/([^A-Za-z0-9_\s\+\-.,:\/@~])/n, "\\\\\\1").gsub("\n", '')
       %("#{escaped}")
     end
   end

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -89,7 +89,7 @@ describe "exim delivery agent" do
     mail.deliver!
   end
 
-  it "should not raise errors if no sender is defined" do
+  it "should raise an error if no sender is defined" do
     mail.from = nil
 
     expect(mail.smtp_envelope_from).to be_nil

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -57,6 +57,18 @@ describe "exim delivery agent" do
 
       mail.deliver
     end
+
+    it 'should not escape ~ in return path address' do
+      mail.from = 'tilde~@test.lindsaar.net'
+
+      expect(Mail::Sendmail).to receive(:call).
+        with('/usr/sbin/exim',
+             '-i -t -f "tilde~@test.lindsaar.net" --',
+             nil,
+             mail.encoded)
+
+      mail.deliver
+    end
   end
 
   it "should still send an email if the settings have been set to nil" do

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -4,24 +4,13 @@ require 'spec_helper'
 
 describe "exim delivery agent" do
   
-  before(:each) do
-    # Reset all defaults back to original state
+  before do
     Mail.defaults do
-      delivery_method :smtp, { :address              => "localhost",
-                               :port                 => 25,
-                               :domain               => 'localhost.localdomain',
-                               :user_name            => nil,
-                               :password             => nil,
-                               :authentication       => nil,
-                               :enable_starttls_auto => true  }
+      delivery_method :exim
     end
   end
 
   it "should send an email using exim" do
-    Mail.defaults do
-      delivery_method :exim
-    end
-    
     mail = Mail.new do
       from    'roger@test.lindsaar.net'
       to      'marcel@test.lindsaar.net, bob@test.lindsaar.net'
@@ -36,10 +25,6 @@ describe "exim delivery agent" do
   describe "return path" do
 
     it "should send an email with a return-path using exim" do
-      Mail.defaults do
-        delivery_method :exim
-      end
-
       mail = Mail.new do
         to "to@test.lindsaar.net"
         from "from@test.lindsaar.net"
@@ -56,10 +41,6 @@ describe "exim delivery agent" do
     end
 
     it "should use the sender address is no return path is specified" do
-      Mail.defaults do
-        delivery_method :exim
-      end
-
       mail = Mail.new do
         to "to@test.lindsaar.net"
         from "from@test.lindsaar.net"
@@ -75,10 +56,6 @@ describe "exim delivery agent" do
     end
 
     it "should use the from address is no return path or sender are specified" do
-      Mail.defaults do
-        delivery_method :exim
-      end
-
       mail = Mail.new do
         to "to@test.lindsaar.net"
         from "from@test.lindsaar.net"
@@ -93,10 +70,6 @@ describe "exim delivery agent" do
     end
 
     it "should escape the return path address" do
-      Mail.defaults do
-        delivery_method :exim
-      end
-
       mail = Mail.new do
         to 'to@test.lindsaar.net'
         from '"from+suffix test"@test.lindsaar.net'
@@ -111,10 +84,6 @@ describe "exim delivery agent" do
     end
 
     it "should quote the destinations to ensure leading -hyphen doesn't confuse exim" do
-      Mail.defaults do
-        delivery_method :exim
-      end
-
       mail = Mail.new do
         to '-hyphen@test.lindsaar.net'
         from 'from@test.lindsaar.net'
@@ -143,10 +112,6 @@ describe "exim delivery agent" do
   end
 
   it "should escape evil haxxor attemptes" do
-    Mail.defaults do
-      delivery_method :exim, :arguments => nil
-    end
-    
     mail = Mail.new do
       from    '"foo\";touch /tmp/PWNED;\""@blah.com'
       to      'marcel@test.lindsaar.net'
@@ -155,7 +120,7 @@ describe "exim delivery agent" do
 
     expect(Mail::Sendmail).to receive(:call).with(
       '/usr/sbin/exim',
-      " -f \"\\\"foo\\\\\\\"\\;touch /tmp/PWNED\\;\\\\\\\"\\\"@blah.com\" --",
+      "-i -t -f \"\\\"foo\\\\\\\"\\;touch /tmp/PWNED\\;\\\\\\\"\\\"@blah.com\" --",
       nil,
       mail.encoded)
 
@@ -163,10 +128,6 @@ describe "exim delivery agent" do
   end
 
   it "should not raise errors if no sender is defined" do
-    Mail.defaults do
-      delivery_method :exim
-    end
-
     mail = Mail.new do
       to "to@somemail.com"
       subject "Email with no sender"
@@ -181,10 +142,6 @@ describe "exim delivery agent" do
   end
 
   it "should raise an error if no recipient if defined" do
-    Mail.defaults do
-      delivery_method :exim
-    end
-
     mail = Mail.new do
       from "from@somemail.com"
       subject "Email with no recipient"

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -57,14 +57,6 @@ describe "exim delivery agent" do
 
       mail.deliver
     end
-
-    it "should quote the destinations to ensure leading -hyphen doesn't confuse exim" do
-      mail.to = '-hyphen@test.lindsaar.net'
-
-      expect(Mail::Sendmail).to receive(:call).with('/usr/sbin/exim', '-i -t -f "roger@test.lindsaar.net" --', nil, mail.encoded)
-
-      mail.deliver
-    end
   end
 
   it "should still send an email if the settings have been set to nil" do

--- a/spec/mail/network/delivery_methods/sendmail_spec.rb
+++ b/spec/mail/network/delivery_methods/sendmail_spec.rb
@@ -58,6 +58,18 @@ describe Mail::Sendmail do
 
       mail.deliver
     end
+
+    it 'does not escape ~ in From address' do
+      mail.from = 'tilde~@test.lindsaar.net'
+
+      expect(described_class).to receive(:call).
+        with('/usr/sbin/sendmail',
+             '-i -f "tilde~@test.lindsaar.net" --',
+             '"marcel@test.lindsaar.net" "bob@test.lindsaar.net"',
+             mail.encoded)
+
+      mail.deliver
+    end
   end
 
   context 'SMTP To' do
@@ -80,6 +92,18 @@ describe Mail::Sendmail do
         with('/usr/sbin/sendmail',
              '-i -f "roger@test.lindsaar.net" --',
              '"\"to+suffix test\"@test.lindsaar.net"',
+             mail.encoded)
+
+      mail.deliver
+    end
+
+    it 'does not escape ~ in To address' do
+      mail.to = 'tilde~@test.lindsaar.net'
+
+      expect(described_class).to receive(:call).
+        with('/usr/sbin/sendmail',
+             '-i -f "roger@test.lindsaar.net" --',
+             '"tilde~@test.lindsaar.net"',
              mail.encoded)
 
       mail.deliver


### PR DESCRIPTION
Fix for #1121, but contains some cleanup in `spec/mail/network/delivery_methods/exim_spec.rb` first.  I wanted to add tests for escaping ~ properly, but the large amount of duplication made the file hard to understand.