### PR TITLE
Fix ruby warnings

### DIFF
--- a/lib/mail/elements/content_type_element.rb
+++ b/lib/mail/elements/content_type_element.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require 'mail/parsers/content_type_parser'
-
 module Mail
   class ContentTypeElement #:nodoc:
     attr_reader :main_type, :sub_type, :parameters


### PR DESCRIPTION
In mail 2.7.0, the following Ruby warnings is output.

```
gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:963: warning: statement not reached
gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1034: warning: mismatched indentations at 'end' with 'while' at 725
gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:1035: warning: mismatched indentations at 'end' with 'begin' at 716
gems/mail-2.7.0/lib/mail/parsers/content_type_parser.rb:717: warning: assigned but unused variable - testEof
```

These warnings are output from the Parser class. The Parser class is generated
by Ragel and it is a known issue that Ruby warnings comes out.

Therefore, there is a file for parser load which temporarily invalidated warning,
should require the parser via it, I think that you not load the parser class directly.

https://github.com/mikel/mail/blob/2-7-stable/lib/mail/parsers.rb