### PR TITLE
Fix performance downgrade with Mail::Utilities.to_crlf/to_lf

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -239,46 +239,26 @@ module Mail
 
     end
 
-    # Test String#encode works correctly with line endings.
-    # Some versions of Ruby (e.g. MRI <1.9, JRuby, Rubinius) line ending
-    # normalization does not work correctly or did not have #encode.
-    if ("\r".encode(:universal_newline => true) rescue nil) == LF &&
-      (LF.encode(:crlf_newline => true) rescue nil) == CRLF
-      # Using String#encode is better performing than Regexp
+    def self.binary_unsafe_to_lf(string) #:nodoc:
+      string.gsub(/\r\n|\r/, LF)
+    end
 
-      def self.binary_unsafe_to_lf(string) #:nodoc:
-        string.encode(string.encoding, :universal_newline => true)
+    TO_CRLF_REGEX =
+      if RUBY_VERSION >= '1.9'
+        # This 1.9 only regex can save a reasonable amount of time (~20%)
+        # by not matching "\r\n" so the string is returned unchanged in
+        # the common case.
+        Regexp.new("(?<!\r)\n|\r(?!\n)")
+      else
+        /\n|\r\n|\r/
       end
 
-      def self.binary_unsafe_to_crlf(string) #:nodoc:
-        string.encode(string.encoding, :universal_newline => true).encode!(string.encoding, :crlf_newline => true)
-      end
+    def self.binary_unsafe_to_crlf(string) #:nodoc:
+      string.gsub(TO_CRLF_REGEX, CRLF)
+    end
 
-      def self.safe_for_line_ending_conversion?(string) #:nodoc:
-        string.ascii_only?
-      end
-    else
-      def self.binary_unsafe_to_lf(string) #:nodoc:
-        string.gsub(/\r\n|\r/, LF)
-      end
-
-      TO_CRLF_REGEX =
-        if RUBY_VERSION >= '1.9'
-          # This 1.9 only regex can save a reasonable amount of time (~20%)
-          # by not matching "\r\n" so the string is returned unchanged in
-          # the common case.
-          Regexp.new("(?<!\r)\n|\r(?!\n)")
-        else
-          /\n|\r\n|\r/
-        end
-
-      def self.binary_unsafe_to_crlf(string) #:nodoc:
-        string.gsub(TO_CRLF_REGEX, CRLF)
-      end
-
-      def self.safe_for_line_ending_conversion?(string) #:nodoc:
-        string.ascii_only?
-      end
+    def self.safe_for_line_ending_conversion?(string) #:nodoc:
+      string.ascii_only?
     end
 
     # Convert line endings to \n unless the string is binary. Used for

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -463,21 +463,6 @@ describe "Utilities Module" do
       expect(Mail::Utilities.to_lf("\r \n\r\n")).to eq "\n \n\n"
     end
 
-    if defined?(Encoding)
-      it "preserves encoding" do
-        saved_default_internal = Encoding.default_internal
-        $VERBOSE, saved_verbose = nil, $VERBOSE
-        begin
-          Encoding.default_internal = "UTF-8"
-          ascii_string = "abcd".dup.force_encoding("ASCII-8BIT")
-          expect(Mail::Utilities.to_lf(ascii_string).encoding).to eq(Encoding::ASCII_8BIT)
-        ensure
-          Encoding.default_internal = saved_default_internal
-          $VERBOSE = saved_verbose
-        end
-      end
-    end
-
     it "should handle japanese characters" do
       string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
       expect(Mail::Utilities.binary_unsafe_to_lf(string)).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\n\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\n\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\n\n"
@@ -526,21 +511,6 @@ describe "Utilities Module" do
     it "should handle japanese characters" do
       string = "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
       expect(Mail::Utilities.binary_unsafe_to_crlf(string)).to eq "\343\201\202\343\201\210\343\201\206\343\201\210\343\201\212\r\n\r\n\343\201\213\343\201\215\343\201\217\343\201\221\343\201\223\r\n\r\n\343\201\225\343\201\227\343\201\244\343\201\233\343\201\235\r\n\r\n"
-    end
-
-    if defined?(Encoding)
-      it "preserves encoding" do
-        saved_default_internal = Encoding.default_internal
-        $VERBOSE, saved_verbose = nil, $VERBOSE
-        begin
-          Encoding.default_internal = "UTF-8"
-          ascii_string = "abcd".dup.force_encoding("ASCII-8BIT")
-          expect(Mail::Utilities.to_crlf(ascii_string).encoding).to eq(Encoding::ASCII_8BIT)
-        ensure
-          Encoding.default_internal = saved_default_internal
-          $VERBOSE = saved_verbose
-        end
-      end
     end
 
     describe "on NilClass" do


### PR DESCRIPTION
Fixes Issue: https://github.com/mikel/mail/issues/1118.
Reverts: https://github.com/mikel/mail/pull/956 and https://github.com/mikel/mail/pull/961.

Test suite time on my local machine before and after this change:

#### Ruby 2.4.1

Before:

```bash
$ be rspec spec/
Running Specs under Ruby Version 2.4.1
Running Specs for Mail Version 2.8.0.edge

Finished in 2.43 seconds (files took 0.40158 seconds to load)
1762 examples, 0 failures, 5 pending
```

After:

```bash
$ be rspec spec/
Running Specs under Ruby Version 2.4.1
Running Specs for Mail Version 2.8.0.edge

Finished in 1.55 seconds (files took 0.41858 seconds to load)
1760 examples, 0 failures, 5 pending
```

#### Ruby 2.1.1

Before:

```bash
$ be rspec spec/
Running Specs under Ruby Version 2.1.1
Running Specs for Mail Version 2.8.0.edge

Finished in 2.65 seconds (files took 0.3783 seconds to load)
1762 examples, 0 failures, 5 pending
```

After:

```bash
$ be rspec spec/
Running Specs under Ruby Version 2.1.1
Running Specs for Mail Version 2.8.0.edge

Finished in 1.75 seconds (files took 0.4047 seconds to load)
1760 examples, 0 failures, 5 pending
```

Or, you can compare Travis specs run times [Ruby 2.4 - before](https://travis-ci.org/mikel/mail/jobs/296108104) (3.59 seconds) vs [Ruby 2.4 - after](https://travis-ci.org/mikel/mail/jobs/296130765) (2.52 seconds)