### PR TITLE
Prevent unhandled RangeError in CommonDateField

### DIFF
--- a/lib/mail/fields/common_date_field.rb
+++ b/lib/mail/fields/common_date_field.rb
@@ -15,6 +15,8 @@ module Mail
         stripped = string.to_s.gsub(/\(.*?\)/, '').squeeze(' ')
         begin
           datetime = ::DateTime.parse(stripped)
+        rescue RangeError
+        # If fails to convert because date is out of range, fall back to use the string, no need to raise
         rescue ArgumentError => e
           raise unless 'invalid date' == e.message
         end


### PR DESCRIPTION
Fixes https://github.com/mikel/mail/issues/1269

The `normalize_datetime` method causes a `RangeError` crash when `DateTime.parse` fails to parse a date too big. This fixes this issue naively by using the original string when a `RangeError` is raised from the DateTime call.