### PR TITLE
Use "Re: " instead of "RE: "

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -12,6 +12,7 @@ Compatibility:
 * Gracefully parse invalid dates in Date and Received headers. (okkez)
 * Converting to multipart moves Content-* headers to the new part. (kirikak2)
 * Multipart Content-Type no longer includes a needless charset param. (kirikak2)
+* Use "Re: " instead of "RE: " (mashedcode)
 
 Performance:
 * Speed up message encoding, especially with large attachments. (dalibor)

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -294,7 +294,7 @@ module Mail
           reply.references ||= bracketed_message_id
         end
         if subject
-          reply.subject = subject =~ /^Re:/i ? subject : "RE: #{subject}"
+          reply.subject = subject =~ /^Re:/i ? subject : "Re: #{subject}"
         end
         if reply_to || from
           reply.to = self[reply_to ? :reply_to : :from].to_s

--- a/spec/fixtures/emails/error_emails/content_transfer_encoding_text-html.eml
+++ b/spec/fixtures/emails/error_emails/content_transfer_encoding_text-html.eml
@@ -18,7 +18,7 @@ Reply-To: "chianfong cuthbert" <abhijit.862153drinnan@datavalet.com>
 From: "chianfong cuthbert" <abhijit.862153drinnan@datavalet.com>
 To: cvs@bruce-guenter.dyndns.org
 Cc: rait@bruce-guenter.dyndns.org
-Subject: RE: We will help you refinance your home.
+Subject: Re: We will help you refinance your home.
 Date: Fri, 06 May 2005 15:55:01 +0400
 MIME-Version: 1.0
 Content-Type: multipart/alternative;

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1979,8 +1979,8 @@ describe Mail::Message do
         expect(@mail.reply.references).to eq '6B7EC235-5B17-4CA8-B2B8-39290DEB43A3@test.lindsaar.net'
       end
 
-      it "should RE: the original subject" do
-        expect(@mail.reply.subject).to eq 'RE: Testing 123'
+      it "should Re: the original subject" do
+        expect(@mail.reply.subject).to eq 'Re: Testing 123'
       end
 
       it "should be sent to the original sender" do
@@ -2041,7 +2041,7 @@ describe Mail::Message do
         expect(@mail.reply[:references].message_ids).to eq ['473FF3B8.9020707@xxx.org', '348F04F142D69C21-291E56D292BC@xxxx.net', '473FFE27.20003@xxx.org']
       end
 
-      it "should not append another RE:" do
+      it "should not append another Re:" do
         expect(@mail.reply.subject).to eq "Re: Test reply email"
       end
 


### PR DESCRIPTION
As specified in [RFC 5322 3.6.5.](https://tools.ietf.org/html/rfc5322#section-3.6.5)