### PR TITLE
Make References field singular like In-Reply-To

### DIFF
--- a/lib/mail/fields/references_field.rb
+++ b/lib/mail/fields/references_field.rb
@@ -31,6 +31,10 @@ module Mail
   class ReferencesField < CommonMessageIdField #:nodoc:
     NAME = 'References'
 
+    def self.singular?
+      true
+    end
+
     def initialize(value = nil, charset = nil)
       value = value.join("\r\n\s") if value.is_a?(Array)
       super value, charset

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -165,6 +165,16 @@ describe Mail::Message do
       expect(Mail::Utilities.blank?(mail.in_reply_to)).to be_truthy
     end
 
+    it "should be able to pass two In-Reply-To headers" do
+      mail = Mail.new("From: bob\r\nIn-Reply-To: <a@a.a>\r\nIn-Reply-To: <b@b.b>\r\nSubject: Hello!\r\n\r\nemail message\r\n")
+      expect(mail.in_reply_to).to eq 'b@b.b'
+    end
+
+    it "should be able to pass two References headers" do
+      mail = Mail.new("From: bob\r\nReferences: <a@a.a>\r\nReferences: <b@b.b>\r\nSubject: Hello!\r\n\r\nemail message\r\n")
+      expect(mail.references).to eq 'b@b.b'
+    end
+
     describe "YAML serialization" do
       before(:each) do
         # Ensure specs don't randomly fail due to messages being generated 1 second apart


### PR DESCRIPTION
`In-Reply-To` was made singular as part of 7c2bc2e4, but `References` wasn’t. It caused the following exception when parsing emails from the wild containing multiple `References` fields:

```
  1) Mail::Message initialization should be able to pass two References headers
     Failure/Error: field.default

     NoMethodError:
       undefined method `default' for #<Array:0x00007f93701ed6a0>
     # ./lib/mail/message.rb:1208:in `default'
     # ./lib/mail/message.rb:756:in `references'
```

[RFC 5322](https://tools.ietf.org/html/rfc5322) indicates both fields should be present at most once:

```
   +----------------+--------+------------+----------------------------+
   | Field          | Min    | Max number | Notes                      |
   |                | number |            |                            |
   +----------------+--------+------------+----------------------------+
   |      ...       |  ...   |    ...     |            ...             |
   |                |        |            |                            |
   | in-reply-to    | 0*     | 1          | SHOULD occur in some       |
   |                |        |            | replies - see 3.6.4        |
   | references     | 0*     | 1          | SHOULD occur in some       |
   |                |        |            | replies - see 3.6.4        |
   |      ...       |  ...   |    ...     |            ...             |
   +----------------+--------+------------+----------------------------+
```

Included are specs for both fields ensuring they can be extracted when present twice in a parsed email, in which case the last value defined is used.