### PR TITLE
Fix b value encoder incorrectly partition long multi-byte string bug

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -58,6 +58,7 @@ Bugs:
 * #1110 - Fix that Mail::Multibyte::Chars#initialize mutated its argument by calling force_encoding on it. (jeremy)
 * #1113 - Eliminate attachment corruption caused by CRLF conversion. (jeremy)
 * #1131 - Fix that Message#without_attachments! didn't parse the remaining parts. (jeremy)
+* #1019 - Fix b value encoder incorrectly partition long multi-byte string. (Kenneth-KT)
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/lib/mail/version_specific/ruby_1_8.rb
+++ b/lib/mail/version_specific/ruby_1_8.rb
@@ -132,6 +132,10 @@ module Mail
       "#{encoding}'#{language}'#{URI.escape(str)}"
     end
 
+    def Ruby18.string_byteslice(str, range)
+      str[range]
+    end
+
     private
 
     def Ruby18.normalize_iconv_charset_encoding(encoding)

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -243,8 +243,14 @@ module Mail
       convert_to_encoding(encoding)
     end
 
-    def Ruby19.string_byteslice(str, range)
-      str.unpack('C*').slice(range).pack('C*').force_encoding(str.encoding)
+    if "string".respond_to?(:byteslice)
+      def Ruby19.string_byteslice(str, range)
+        str.byteslice(range)
+      end
+    else
+      def Ruby19.string_byteslice(str, range)
+        str.unpack('C*').slice(range).pack('C*').force_encoding(str.encoding)
+      end
     end
 
     class << self

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -243,6 +243,10 @@ module Mail
       convert_to_encoding(encoding)
     end
 
+    def Ruby19.string_byteslice(str, range)
+      str.unpack('C*').slice(range).pack('C*').force_encoding(str.encoding)
+    end
+
     class << self
       private
 

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -102,6 +102,13 @@ describe Mail::Encodings do
       end
     end
 
+    it "should correctly encode long string mixing with single/multi-byte characters" do
+      input = '意地悪 sample; = filename= name= "file" 笑.txt'
+      encoded = Mail::Encodings.decode_encode(input, :encode)
+      decoded = Mail::Encodings.decode_encode(encoded, :decode)
+      expect(decoded).to eq(input)
+    end
+
     it "should complain if there is no encoding passed for Ruby < 1.9" do
       string = "This is あ string"
       if string.respond_to?(:force_encoding)


### PR DESCRIPTION
This fix addresses issue https://github.com/mikel/mail/issues/1019.