### PR TITLE
Prevent “invalid byte sequence in UTF-8” when initializing from string

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1981,6 +1981,7 @@ module Mail
     end
 
     def raw_source=(value)
+      value = value.dup.force_encoding(Encoding::BINARY) if RUBY_VERSION >= "1.9.1"
       @raw_source = value
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -402,6 +402,14 @@ describe Mail::Message do
         end
       end
     end
+
+    if '1.9+'.respond_to?(:encoding)
+      it "should allow invalid bytes in UTF-8" do
+        mail = Mail.new("From: mikel\r\nSubject: foo \xE1 bar\r\n\r\nThis is the body")
+        expect(mail.body.to_s).to eq 'This is the body'
+        expect(mail.subject).to eq String.new("foo \xE1 bar").force_encoding(Encoding::BINARY)
+      end
+    end
   end
 
   describe "directly setting values of a message" do


### PR DESCRIPTION
When upgrading to current master, we had regressions in our test suite for all emails containing non-valid UTF-8 bytes, which are often seen in the wild. The exception was raised by `String#match` in `#set_envelope_header`, which is called right after `#raw_source=` in `#init_with_string`.

Bringing back `#force_encoding` in `#raw_source=` (removed in dedb6695) solved all of these without breaking any other spec, so I figured it was a sensible fix. Let me know if something else would be more appropriate.