### PR TITLE
Fix "wrong number of arguments (given 1, expected 0)" in "sort!"

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -130,7 +130,7 @@ module Mail
         p.body.set_sort_order(@part_sort_order)
         p.body.sort_parts!
       end
-      @parts.sort!(@part_sort_order)
+      @parts.sort!(@part_sort_order) if @parts.kind_of?(Mail::PartsList)
     end
     
     # Returns the raw source that the body was initialized with, without

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -457,4 +457,12 @@ describe Mail::Body do
       expect(body.encoded).to eq 'The Body'
     end
   end
+  
+  describe "Partslist empty" do
+    it "should not break on empty PartsList on body" do
+      body = Mail::Body.new('The Body')
+      body.sort_parts!
+      expect(body.parts.count).to eq 0
+    end
+  end
 end

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -18,6 +18,12 @@ describe "PartsList" do
     p << 'text/html'
     p.sort!(order)
   end
+  
+  it "should not break on empty PartsList" do
+    p = Mail::PartsList.new
+    order = ['text/plain']
+    p.sort!(order)
+  end
 
   it "should not fail if we do not have a content_type" do
     p = Mail::PartsList.new


### PR DESCRIPTION
…. And Array#sort! doesn't take arguments.

wrong number of arguments (given 1, expected 0)

### Backtrace ### :
	/Users/xxx/mail/lib/mail/body.rb:133:in `sort!'
	/Users/xxx/mail/lib/mail/body.rb:133:in `sort_parts!'
	/Users/xxx/mail/lib/mail/body.rb:131:in `block in sort_parts!'
	/Users/xxx/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/delegate.rb:341:in `each'
	/Users/xxx/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/delegate.rb:341:in `block in delegating_block'
	/Users/xxx/mail/lib/mail/body.rb:129:in `sort_parts!'
	/Users/xxx/mail/lib/mail/body.rb:153:in `encoded'