### PR TITLE
Preserve compatible attachment transfer encoding

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -60,6 +60,7 @@ Bugs:
 * #1113 - Eliminate attachment corruption caused by CRLF conversion. (jeremy)
 * #1131 - Fix that Message#without_attachments! didn't parse the remaining parts. (jeremy)
 * #1019 - Fix b value encoder incorrectly splitting multibyte characters. (Kenneth-KT)
+* #1157 - Fix base64 attachment transfer encoding being overridden by quoted-printable. (dalibor)
 
 == Version 2.6.4 - Wed Mar 23 08:16 -0700 2016 Jeremy Daer <jeremydaer@gmail.com>
 

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -7,7 +7,6 @@ module Mail
   end
 
   module Encodings
-
     include Mail::Constants
     extend  Mail::Utilities
 
@@ -19,7 +18,7 @@ module Mail
     #
     # Encodings.register "base64", Mail::Encodings::Base64
     def Encodings.register(name, cls)
-        @transfer_encodings[get_name(name)] = cls
+      @transfer_encodings[get_name(name)] = cls
     end
 
     # Is the encoding we want defined?
@@ -27,8 +26,8 @@ module Mail
     # Example:
     #
     #  Encodings.defined?(:base64) #=> true
-    def Encodings.defined?( str )
-      @transfer_encodings.include? get_name(str)
+    def Encodings.defined?(name)
+      @transfer_encodings.include? get_name(name)
     end
 
     # Gets a defined encoding type, QuotedPrintable or Base64 for now.
@@ -39,16 +38,16 @@ module Mail
     # Example:
     #
     #  Encodings.get_encoding(:base64) #=> Mail::Encodings::Base64
-    def Encodings.get_encoding( str )
-      @transfer_encodings[get_name(str)]
+    def Encodings.get_encoding(name)
+      @transfer_encodings[get_name(name)]
     end
 
     def Encodings.get_all
       @transfer_encodings.values
     end
 
-    def Encodings.get_name(enc)
-      underscoreize(enc).downcase
+    def Encodings.get_name(name)
+      underscoreize(name).downcase
     end
 
     def Encodings.transcode_charset(str, from_charset, to_charset = 'UTF-8')

--- a/lib/mail/encodings/base64.rb
+++ b/lib/mail/encodings/base64.rb
@@ -6,9 +6,9 @@ module Mail
   module Encodings
     class Base64 < SevenBit
       NAME = 'base64'
-     
+
       PRIORITY = 3
- 
+
       def self.can_encode?(enc)
         true
       end
@@ -17,7 +17,7 @@ module Mail
       def self.decode(str)
         RubyVer.decode_base64( str )
       end
-    
+
       # Encode the string to Base64
       def self.encode(str)
         ::Mail::Utilities.to_crlf(RubyVer.encode_base64( str ))
@@ -33,7 +33,7 @@ module Mail
         true
       end
 
-      Encodings.register(NAME, self)      
+      Encodings.register(NAME, self)
     end
   end
 end

--- a/lib/mail/encodings/quoted_printable.rb
+++ b/lib/mail/encodings/quoted_printable.rb
@@ -6,11 +6,11 @@ module Mail
   module Encodings
     class QuotedPrintable < SevenBit
       NAME='quoted-printable'
-   
+
       PRIORITY = 2
 
-      def self.can_encode?(str)
-        EightBit.can_encode? str
+      def self.can_encode?(enc)
+        EightBit.can_encode? enc
       end
 
       # Decode the string from Quoted-Printable. Cope with hard line breaks
@@ -26,7 +26,7 @@ module Mail
       def self.cost(str)
         # These bytes probably do not need encoding
         c = str.count("\x9\xA\xD\x20-\x3C\x3E-\x7E")
-        # Everything else turns into =XX where XX is a 
+        # Everything else turns into =XX where XX is a
         # two digit hex number (taking 3 bytes)
         total = (str.bytesize - c)*3 + c
         total.to_f/str.bytesize

--- a/lib/mail/encodings/transfer_encoding.rb
+++ b/lib/mail/encodings/transfer_encoding.rb
@@ -7,17 +7,17 @@ module Mail
 
       PRIORITY = -1
 
+      # And encoding's superclass can always transport it since the
+      # class hierarchy is arranged e.g. Base64 < 7bit < 8bit < Binary.
       def self.can_transport?(enc)
-        enc = Encodings.get_name(enc)
-        if Encodings.defined? enc
-          Encodings.get_encoding(enc).new.is_a? self
-        else
-          false
-        end
+        enc && enc <= self
       end
 
