### PR TITLE
Allowing multipart messages to be split when they are separated by LF only instead of CRLF

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -267,7 +267,7 @@ module Mail
       parts_regex = /
         (?:                    # non-capturing group
           \A                |  # start of string OR
-          \r\n                 # line break
+          \r?\n                # line break
          )
         (
           --#{Regexp.escape(boundary || "")}  # boundary delimiter


### PR DESCRIPTION
Some multipart messages use \n only instead of \r\n in their boundaries. Ran into this while parsing feedback loop reports sent by Return Path.