### PR TITLE
Avoid 7bit transfer encoding for attachments with non-ASCII bytes

### DIFF
--- a/lib/mail/encodings/7bit.rb
+++ b/lib/mail/encodings/7bit.rb
@@ -17,6 +17,11 @@ module Mail
       def self.encode(str)
         ::Mail::Utilities.binary_unsafe_to_crlf str
       end
+
+      # Per RFC 2045 2.7. 7bit Data, No octets with decimal values greater than 127 are allowed.
+      def self.compatible_input?(str)
+        str.ascii_only? && super
+      end
     end
   end
 end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1482,7 +1482,9 @@ describe Mail::Message do
 
         it "should use QP transfer encoding for 8bit text attachment with only a few 8bit characters" do
           mail = Mail.new
-          mail.attachments['iso_text.txt'] = (+"Pok\xE9mon").force_encoding('BINARY')
+          file_content = String.new("Pok\xE9mon")
+          file_content = file_content.force_encoding('BINARY') if file_content.respond_to?(:force_encoding)
+          mail.attachments['iso_text.txt'] = file_content
           mail.body = 'This is plain text US-ASCII'
           expect(mail.to_s).to match(%r{
             Content-Transfer-Encoding:\ 7bit

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1480,6 +1480,21 @@ describe Mail::Message do
           expect(mail.to_s).to match(%r{Content-Transfer-Encoding: quoted-printable})
         end
 
+        it "should use QP transfer encoding for 8bit text attachment with only a few 8bit characters" do
+          mail = Mail.new
+          mail.attachments['iso_text.txt'] = (+"Pok\xE9mon").force_encoding('BINARY')
+          mail.body = 'This is plain text US-ASCII'
+          expect(mail.to_s).to match(%r{
+            Content-Transfer-Encoding:\ 7bit
+            .*
+            This\ is\ plain\ text\ US-ASCII
+            .*
+            Content-Transfer-Encoding:\ quoted-printable
+            .*
+            Pok=E9mon
+          }mx)
+        end
+
         it "should use base64 transfer encoding for 8-bit text with lots of 8bit characters" do
           body = "This is NOT plain text ASCII　− かきくけこ"
           mail = Mail.new

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1491,7 +1491,7 @@ describe Mail::Message do
           expect(mail.to_s).to match(%r{Content-Transfer-Encoding: base64})
         end
 
-        it "should not use 8bit transfer encoding when 8bit is allowed" do
+        it "should use 8bit transfer encoding when 8bit is forced" do
           body = "This is NOT plain text ASCII　− かきくけこ"
           mail = Mail.new
           mail.charset = "UTF-8"


### PR DESCRIPTION
Prior to this change, non-ASCII attachments were encoded as `7bit` as long as they did not contain any line longer than 998 bytes. Such basic encoding negotiation is handled for the top-most part (the email itself) through the `Body#default_encoding` method:

```ruby
module Mail
  class Body
    # ...

    def default_encoding
      ascii_only? ? '7bit' : '8bit'
    end

    # ...
  end
end
```

But attachments were lacking this. I believe making the `SevenBit` class aware of it is a sensible fix.

Note that this doesn’t [deal with NULs](https://tools.ietf.org/html/rfc2045#section-2.7):

> No octets with decimal values greater than 127 are allowed **and neither are NULs (octets with decimal value 0)**.

`"\x00".ascii_only?` returns true, but I figured it wasn’t a big deal and belonged in a separate issue since [8bit is also affected](https://tools.ietf.org/html/rfc2045#section-2.8):

> As with "7bit data" CR and LF octets only occur as part of CRLF line separation sequences **and no NULs are allowed**.

I’m happy to amend this pull request to handle NULs if you believe it’s worth it.