+      # Override in subclasses to indicate that they can encode text
+      # that couldn't be directly transported, e.g. Base64 has 7bit output,
+      # but it can encode binary.
       def self.can_encode?(enc)
-        can_transport? enc 
+        can_transport? enc
       end
 
       def self.cost(str)
@@ -32,38 +32,45 @@ module Mail
         self::NAME
       end
 
-      def self.get_best_compatible(source_encoding, str, allowed_encodings = nil)
-        if self.can_transport?(source_encoding) && self.compatible_input?(str)
+      def self.negotiate(message_encoding, source_encoding, str, allowed_encodings = nil)
+        message_encoding = Encodings.get_encoding(message_encoding || '8bit')
+        source_encoding  = Encodings.get_encoding(source_encoding)
+
+        if message_encoding && source_encoding && message_encoding.can_transport?(source_encoding) && source_encoding.compatible_input?(str)
           source_encoding
         else
-          choices = Encodings.get_all.select do |enc|
-            self.can_transport?(enc) &&
-              enc.can_encode?(source_encoding) &&
-              (allowed_encodings.nil? || allowed_encodings.include?(enc))
-          end
-
-          best = nil
-          best_cost = nil
-
-          choices.each do |enc|
-            # If the current choice cannot be transported safely,
-            # give priority to other choices but allow it to be used as a fallback.
-            this_cost = enc.cost(str) if enc.compatible_input?(str)
-
-            if !best_cost || (this_cost && this_cost < best_cost)
-              best_cost = this_cost
-              best = enc
-            elsif this_cost == best_cost
-              best = enc if enc::PRIORITY < best::PRIORITY
-            end
-          end
-
-          best
+          renegotiate(message_encoding, source_encoding, str, allowed_encodings)
         end
       end
 
-      def to_s
-        self.class.to_s
+      def self.renegotiate(message_encoding, source_encoding, str, allowed_encodings = nil)
+        encodings = Encodings.get_all.select do |enc|
+          (allowed_encodings.nil? || allowed_encodings.include?(enc)) &&
+            message_encoding.can_transport?(enc) &&
+            enc.can_encode?(source_encoding)
+        end
+
+        lowest_cost(str, encodings)
+      end
+
+      def self.lowest_cost(str, encodings)
+        best = nil
+        best_cost = nil
+
+        encodings.each do |enc|
+          # If the current choice cannot be transported safely, give priority
+          # to other choices but allow it to be used as a fallback.
+          this_cost = enc.cost(str) if enc.compatible_input?(str)
+
+          if !best_cost || (this_cost && this_cost < best_cost)
+            best_cost = this_cost
+            best = enc
+          elsif this_cost == best_cost
+            best = enc if enc::PRIORITY < best::PRIORITY
+          end
+        end
+
+        best
       end
     end
   end

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2057,7 +2057,7 @@ module Mail
       if body && body.multipart?
         self.content_transfer_encoding = @transport_encoding
       else
-        self.content_transfer_encoding = body.get_best_encoding(@transport_encoding, allowed_encodings)
+        self.content_transfer_encoding = body.negotiate_best_encoding(@transport_encoding, allowed_encodings).to_s
       end
     end
 

--- a/spec/mail/encodings/unix_to_unix_spec.rb
+++ b/spec/mail/encodings/unix_to_unix_spec.rb
@@ -11,12 +11,16 @@ describe Mail::Encodings::UnixToUnix do
     Mail::Encodings::UnixToUnix.encode(str)
   end
 
-  it "can transport x-uuencode" do
-    expect(Mail::Encodings::UnixToUnix.can_transport?('x-uuencode')).to be_truthy
+  it "is registered as uuencode" do
+    expect(Mail::Encodings.get_encoding('uuencode')).to eq(Mail::Encodings::UnixToUnix)
   end
 
-  it "can transport uuencode" do
-    expect(Mail::Encodings::UnixToUnix.can_transport?('uuencode')).to be_truthy
+  it "is registered as x-uuencode" do
+    expect(Mail::Encodings.get_encoding('x-uuencode')).to eq(Mail::Encodings::UnixToUnix)
+  end
+
+  it "can transport itself" do
+    expect(Mail::Encodings::UnixToUnix.can_transport?(Mail::Encodings::UnixToUnix)).to be_truthy
   end
 
   it "decodes" do


### PR DESCRIPTION
Even if it's higher cost that the message's transfer encoding. Prevents attachments getting forced into quoted-printable when base64 was chosen.

Closes #988
References #874