### PR TITLE
Travis: jruby-9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ rvm:
   - ruby-head
   - jruby
   - jruby-9.0.5.0
-  - jruby-9.1.6.0
+  - jruby-9.1.15.0
   - jruby-head
   - rbx-2
   - rbx-3
@@ -37,7 +37,7 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby
     - rvm: jruby-9.0.5.0
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.15.0
     - rvm: jruby-head
     - rvm: rbx-2
     - rvm: rbx-3


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html