### PR TITLE
Fix that set not-accurate multipart header

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -58,6 +58,8 @@ Bugs:
 * #1110 - Fix that Mail::Multibyte::Chars#initialize mutated its argument by calling force_encoding on it. (jeremy)
 * #1113 - Eliminate attachment corruption caused by CRLF conversion. (jeremy)
 * #1131 - Fix that Message#without_attachments! didn't parse the remaining parts. (jeremy)
+* #1145 - Fix that set not-accurate multipart header. (kirikak2)
+
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1801,8 +1801,7 @@ module Mail
     def convert_to_multipart
       text = body.decoded
       self.body = ''
-      text_part = Mail::Part.new({:content_type => 'text/plain;',
-                                  :body => text})
+      text_part = Mail::Part.new({:content_type => 'text/plain;', :body => text})
       text_part.charset = charset unless @defaulted_charset
       self.body << text_part
     end
@@ -2077,7 +2076,6 @@ module Mail
 
     def add_multipart_alternate_header
       header['content-type'] = ContentTypeField.with_boundary('multipart/alternative').value
-      header['content_type'].parameters[:charset] = @charset
       body.boundary = boundary
     end
 
@@ -2085,7 +2083,6 @@ module Mail
       unless body.boundary && boundary
         header['content-type'] = 'multipart/mixed' unless header['content-type']
         header['content-type'].parameters[:boundary] = ContentTypeField.generate_boundary
-        header['content_type'].parameters[:charset] = @charset
         body.boundary = boundary
       end
     end
@@ -2093,7 +2090,6 @@ module Mail
     def add_multipart_mixed_header
       unless header['content-type']
         header['content-type'] = ContentTypeField.with_boundary('multipart/mixed').value
-        header['content_type'].parameters[:charset] = @charset
         body.boundary = boundary
       end
     end

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1801,7 +1801,24 @@ module Mail
     def convert_to_multipart
       text = body.decoded
       self.body = ''
-      text_part = Mail::Part.new({:content_type => 'text/plain;', :body => text})
+      params = {:content_type => 'text/plain;', :body => text}
+      if self.header[:content_type]
+        params.merge!(:content_type => self.header[:content_type].value)
+        self.header[:content_type] = nil
+      end
+      if self.header[:content_disposition]
+        params.merge!(:content_disposition => self.header[:content_disposition].value)
+        self.header[:content_disposition] = nil
+      end
+      if self.header[:content_transfer_encoding]
+        params.merge!(:content_transfer_encoding => self.header[:content_transfer_encoding].value)
+        self.header[:content_transfer_encoding] = nil
+      end
+      if self.header[:content_description]
+        params.merge!(:content_description => self.header[:content_description].value)
+        self.header[:content_description] = nil
+      end
+      text_part = Mail::Part.new(params)
       text_part.charset = charset unless @defaulted_charset
       self.body << text_part
     end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1417,6 +1417,24 @@ describe Mail::Message do
         expect(mail.parts.last.content_transfer_encoding).to match(/7bit|8bit|binary/)
       end
 
+      describe "convert_to_multipart" do
+        subject do
+          mail = read_fixture('emails', 'attachment_emails', 'attachment_only_email.eml')
+          mail.convert_to_multipart
+          mail
+        end
+
+        it "original header move to part" do
+          expect(subject.header[:content_type]).to be_nil
+          expect(subject.header[:content_disposition]).to be_nil
+          expect(subject.header[:content_description]).to be_nil
+          expect(subject.header[:content_transfer_encoding]).to be_nil
+          expect(subject.parts[0].header[:content_disposition].value).to eq("attachment; filename=blah.gz")
+          expect(subject.parts[0].header[:content_transfer_encoding].value).to eq("base64")
+          expect(subject.parts[0].header[:content_description].value).to eq("Attachment has identical content to above foo.gz")
+        end
+      end
+
       describe "content-transfer-encoding" do
 
         it "should use 7bit for only US-ASCII chars" do


### PR DESCRIPTION
According to RFC2046, multipart/* content-type do not need to have charset parameter.
Currentry, When I create multipart mail, mail library append `charset="UTF-8"` in content-type header automatically.

This patch fixes 2 issues.

1. When create multipart content-type header, mail library appends charset parameter.
2. When call `Message#convert_to_multipart`, mail library ignores original header. I think `Content-Type`, `Content-Disposition`, `Content-Transfer-Encoding` and`Content-Description` should move to part header.