### PR TITLE
eml attachments encoding regression

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -153,6 +153,10 @@ module Mail
         encoded_parts = parts.map { |p| p.encoded }
         ([preamble] + encoded_parts).join(crlf_boundary) + end_boundary + epilogue.to_s
       else
+        if transfer_encoding == ''
+          # transfer_encoding wasn't negotiated, see #identify_and_set_transfer_encoding
+          return raw_source
+        end
         dec = Mail::Encodings.get_encoding(encoding)
         enc = negotiate_best_encoding(transfer_encoding)
         if dec.nil?

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1405,6 +1405,18 @@ describe Mail::Message do
 
       end
 
+      it "rfc2046 can be decoded" do
+        body = "This is NOT plain text ASCII　− かきくけこ" * 30
+        mail = Mail.new
+        mail.body << Mail::Part.new.tap do |part|
+          part.content_disposition = 'attachment; filename="test.eml"'
+          part.content_type  = 'message/rfc822'
+          part.body          = body
+        end
+
+        expect(Mail.new(mail.to_s).parts.last.decoded).to include('NOT plain')
+      end
+
       # https://www.ietf.org/rfc/rfc2046.txt
       # No encoding other than "7bit", "8bit", or "binary" is permitted for
       # the body of a "message/rfc822" entity.


### PR DESCRIPTION
I found out that my change wasn't enough #1106

Mail::Body.encoded calls get_best_encoding twice (correct transfer encoding should already be set for example in identify_and_set_transfer_encoding)
in my opinion, the encoding availability check shouldn't be called here.

the problem is in my case get_best_encoding('7bit') without available encodings always chooses base64 which is not compatible with eml file, but it encodes the content.

So as a result I have an eml attachment which claims to have
Content-Transfer-Encoding: 7bit (which is correct)
but in reality the content is encoded in base64 (which is forbidden), that makes the attachment unreadable