### PR TITLE
Address `LoadError: cannot load such file -- bundler/dep_proxy`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 
 bundler_args: --without local_development
 before_install:
-  - gem update bundler
+  - gem install bundler
 
 script: bundle exec rake
 


### PR DESCRIPTION
CI with `ruby-head` is getting this error https://travis-ci.org/mikel/mail/jobs/359195509
```ruby
$ bundle exec rake
bundler: failed to load command: rake (/home/travis/build/mikel/mail/vendor/bundle/ruby/2.6.0/bin/rake)
LoadError: cannot load such file -- bundler/dep_proxy
```
It is likely duplicate with
https://github.com/travis-ci/travis-ci/issues/8969

It would also address CI failure at #1221. 