### PR TITLE
Use spelling for MIME-Version as defined in RFC 2045

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,14 +418,14 @@ Content-Type: multipart/alternative;
   boundary=--==_mimepart_4a914f0c911be_6f0f1ab8026659
 Message-ID: <4a914f12ac7e_6f0f1ab80267d1@baci.local.mail>
 Date: Mon, 24 Aug 2009 00:15:46 +1000
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
 
 ----==_mimepart_4a914f0c911be_6f0f1ab8026659
 Content-ID: <4a914f12c8c4_6f0f1ab80268d6@baci.local.mail>
 Date: Mon, 24 Aug 2009 00:15:46 +1000
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 
@@ -434,7 +434,7 @@ This is plain text
 Content-Type: text/html; charset=UTF-8
 Content-ID: <4a914f12cf86_6f0f1ab802692c@baci.local.mail>
 Date: Mon, 24 Aug 2009 00:15:46 +1000
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
 <h1>This is HTML</h1>

--- a/lib/mail/fields/mime_version_field.rb
+++ b/lib/mail/fields/mime_version_field.rb
@@ -5,7 +5,7 @@ require 'mail/utilities'
 
 module Mail
   class MimeVersionField < NamedStructuredField #:nodoc:
-    NAME = 'Mime-Version'
+    NAME = 'MIME-Version'
 
     def self.singular?
       true

--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -213,7 +213,7 @@ module Mail
 
     # Returns true if the header has a MIME version defined (empty or not)
     def has_mime_version?
-      fields.has_field? 'Mime-Version'
+      fields.has_field? 'MIME-Version'
     end
 
     private

--- a/spec/mail/fields/mime_version_field_spec.rb
+++ b/spec/mail/fields/mime_version_field_spec.rb
@@ -89,7 +89,7 @@ describe Mail::MimeVersionField do
 
     it "should accept a string without the field name" do
       t = Mail::MimeVersionField.new('1.0')
-      expect(t.name).to eq 'Mime-Version'
+      expect(t.name).to eq 'MIME-Version'
       expect(t.value).to eq '1.0'
     end
 
@@ -148,7 +148,7 @@ describe Mail::MimeVersionField do
     
     it "should provide an encoded value" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
-      expect(t.encoded).to eq "Mime-Version: 1.0\r\n"
+      expect(t.encoded).to eq "MIME-Version: 1.0\r\n"
     end
 
     it "should provide an decoded value" do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1253,7 +1253,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_mime_version("3.0 (This is an unreal version number)")
-          expect(mail.to_s).to match(/Mime-Version: 3.0\r\n/)
+          expect(mail.to_s).to match(/MIME-Version: 3.0\r\n/)
         end
 
         it "should generate a mime version if nothing is passed to add_date" do
@@ -1264,7 +1264,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_mime_version
-          expect(mail.to_s).to match(/Mime-Version: 1.0\r\n/)
+          expect(mail.to_s).to match(/MIME-Version: 1.0\r\n/)
         end
 
         it "should make an email and inject a mime_version if none was set if told to_s" do
@@ -1274,7 +1274,7 @@ describe Mail::Message do
             subject 'This is a test email'
                body 'This is a body of the email'
           end
-          expect(mail.to_s).to match(/Mime-Version: 1.0\r\n/)
+          expect(mail.to_s).to match(/MIME-Version: 1.0\r\n/)
         end
 
         it "should add the mime version to the message permanently once sent to_s" do


### PR DESCRIPTION
This will result in better rating by some spam checkers.

e.g.: [MV_CASE](https://github.com/vstakhov/rspamd/blob/0e654a69f908ae3abe19663dc192f1dbc45d8ed0/rules/headers_checks.lua#L561) rule in Rspamd 