### PR TITLE
Parse emails with \n newlines if they don't contain binary content

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -36,6 +36,7 @@ Compatibility:
 * #1106 – Limit message/rfc822 parts' transfer encoding per RFC 2046. (ahorek)
 * #1112 – Support Windows-1258 charset by parsing it as Windows-1252 in Ruby. (jeremy)
 * #1114 – Setting `mail.body = …` on a multipart message now adds a new text part instead of adding a raw MIME part. (jeremy)
+* #1159 – Parse emails with \n newlines so long as they have no binary content. (jeremy)
 
 Bugs:
 * #539 - Fix that whitespace-only continued headers would be incorrectly parsed as the break between headers and body. (ConradIrwin)

--- a/lib/mail/encodings/7bit.rb
+++ b/lib/mail/encodings/7bit.rb
@@ -4,29 +4,19 @@ require 'mail/encodings/8bit'
 
 module Mail
   module Encodings
+    # 7bit and 8bit are equivalent. 7bit encoding is for text only.
     class SevenBit < EightBit
       NAME = '7bit'
-    
       PRIORITY = 1
+      Encodings.register(NAME, self)
 
-      # 7bit and 8bit operate the same
-      
-      # Decode the string
       def self.decode(str)
-        super
-      end
-    
-      # Encode the string
-      def self.encode(str)
-        super
-      end
-     
-      # Idenity encodings have a fixed cost, 1 byte out per 1 byte in
-      def self.cost(str)
-        super 
+        ::Mail::Utilities.binary_unsafe_to_lf str
       end
 
-      Encodings.register(NAME, self) 
+      def self.encode(str)
+        ::Mail::Utilities.binary_unsafe_to_crlf str
+      end
     end
   end
 end

--- a/lib/mail/encodings/8bit.rb
+++ b/lib/mail/encodings/8bit.rb
@@ -6,32 +6,13 @@ module Mail
   module Encodings
     class EightBit < Binary
       NAME = '8bit'
-
       PRIORITY = 4
-
-      # 8bit is an identiy encoding, meaning nothing to do
-      
-      # Decode the string
-      def self.decode(str)
-        ::Mail::Utilities.to_lf str
-      end
-    
-      # Encode the string
-      def self.encode(str)
-        ::Mail::Utilities.to_crlf str
-      end
-     
-      # Idenity encodings have a fixed cost, 1 byte out per 1 byte in
-      def self.cost(str)
-        1.0
-      end
+      Encodings.register(NAME, self)
 
       # Per RFC 2821 4.5.3.1, SMTP lines may not be longer than 1000 octets including the <CRLF>.
       def self.compatible_input?(str)
-        !str.lines.find { |line| line.length > 998 }
+        !str.lines.find { |line| line.bytesize > 998 }
       end
-
-      Encodings.register(NAME, self) 
     end
   end
 end

--- a/lib/mail/encodings/base64.rb
+++ b/lib/mail/encodings/base64.rb
@@ -4,36 +4,35 @@ require 'mail/encodings/7bit'
 
 module Mail
   module Encodings
+    # Base64 encoding handles binary content at the cost of 4 output bytes
+    # per input byte.
     class Base64 < SevenBit
       NAME = 'base64'
-
       PRIORITY = 3
+      Encodings.register(NAME, self)
 
       def self.can_encode?(enc)
         true
       end
 
-      # Decode the string from Base64
       def self.decode(str)
-        RubyVer.decode_base64( str )
+        RubyVer.decode_base64(str)
       end
 
-      # Encode the string to Base64
       def self.encode(str)
-        ::Mail::Utilities.to_crlf(RubyVer.encode_base64( str ))
+        ::Mail::Utilities.binary_unsafe_to_crlf(RubyVer.encode_base64(str))
       end
 
-      # Base64 has a fixed cost, 4 bytes out per 3 bytes in
+      # 3 bytes in -> 4 bytes out
       def self.cost(str)
