### PR TITLE
additionally register UnixToUnix encoding as 'x-uue'

### DIFF
--- a/lib/mail/encodings/unix_to_unix.rb
+++ b/lib/mail/encodings/unix_to_unix.rb
@@ -14,6 +14,7 @@ module Mail
 
       Encodings.register(NAME, self)
       Encodings.register("uuencode", self)
+      Encodings.register("x-uue", self)
     end
   end
 end

--- a/spec/mail/encodings/unix_to_unix_spec.rb
+++ b/spec/mail/encodings/unix_to_unix_spec.rb
@@ -19,6 +19,10 @@ describe Mail::Encodings::UnixToUnix do
     expect(Mail::Encodings.get_encoding('x-uuencode')).to eq(Mail::Encodings::UnixToUnix)
   end
 
+  it "is registered as x-uue" do
+    expect(Mail::Encodings.get_encoding('x-uue')).to eq(Mail::Encodings::UnixToUnix)
+  end
+
   it "can transport itself" do
     expect(Mail::Encodings::UnixToUnix.can_transport?(Mail::Encodings::UnixToUnix)).to be_truthy
   end


### PR DESCRIPTION
Processing an email that used 'x-uue' as encoding name failed. Problem and fix are similar to #844 / #878