### PR TITLE
restore LF->CRLF conversion for properly encoded non-binary messages

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -10,6 +10,8 @@ Compatibility:
 Performance:
 * Speed up message encoding, especially with large attachments. (dalibor)
 
+Features:
+* Restore LF=>CRLF conversions for properly encoded non-binary emails (rubys)
 
 == Version 2.7.0 (2017-10-31)
 

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1962,7 +1962,6 @@ module Mail
     end
 
     def raw_source=(value)
-      value = value.dup.force_encoding(Encoding::BINARY) if RUBY_VERSION >= "1.9.1"
       @raw_source = ::Mail::Utilities.to_crlf(value)
     end
 

--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -258,7 +258,12 @@ module Mail
     end
 
     def self.safe_for_line_ending_conversion?(string) #:nodoc:
-      string.ascii_only?
+      if RUBY_VERSION >= '1.9'
+        string.ascii_only? or 
+          (string.encoding != Encoding::BINARY and string.valid_encoding?)
+      else
+        string.ascii_only?
+      end
     end
 
     # Convert line endings to \n unless the string is binary. Used for

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -460,6 +460,20 @@ HERE
       expect(header['Received'].value).to eq "from [127.0.220.158] (helo=fg-out-1718.google.com)\tby smtp.totallyrandom.com with esmtp (Exim 4.68)\t(envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>)\tid 1K4JeQ-0005Nd-Ij\tfor support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700"
     end
 
+    it "should convert all lonesome LFs to CRLF in UTF-8 too" do
+      header_text =<<HERE
+Subject: Iñtërnâtiônàlizætiøn
+Received: from [127.0.220.158] (helo=fg-out-1718.google.com)
+	by smtp.totallyrandom.com with esmtp (Exim 4.68)
+	(envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>)
+	id 1K4JeQ-0005Nd-Ij
+	for support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700
+HERE
+      header = Mail::Header.new(header_text.gsub(/\n/, "\n"))
+      expect(header['Received'].value).to eq "from [127.0.220.158] (helo=fg-out-1718.google.com)\tby smtp.totallyrandom.com with esmtp (Exim 4.68)\t(envelope-from <stuff+caf_=support=aaa.somewhere.com@gmail.com>)\tid 1K4JeQ-0005Nd-Ij\tfor support@aaa.somewhere.com; Thu, 05 Jun 2008 10:53:29 -0700"
+    end
+
+
     it "should convert all lonesome CRs to CRLF" do
       header_text =<<HERE
 Received: from [127.0.220.158] (helo=fg-out-1718.google.com)

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -461,6 +461,7 @@ HERE
     end
 
     it "should convert all lonesome LFs to CRLF in UTF-8 too" do
+      skip if RUBY_VERSION < '1.9'
       header_text =<<HERE
 Subject: Iñtërnâtiônàlizætiøn
 Received: from [127.0.220.158] (helo=fg-out-1718.google.com)


### PR DESCRIPTION
Useful for templated emails and test data