### PR TITLE
Bugfix/pop3 frozen string

### DIFF
--- a/lib/mail/network/retriever_methods/pop3.rb
+++ b/lib/mail/network/retriever_methods/pop3.rb
@@ -70,10 +70,12 @@ module Mail
            options[:what].to_sym == :first && options[:order].to_sym == :asc ||
           mails.reverse!
         end
-        
+
         if block_given?
           mails.each do |mail|
-            new_message = Mail.new(mail.pop)
+            mail_data = StringIO.new
+            mail.pop(mail_data)
+            new_message = Mail.new(mail_data.string)
             new_message.mark_for_delete = true if options[:delete_after_find]
             yield new_message
             mail.delete if options[:delete_after_find] && new_message.is_marked_for_delete? # Delete if still marked for delete
@@ -81,7 +83,9 @@ module Mail
         else
           emails = []
           mails.each do |mail|
-            emails << Mail.new(mail.pop)
+            mail_data = StringIO.new
+            mail.pop mail_data
+            emails << Mail.new(mail_data.string)
             mail.delete if options[:delete_after_find]
           end
           emails.size == 1 && options[:count] == 1 ? emails.first : emails

--- a/lib/mail/network/retriever_methods/pop3.rb
+++ b/lib/mail/network/retriever_methods/pop3.rb
@@ -75,7 +75,7 @@ module Mail
           mails.each do |mail|
             mail_data = StringIO.new
             mail.pop(mail_data)
-            new_message = Mail.new(mail_data.string)
+            new_message = Mail.new(mail_data.string.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: ''))
             new_message.mark_for_delete = true if options[:delete_after_find]
             yield new_message
             mail.delete if options[:delete_after_find] && new_message.is_marked_for_delete? # Delete if still marked for delete
@@ -85,7 +85,7 @@ module Mail
           mails.each do |mail|
             mail_data = StringIO.new
             mail.pop mail_data
-            emails << Mail.new(mail_data.string)
+            emails << Mail.new(mail_data.string.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: ''))
             mail.delete if options[:delete_after_find]
           end
           emails.size == 1 && options[:count] == 1 ? emails.first : emails


### PR DESCRIPTION
Hi mikel :wave: 

I tried to use you library with ruby 2.5.0 and 2.6.0-preview1 and I had Froze String Exception.
So I digged a little bit and I found this is because appending mail body to pure string.
So I replaced it with `StringIO` and it started to working properly.