### PR TITLE
remove has rdoc

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.summary     = "Mail provides a nice Ruby DSL for making, sending and reading emails."
   s.license     = "MIT"
 
-  s.has_rdoc = true
   s.extra_rdoc_files = %w[ README.md ]
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 


### PR DESCRIPTION
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /mail/mail.gemspec:13.
```