-        4.0/3
+        4.0 / 3
       end
 
-      # Base64 inserts newlines automatically and cannot violate the SMTP spec.
+      # Ruby Base64 inserts newlines automatically, so it doesn't exceed
+      # SMTP line length limits.
       def self.compatible_input?(str)
         true
       end
-
-      Encodings.register(NAME, self)
     end
   end
 end

--- a/lib/mail/encodings/binary.rb
+++ b/lib/mail/encodings/binary.rb
@@ -1,32 +1,13 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require 'mail/encodings/transfer_encoding'
+require 'mail/encodings/identity'
 
 module Mail
   module Encodings
-    class Binary < TransferEncoding
+    class Binary < Identity
       NAME = 'binary'
-
       PRIORITY = 5
-
-      # Binary is an identiy encoding, meaning nothing to do
-      
-      # Decode the string
-      def self.decode(str)
-        str
-      end
-    
-      # Encode the string
-      def self.encode(str)
-        str
-      end
-     
-      # Idenity encodings have a fixed cost, 1 byte out per 1 byte in
-      def self.cost(str)
-        1.0
-      end
-
-      Encodings.register(NAME, self) 
+      Encodings.register(NAME, self)
     end
   end
 end

--- a/lib/mail/encodings/identity.rb
+++ b/lib/mail/encodings/identity.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# frozen_string_literal: true
+require 'mail/encodings/transfer_encoding'
+
+module Mail
+  module Encodings
+    # Identity encodings do no encoding/decoding and have a fixed cost:
+    # 1 byte in -> 1 byte out.
+    class Identity < TransferEncoding #:nodoc:
+      def self.decode(str)
+        str
+      end
+
+      def self.encode(str)
+        str
+      end
+
+      # 1 output byte per input byte.
+      def self.cost(str)
+        1.0
+      end
+    end
+  end
+end

--- a/lib/mail/network/delivery_methods/sendmail.rb
+++ b/lib/mail/network/delivery_methods/sendmail.rb
@@ -61,7 +61,7 @@ module Mail
 
     def self.call(path, arguments, destinations, encoded_message)
       popen "#{path} #{arguments} #{destinations}" do |io|
-        io.puts ::Mail::Utilities.to_lf(encoded_message)
+        io.puts ::Mail::Utilities.binary_unsafe_to_lf(encoded_message)
         io.flush
       end
     end

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -443,7 +443,7 @@ describe Mail::Body do
 
   describe "non US-ASCII charset" do
     it "should encoded" do
-      body = Mail::Body.new("あいうえお\n")
+      body = Mail::Body.new("あいうえお\r\n")
       body.charset = 'iso-2022-jp'
       expect = (RUBY_VERSION < '1.9') ? "あいうえお\r\n" : "\e$B$\"$$$&$($*\e(B\r\n"
       expect(body.encoded).to eq expect

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -390,7 +390,7 @@ describe Mail::Message do
       raw_message = read_raw_fixture('emails', 'multi_charset', 'ks_c_5601-1987.eml')
       original_encoding = raw_message.encoding if raw_message.respond_to?(:encoding)
       mail = Mail.new(raw_message)
-      expect(mail.decoded).to eq "스티해\n"
+      expect(mail.decoded.chomp).to eq "스티해"
       expect(raw_message.encoding).to eq original_encoding if raw_message.respond_to?(:encoding)
     end
 

--- a/spec/mail/part_spec.rb
+++ b/spec/mail/part_spec.rb
@@ -36,7 +36,7 @@ describe Mail::Part do
     end
     expect(part.content_id).to eq "<thisis@acontentid>"
   end
-  
+
   it "should return an inline content_id" do
     part = Mail::Part.new do
       content_id "<thisis@acontentid>"
@@ -46,8 +46,8 @@ describe Mail::Part do
     expect($stderr).to receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
     expect(part.inline_content_id).to eq "thisis@acontentid"
   end
