### PR TITLE
Update mini_mime dependency to 1.0.0

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[ README.md ]
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 
-  s.add_dependency('mini_mime', '>= 0.1.1')
+  s.add_dependency('mini_mime', '~> 1.0.0')
 
   s.add_development_dependency('bundler', '>= 1.0.3')
   s.add_development_dependency('rake', '> 0.8.7')


### PR DESCRIPTION
(Assuming https://github.com/discourse/mini_mime/pull/9 goes through)

The `mini_mime` gem version dependency is open ended enough that a possible future `mini_mime` release with breaking API changes _could_ potentially break current `mail` gem versions. 

To prevent this from happening, we should lock down the `mini_mime` dependency, according to semver best practices.