### PR TITLE
Suppress warning

### DIFF
--- a/spec/mail/multibyte_spec.rb
+++ b/spec/mail/multibyte_spec.rb
@@ -17,7 +17,7 @@ describe Mail::Multibyte::Chars do
   if 'string'.respond_to?(:force_encoding)
     it "doesn't mutate input string encoding" do
       s = 'ascii'.dup.force_encoding(Encoding::US_ASCII)
-      chars = described_class.new(s)
+      described_class.new(s)
       expect(s.encoding).to eq(Encoding::US_ASCII)
     end
   end

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -16,14 +16,14 @@ describe "SMTP Delivery Method" do
   end
 
   it "dot-stuff unterminated last line of the message" do
-    mail = Mail.deliver do
+    Mail.deliver do
       from 'from@example.com'
       to 'to@example.com'
       subject 'dot-stuff last line'
       body "this is a test\n.\nonly a test\n."
     end
 
-    message, from, to = MockSMTP.deliveries.first
+    message = MockSMTP.deliveries.first
     expect(Mail.new(message).decoded).to eq("this is a test\n..\nonly a test\n..")
   end
 

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -27,14 +27,14 @@ describe "SMTP Delivery Method" do
 
   describe "general usage" do
     it "dot-stuff unterminated last line of the message" do
-      mail = Mail.deliver do
+      Mail.deliver do
         from 'from@example.com'
         to 'to@example.com'
         subject 'dot-stuff last line'
         body "this is a test\n.\nonly a test\n."
       end
 
-      message, from, to = MockSMTP.deliveries.first
+      message = MockSMTP.deliveries.first
       expect(Mail.new(message).decoded).to eq("this is a test\n..\nonly a test\n..")
     end
 

--- a/tasks/ragel.rake
+++ b/tasks/ragel.rake
@@ -4,23 +4,23 @@ load 'lib/mail/parsers.rb'
 rule 'lib/mail/parsers/rfc5234_abnf_core_rules.rl' => 'lib/mail/parsers/rfc3629_utf8.rl'
 
 # All RFC 5322 parsers depend on ABNF core rules
-rule /rfc5322_.+\.rl\z/ => 'lib/mail/parsers/rfc5234_abnf_core_rules.rl'
+rule %r|/rfc5322_.+\.rl\z/| => 'lib/mail/parsers/rfc5234_abnf_core_rules.rl'
 
 # RFC 5322 parser depends on its submodules
 file 'lib/mail/parsers/rfc5322.rl' => FileList['lib/mail/parsers/rfc5322_*.rl']
 
 # Ruby parsers depend on Ragel parser definitions
 # (remove -L to include line numbers for debugging)
-rule /_parser\.rb\z/ => '.rl' do |t|
+rule %r|/_parser\.rb\z/| => '.rl' do |t|
   sh "ragel -s -R -L -F1 -o #{t.name} #{t.source}"
 end
 
 # Dot files for Ragel parsers
-rule /_parser\.dot\z/ => '.rl' do |t|
+rule %r|/_parser\.dot\z/| => '.rl' do |t|
   sh "ragel -s -V -o #{t.name} #{t.source}"
 end
 
-rule /_parser\.svg\z/ => '.dot' do |t|
+rule %r|/_parser\.svg\z/| => '.dot' do |t|
   sh "dot -v -Tsvg -Goverlap=scale -o #{t.name} #{t.source}"
 end
 


### PR DESCRIPTION
This PR suppresses the following warning.

``` ruby
ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]

RUBYOPT=-w bundle exec rake
/mail/tasks/ragel.rake:7: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/mail/tasks/ragel.rake:14: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/mail/tasks/ragel.rake:19: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/mail/tasks/ragel.rake:23: warning: ambiguous first argument; put parentheses or a space even after `/' operator

/mail/spec/mail/multibyte_spec.rb:20: warning: assigned but unused variable - chars

/mail/spec/mail/network/delivery_methods/smtp_connection_spec.rb:19: warning: assigned but unused variable - mail
/mail/spec/mail/network/delivery_methods/smtp_connection_spec.rb:26: warning: assigned but unused variable - from
/mail/spec/mail/network/delivery_methods/smtp_connection_spec.rb:26: warning: assigned but unused variable - to

/mail/spec/mail/network/delivery_methods/smtp_spec.rb:30: warning: assigned but unused variable - mail
/mail/spec/mail/network/delivery_methods/smtp_spec.rb:37: warning: assigned but unused variable - from
/mail/spec/mail/network/delivery_methods/smtp_spec.rb:37: warning: assigned but unused variable - to
```