### PR TITLE
Add the release date to v2.7.1

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,4 @@
-== Version 2.7.1 (unreleased)
+== Version 2.7.1 (2018-10-13)
 
 Compatibility:
 * Restore LF=>CRLF conversions for properly encoded non-binary emails. (rubys)


### PR DESCRIPTION
`2.7.1` already released https://rubygems.org/gems/mail/versions/2.7.1