### PR TITLE
lock development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,15 @@ end
 gem 'tlsmail', '~> 0.0.1' if RUBY_VERSION <= '1.8.6'
 gem 'jruby-openssl', :platforms => :jruby
 
+gem 'rufo', '< 0.4' if RUBY_VERSION < '2.3.5'
 gem 'rake', '< 11.0' if RUBY_VERSION < '1.9.3'
-gem 'rdoc', '< 4.3' if RUBY_VERSION < '2.0'
+if RUBY_VERSION < '2.0'
+  gem 'rdoc', '< 4.3'
+elsif RUBY_VERSION < '2.2.2'
+  gem 'rdoc', '< 6'
+end
 
-gem 'mini_mime', :git => 'https://github.com/discourse/mini_mime'
+gem 'mini_mime'
 
 if RUBY_VERSION >= '2.0'
   gem 'byebug', :platforms => :mri


### PR DESCRIPTION
```
Gem::RuntimeRequirementNotMetError: rdoc 6.0.4 requires Ruby version >= 2.2.2.
Gem::RuntimeRequirementNotMetError: rufo 0.4.0 requires Ruby version >= 2.3.5.
+ use mini_mime from rubygems
```