-  
-  
+
+
   it "should URL escape its inline content_id" do
     part = Mail::Part.new do
       content_id "<thi%%sis@acontentid>"
@@ -57,14 +57,14 @@ describe Mail::Part do
     expect($stderr).to receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
     expect(part.inline_content_id).to eq "thi%25%25sis@acontentid"
   end
-  
+
   it "should add a content_id if there is none and is asked for an inline_content_id" do
     part = Mail::Part.new
     expect(part.cid).not_to be_nil
     expect($stderr).to receive(:puts).with("Part#inline_content_id is deprecated, please call Part#cid instead")
     expect(part.inline_content_id).not_to be_nil
   end
-  
+
   it "should respond correctly to inline?" do
     part = Mail::Part.new(:content_disposition => 'attachment')
     expect(part).not_to be_inline
@@ -83,7 +83,8 @@ describe Mail::Part do
 
   describe "parts that have a missing header" do
     it "should not try to init a header if there is none" do
-      part =<<PARTEND
+      expect($stderr).not_to receive(:puts)
+      Mail::Part.new(Mail::Utilities.to_crlf(<<PARTEND))
 
 The original message was received at Mon, 24 Dec 2007 10:03:47 +1100
 from 60-0-0-146.static.tttttt.com.au [60.0.0.146]
@@ -106,11 +107,9 @@ This message has been scanned for viruses and
 dangerous content by MailScanner, and is
 believed to be clean.
 PARTEND
-      expect($stderr).not_to receive(:puts)
-      Mail::Part.new(part)
     end
   end
-  
+
   describe "delivery status reports" do
     before do
       @delivery_report = Mail::Part.new(Mail::Utilities.to_crlf(<<ENDPART))
@@ -132,7 +131,7 @@ ENDPART
     it "should know if it is a delivery-status report" do
       expect(@delivery_report).to be_delivery_status_report_part
     end
-    
+
     it "should create a delivery_status_data header object" do
       expect(@delivery_report.delivery_status_data).not_to be_nil
     end
@@ -140,34 +139,34 @@ ENDPART
     it "should be bounced" do
       expect(@delivery_report).to be_bounced
     end
-    
+
     it "should say action 'delayed'" do
       expect(@delivery_report.action).to eq 'failed'
     end
-    
+
     it "should give a final recipient" do
       expect(@delivery_report.final_recipient).to eq 'RFC822; edwin@zzzzzzz.com'
     end
-    
+
     it "should give an error code" do
       expect(@delivery_report.error_status).to eq '5.3.0'
     end
-    
+
     it "should give a diagostic code" do
       expect(@delivery_report.diagnostic_code).to eq 'SMTP; 553 5.3.0 <edwin@zzzzzzz.com>... Unknown E-Mail Address'
     end
-    
+
     it "should give a remote-mta" do
       expect(@delivery_report.remote_mta).to eq 'DNS; mail.zzzzzz.com'
     end
-    
+
     it "should be retryable" do
       expect(@delivery_report).not_to be_retryable
     end
 
     context "on a part without a certain field" do
       before(:each) do
-        part =<<ENDPART
+        @delivery_report = Mail::Part.new(Mail::Utilities.to_crlf(<<ENDPART))
 Content-Type: message/delivery-status
 
 Reporting-MTA: dns; mail12.rrrr.com.au
@@ -180,7 +179,6 @@ Status: 5.3.0
 Remote-MTA: DNS; mail.zzzzzz.com
 Last-Attempt-Date: Mon, 24 Dec 2007 10:03:53 +1100
 ENDPART
-        @delivery_report = Mail::Part.new(part)
       end
 
       it "returns nil" do
@@ -188,7 +186,7 @@ ENDPART
       end
     end
   end
-  
+
   it "should correctly parse plain text raw source and not truncate after newlines - issue 208" do
     plain_text = "First Line\n\nSecond Line\n\nThird Line\n\n"
     #Note: trailing \n\n is stripped off by Mail::Part initialization

