### PR TITLE
Fix PartsList#recursive_each on Ruby 1.8

### DIFF
--- a/lib/mail/parts_list.rb
+++ b/lib/mail/parts_list.rb
@@ -60,25 +60,18 @@ module Mail
       }.join("\n")
     end
 
-    def recursive
-      Enumerator.new do |y|
-        each { |part|
-          if part.content_type == "message/rfc822"
-            sub_list = Mail.new(part.body).parts
-          else
-            sub_list = part.parts
-          end
-          y.yield part
-          if sub_list.any?
-            sub_list.recursive_each {|part|
-              y.yield part }
-          end
-        }
-      end
-    end
+    def recursive_each(&block)
+      each do |part|
+        if part.content_type == "message/rfc822"
+          sub_list = Mail.new(part.body).parts
+        else
+          sub_list = part.parts
+        end
 
-    def recursive_each
-      recursive.each {|part| yield part }
+        yield part
+
+        sub_list.recursive_each(&block)
+      end
     end
 
     def recursive_size

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1977,11 +1977,11 @@ describe Mail::Message do
 
       emails_with_attachments.each { |file_name|
         mail = read_fixture('emails', *file_name)
-        non_attachment_parts = mail.parts.recursive.reject(&:attachment?)
+        non_attachment_parts = mail.all_parts.reject(&:attachment?)
         expect(mail.has_attachments?).to be_truthy
         mail.without_attachments!
 
-        expect(mail.parts.recursive.to_a).to eq non_attachment_parts
+        expect(mail.all_parts).to eq non_attachment_parts
         expect(mail.has_attachments?).to be_falsey
       }
     end


### PR DESCRIPTION
Ruby 1.8 has `Enumerable::Enumerator` but not toplevel `Enumerator`. We don't necessarily need an enumerator, though, so just remove it.

References #858