### PR TITLE
Fix parsing boundary containing "=" within invalid Content-Type

### DIFF
--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -150,7 +150,7 @@ module Mail
         # and: audio/x-midi;\r\n\sname=Part .exe
         params = $2.to_s.split(/\s+/)
         params = params.map { |i| i.to_s.chomp.strip }
-        params = params.map { |i| i.split(/\s*\=\s*/) }
+        params = params.map { |i| i.split(/\s*\=\s*/, 2) }
         params = params.map { |i| "#{i[0]}=#{Utilities.dquote(i[1].to_s.gsub(/;$/,""))}" }.join('; ')
         "#{type}; #{params}"
       when val =~ /^\s*$/

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -560,6 +560,15 @@ describe Mail::ContentTypeField do
       expect(c.parameters).to eql({"boundary" => '=_NextPart_Lycos_15031600484464_ID'})
     end
 
+    it "should handle 'multipart/mixed; boundary=\"=_NextPart_2rfkindysadvnqw3nerasdf\";windows-852" do
+      string = %q{multipart/mixed; boundary="=_NextPart_2rfkindysadvnqw3nerasdf";windows-852}
+      c = Mail::ContentTypeField.new(string)
+      expect(c.content_type).to eq 'multipart/mixed'
+      expect(c.main_type).to eq 'multipart'
+      expect(c.sub_type).to eq 'mixed'
+      expect(c.parameters).to eql({"boundary" => '=_NextPart_2rfkindysadvnqw3nerasdf', "windows-852" => ''})
+    end
+
     it "should handle 'multipart/alternative; boundary=----=_=NextPart_000_0093_01C81419.EB75E850" do
       string = %q{multipart/alternative; boundary=----=_=NextPart_000_0093_01C81419.EB75E850}
       c = Mail::ContentTypeField.new(string)


### PR DESCRIPTION
The following header was see in the wild:

```
Content-Type: multipart/mixed;
 boundary="=_NextPart_2rfkindysadvnqw3nerasdf";windows-852
```

Due to the value-less `windows-852` param at the end, this header raises in the parser and gets sanitized before being re-parsed. The sanitize method, among other things, splits on "=" in order to reconstruct key-value params. Because the boundary contains "=" itself, everything after "=" was ignored.

Resulting params before commit:

```ruby
{ "boundary" => "\\\"", "windows-852" => "" }
```

Resulting params after commit:

```ruby
{ "boundary" => "=_NextPart_2rfkindysadvnqw3nerasdf", "windows-852" => "" }
```

Params are key-value pairs, so it just makes sense to split at most 2 parts.