--- a/spec/mail/round_tripping_spec.rb
+++ b/spec/mail/round_tripping_spec.rb
@@ -43,10 +43,10 @@ describe "Round Tripping" do
     expect(Mail.new(initial.encoded).encoded).to eq initial.encoded
   end
 
-  it "should round trip attachment newlines" do
-    body = "I have \ntwo lines\n\n"
+  it "preserves text attachment newlines" do
+    body = "I have \r\ntwo lines\n\r"
     initial = Mail.new
     initial.add_file :filename => "foo.txt", :content => body
-    expect(Mail.new(initial.encoded).attachments.first.decoded).to eq body
+    expect(Mail.new(initial.encoded).attachments.first.decoded).to eq ::Mail::Utilities.binary_unsafe_to_lf(body)
   end
 end

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -439,36 +439,32 @@ describe "Utilities Module" do
   end
 
   describe "to_lf" do
-    it "should change a single CR to LF" do
+    it "converts single CR" do
       expect(Mail::Utilities.to_lf("\r")).to eq "\n"
     end
 
-    it "should change multiple LF to CRLF" do
+    it "converts multiple CR" do
       expect(Mail::Utilities.to_lf("\r\r")).to eq "\n\n"
     end
 
-    it "should change a single CRLF to LF" do
+    it "converts single CRLF" do
       expect(Mail::Utilities.to_lf("\r\n")).to eq "\n"
     end
 
-    it "should change multiple CR to LF" do
+    it "converts multiple CRLF" do
       expect(Mail::Utilities.to_lf("\r\n\r\n")).to eq "\n\n"
     end
 
-    it "should not change LF" do
-      expect(Mail::Utilities.to_lf("\n")).to eq "\n"
-    end
-
-    it "should not change multiple CRLF" do
+    it "leaves LF intact" do
       expect(Mail::Utilities.to_lf("\n\n")).to eq "\n\n"
     end
 
-    it "should handle a mix" do
+    it "converts mixed line endings" do
       expect(Mail::Utilities.to_lf("\r \n\r\n")).to eq "\n \n\n"
     end
 
     if defined?(Encoding)
-      it "should not change the encoding of the string" do
+      it "preserves encoding" do
         saved_default_internal = Encoding.default_internal
         $VERBOSE, saved_verbose = nil, $VERBOSE
         begin
@@ -482,114 +478,83 @@ describe "Utilities Module" do
       end
     end
 
-    describe "to_lf method on String" do
-      it "should leave lf as lf" do
-        expect(Mail::Utilities.to_lf("\n")).to eq "\n"
-      end
-
-      it "should clean just cr to lf" do
-        expect(Mail::Utilities.to_lf("\r")).to eq "\n"
-      end
-
-      it "should leave crlf as lf" do
-        expect(Mail::Utilities.to_lf("\r\n")).to eq "\n"
-      end
-
-      it "should handle japanese characters" do
-        string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
-        expect(Mail::Utilities.to_lf(string)).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\n\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\n\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\n\n"
-      end
+    it "should handle japanese characters" do
+      string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
+      expect(Mail::Utilities.binary_unsafe_to_lf(string)).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\n\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\n\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\n\n"
     end
 
-    describe "methods on NilClass" do
-      it "should return empty string on to_lf" do
+    describe "on NilClass" do
+      it "returns an empty string" do
         expect(Mail::Utilities.to_lf(nil)).to eq ''
       end
     end
 
-    describe "methods on subclass" do
-      it "should return String not subclass" do
+    describe "on String subclasses" do
+      it "returns Strings" do
         klass = Class.new(String)
         string = klass.new('')
         expect(Mail::Utilities.to_lf(string)).to be_an_instance_of(String)
       end
     end
-
   end
 
   describe "to_crlf" do
+    it "converts single LF" do
+      expect(Mail::Utilities.to_crlf("\n")).to eq "\r\n"
+    end
 
