### PR TITLE
Expose Message Field Origin (Unparsed) Value

### DIFF
--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -173,6 +173,8 @@ module Mail
       @name = FIELD_NAME_MAP[@name.to_s.downcase] || @name
     end
 
+    attr_reader :unparsed_value
+
     def field=(field)
       @field = field
     end

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -321,6 +321,23 @@ describe Mail::Field do
     end
   end
 
+  describe "value" do
+    let(:origin_value) { { :template => "t1" } }
+    subject { Mail::Field.new("name", origin_value) }
+
+    context "parsed" do
+      it "returns parsed value" do
+        expect(subject.value).to eq(origin_value.to_s)
+      end
+    end
+
+    context "unparsed" do
+      it "returns origin unparsed value" do
+        expect(subject.unparsed_value).to eq(origin_value)
+      end
+    end
+  end
+
   describe Mail::Field::ParseError do
     it "should be structured" do
       error = nil
@@ -334,7 +351,6 @@ describe Mail::Field do
       expect(error.value).to eq "invalid"
       expect(error.reason).not_to be_nil
     end
-
   end
 
 end


### PR DESCRIPTION
PR for #1195 

Allows getting origin (unparsed) field (header) value with public API. Compare before:

    > m = Mail.new(headers: { merge_vars: { template: "t1" } })
    #=> <Mail::Message:70148510270720, Multipart: false, Headers: <merge-vars: {"template"=>"t1"}>>
    > m[:merge_vars].value
    #=> "{\"template\"=>\"t1\"}"
    > m[:merge_vars].instance_variable_get(:@unparsed_value)
    #=> { "template" => "t1" }

after:

    > m = Mail.new(headers: { merge_vars: { template: "t1" } })
    #=> <Mail::Message:70148510270720, Multipart: false, Headers: <merge-vars: {"template"=>"t1"}>>
    > m[:merge_vars].value
    #=> "{\"template\"=>\"t1\"}"
    > m[:merge_vars].unparsed_value
    #=> { "template" => "t1" }