### PR TITLE
default parser

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -159,7 +159,7 @@ module Mail
     end
 
     def uri_parser
-      @uri_parser ||= URI.const_defined?(:Parser) ? URI::Parser.new : URI
+      @uri_parser ||= URI.const_defined?(:Parser) ? URI::DEFAULT_PARSER : URI
     end
 
     # Matches two objects with their to_s values case insensitively

--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -159,7 +159,7 @@ module Mail
     end
 
     def uri_parser
-      @uri_parser ||= URI.const_defined?(:Parser) ? URI::DEFAULT_PARSER : URI
+      @uri_parser ||= URI.const_defined?(:DEFAULT_PARSER) ? URI::DEFAULT_PARSER : URI
     end
 
     # Matches two objects with their to_s values case insensitively

--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -174,7 +174,7 @@ module Mail
     end
 
     def Ruby19.uri_parser
-      @uri_parser ||= URI::Parser.new
+      URI::DEFAULT_PARSER
     end
 
     # Pick a Ruby encoding corresponding to the message charset. Most

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -184,8 +184,7 @@ describe "Attachments" do
 
     it "should provide a URL escaped content_id (without brackets) for use inside an email" do
       @inline = @mail.attachments['test.gif'].cid
-      uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
-      expect(@inline).to eq uri_parser.escape(@cid.gsub(/^</, '').gsub(/>$/, ''))
+      expect(@inline).to eq Mail::Utilities.uri_parser.escape(@cid.gsub(/^</, '').gsub(/>$/, ''))
     end
   end
 

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -382,7 +382,7 @@ describe "Utilities Module" do
   end
 
   describe "url escaping" do
-    uri_parser = URI.const_defined?(:Parser) ? URI::Parser.new : URI
+    uri_parser = Mail::Utilities.uri_parser
 
     it "should have a wrapper on URI.escape" do
       expect(uri_escape("@?@!")).to eq uri_parser.escape("@?@!")


### PR DESCRIPTION
URI::Parser.new always allocates a new instance, but we can use URI::DEFAULT_PARSER instead