-    describe "to_crlf method on String" do
-      it "should clean just lf to crlf" do
-        expect(Mail::Utilities.to_crlf("\n")).to eq "\r\n"
-      end
+    it "converts multiple LF" do
+      expect(Mail::Utilities.to_crlf("\n\n")).to eq "\r\n\r\n"
+    end
 
-      it "should clean just cr to crlf" do
-        expect(Mail::Utilities.to_crlf("\r")).to eq "\r\n"
-      end
+    it "converts single CR" do
+      expect(Mail::Utilities.to_crlf("\r")).to eq "\r\n"
+    end
 
-      it "should leave crlf as crlf" do
-        expect(Mail::Utilities.to_crlf("\r\n")).to eq "\r\n"
-      end
+    it "preserves single CRLF" do
+      expect(Mail::Utilities.to_crlf("\r\n")).to eq "\r\n"
+    end
 
-      it "should handle japanese characters" do
-        string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
-        expect(Mail::Utilities.to_crlf(string)).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
-      end
+    it "preserves multiple CRLF" do
+      expect(Mail::Utilities.to_crlf("\r\n\r\n")).to eq "\r\n\r\n"
+    end
 
-      if defined?(Encoding)
-        it "should not change the encoding of the string" do
-          saved_default_internal = Encoding.default_internal
+    it "converts mixed line endings" do
+      expect(Mail::Utilities.to_crlf("\r \n\r\n")).to eq "\r\n \r\n\r\n"
+    end
+
+    it "should handle japanese characters" do
+      string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
+      expect(Mail::Utilities.binary_unsafe_to_crlf(string)).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
+    end
+
+    if defined?(Encoding)
+      it "preserves encoding" do
+        saved_default_internal = Encoding.default_internal
+        $VERBOSE, saved_verbose = nil, $VERBOSE
+        begin
           Encoding.default_internal = "UTF-8"
           ascii_string = "abcd".dup.force_encoding("ASCII-8BIT")
           expect(Mail::Utilities.to_crlf(ascii_string).encoding).to eq(Encoding::ASCII_8BIT)
+        ensure
           Encoding.default_internal = saved_default_internal
+          $VERBOSE = saved_verbose
         end
       end
-
     end
 
-    describe "methods on NilClass" do
-      it "should return empty string on to_crlf" do
+    describe "on NilClass" do
+      it "returns an empty string" do
         expect(Mail::Utilities.to_crlf(nil)).to eq ''
       end
     end
 
-    describe "methods on subclass" do
-      it "should return String not subclass" do
+    describe "on String subclasses" do
+      it "returns Strings" do
         klass = Class.new(String)
         string = klass.new('')
         expect(Mail::Utilities.to_crlf(string)).to be_an_instance_of(String)
       end
     end
-
-    describe "to_crlf" do
-
-      it "should change a single LF to CRLF" do
-        expect(Mail::Utilities.to_crlf("\n")).to eq "\r\n"
-      end
-
-      it "should change multiple LF to CRLF" do
-        expect(Mail::Utilities.to_crlf("\n\n")).to eq "\r\n\r\n"
-      end
-
-      it "should change a single CR to CRLF" do
-        expect(Mail::Utilities.to_crlf("\r")).to eq "\r\n"
-      end
-
-      it "should not change CRLF" do
-        expect(Mail::Utilities.to_crlf("\r\n")).to eq "\r\n"
-      end
-
-      it "should not change multiple CRLF" do
-        expect(Mail::Utilities.to_crlf("\r\n\r\n")).to eq "\r\n\r\n"
-      end
-
-      it "should handle a mix" do
-        expect(Mail::Utilities.to_crlf("\r \n\r\n")).to eq "\r\n \r\n\r\n"
-      end
-    end
-
   end
-
 end


### PR DESCRIPTION
Binary-safe newline conversion ensures that attachments don't get corrupted. Requires that text is ASCII-only.

Fixes #1129
References #1113