### PR TITLE
Fix that Message#without_attachments! didn't parse the remaining non-attachment parts

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -57,6 +57,7 @@ Bugs:
 * #1107 - Fix Address#display_name and other formatting flip-flopping between encoded and decoded forms depending on whether #encoded or #decoded was called last. (jeremy)
 * #1110 - Fix that Mail::Multibyte::Chars#initialize mutated its argument by calling force_encoding on it. (jeremy)
 * #1113 - Eliminate attachment corruption caused by CRLF conversion. (jeremy)
+* #1131 - Fix that Message#without_attachments! didn't parse the remaining parts. (jeremy)
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1835,16 +1835,13 @@ module Mail
     end
 
     def without_attachments!
-      return self unless has_attachments?
+      if has_attachments?
+        parts.delete_if { |p| p.attachment? }
 
-      parts.delete_if { |p| p.attachment? }
-      body_raw = if parts.empty?
-                   ''
-                 else
-                   body.encoded
-                 end
-
-      @body = Mail::Body.new(body_raw)
+        reencoded = parts.empty? ? '' : body.encoded(content_transfer_encoding)
+        @body = nil # So the new parts won't be added to the existing body
+        self.body = reencoded
+      end
 
       self
     end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1936,12 +1936,11 @@ describe Mail::Message do
 
       emails_with_attachments.each { |email|
         mail = read_fixture('emails', 'attachment_emails', "attachment_#{email}.eml")
-        mail_length_with_attachments = mail.to_s.length
+        non_attachment_parts = mail.parts.reject(&:attachment?)
         expect(mail.has_attachments?).to be_truthy
         mail.without_attachments!
 
-        mail_length_without_attachments = mail.to_s.length
-        expect(mail_length_without_attachments).to be < mail_length_with_attachments
+        expect(mail.parts).to eq non_attachment_parts
         expect(mail.has_attachments?).to be_falsey
       }
     end


### PR DESCRIPTION
Fixes #1130.

References #278 and #33.