### PR TITLE
incompatible encoding regexp fix

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -45,7 +45,7 @@ module Mail
     # If the string supplied has TOKEN unsafe characters in it, will return the string quoted
     # in double quotes, otherwise returns the string unmodified
     def quote_token( str )
-      if RUBY_VERSION >= '1.9'
+      if RUBY_VERSION >= '1.9' && str.is_a?(String)
         original_encoding = str.encoding
         ascii_str = str.dup.force_encoding('ASCII-8BIT')
         if token_safe?( ascii_str )

--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -45,7 +45,17 @@ module Mail
     # If the string supplied has TOKEN unsafe characters in it, will return the string quoted
     # in double quotes, otherwise returns the string unmodified
     def quote_token( str )
-      token_safe?( str ) ? str : dquote(str)
+      if RUBY_VERSION >= '1.9'
+        original_encoding = str.encoding
+        ascii_str = str.dup.force_encoding('ASCII-8BIT')
+        if token_safe?( ascii_str )
+          str
+        else
+          dquote(ascii_str).force_encoding(original_encoding)
+        end
+      else
+        token_safe?( str ) ? str : dquote(str)
+      end
     end
 
     # Wraps supplied string in double quotes and applies \-escaping as necessary,

--- a/spec/fixtures/emails/attachment_emails/attachment_nonascii_filename.eml
+++ b/spec/fixtures/emails/attachment_emails/attachment_nonascii_filename.eml
@@ -1,0 +1,28 @@
+Mime-Version: 1.0 (Apple Message framework v730)
+Content-Type: multipart/mixed; boundary=Apple-Mail-13-196941151
+Message-Id: <9169D984-4E0B-45EF-82D4-8F5E53AD7012@example.com>
+From: foo@example.com
+Subject: testing
+Date: Mon, 6 Jun 2005 22:21:22 +0200
+To: blah@example.com
+
+
+--Apple-Mail-13-196941151
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+	charset=ISO-8859-1;
+	delsp=yes;
+	format=flowed
+
+This is the first part.
+
+--Apple-Mail-13-196941151
+Content-Type: text/plain; name=ciële.txt
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment;
+	filename=ciële.txt
+
+Hi there.
+
+--Apple-Mail-13-196941151--
+

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -266,6 +266,12 @@ describe "reading emails with attachments" do
       expect(mail.attachments.first.filename).to eq "This is a test.txt"
     end
 
+    it "should decode an attachment without ascii compatible filename" do
+      mail = read_fixture('emails/attachment_emails/attachment_nonascii_filename.eml')
+      expect(mail.attachments.length).to eq 1
+      expect(mail.attachments.first.filename).to eq "ciële.txt"
+    end
+
     it "should find attachments inside parts with content-type message/rfc822" do
       mail = read_fixture('emails/attachment_emails/attachment_message_rfc822.eml')
       expect(mail.attachments.length).to eq 1


### PR DESCRIPTION
expected
attachments with a utf-8 encoded filename can be processed

actual
```ruby
Failure/Error: not TOKEN_UNSAFE === str

     Encoding::CompatibilityError:
       incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)
     # ./lib/mail/utilities.rb:42:in `==='
     # ./lib/mail/utilities.rb:42:in `token_safe?'
     # ./lib/mail/utilities.rb:48:in `quote_token'
     # ./lib/mail/fields/common/parameter_hash.rb:55:in `block in decoded'
     # ./lib/mail/fields/common/parameter_hash.rb:54:in `map!'
     # ./lib/mail/fields/common/parameter_hash.rb:54:in `decoded'
     # ./lib/mail/fields/content_type_field.rb:123:in `decoded'
     # ./lib/mail/fields/content_type_field.rb:66:in `default'
     # ./lib/mail/field.rb:237:in `method_missing'
     # ./lib/mail/message.rb:1215:in `default'
     # ./lib/mail/message.rb:613:in `content_type'
     # ./lib/mail/message.rb:2145:in `find_attachment'
     # ./lib/mail/message.rb:1931:in `attachment?'
     # ./lib/mail/attachments_list.rb:12:in `block in initialize'
     # ./lib/mail/attachments_list.rb:8:in `map'
     # ./lib/mail/attachments_list.rb:8:in `initialize'
     # ./lib/mail/parts_list.rb:25:in `new'
     # ./lib/mail/parts_list.rb:25:in `attachments'
     # ./lib/mail/message.rb:1658:in `attachments'
```

ruby 2.5.0 stable
mail 2.7.0 stable