### PR TITLE
Add Address#==

### DIFF
--- a/lib/mail/elements/address.rb
+++ b/lib/mail/elements/address.rb
@@ -178,6 +178,10 @@ module Mail
       @data && @data.group
     end
 
+    def ==(other_address)
+      other_address.is_a?(Mail::Address) && to_s == other_address.to_s
+    end
+
     private
 
     def parse(value = nil)

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -176,6 +176,18 @@ describe Mail::Address do
       a = Mail::Address.new('Mikel Lindsaar <test@lindsaar.net>')
       expect(a).to eq(a)
     end
+
+    it "is not equal to another address instance with a different value" do
+      a = Mail::Address.new('Mikel Lindsaar <test@lindsaar.net>')
+      b = Mail::Address.new('test@lindsaar.net')
+      expect(a).not_to eq(b)
+    end
+
+    it "is not equal to a non-address object" do
+      a = Mail::Address.new('Mikel Lindsaar <test@lindsaar.net>')
+      b = 'Mikel Lindsaar <test@lindsaar.net>'
+      expect(a).not_to eq(b)
+    end
   end
 
   describe "assigning values directly" do

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -166,6 +166,16 @@ describe Mail::Address do
       expect(Mail::Address.new(junk).format).to eq junk
     end
 
+    it "is equal to another address instance with the same value" do
+      a = Mail::Address.new('Mikel Lindsaar <test@lindsaar.net>')
+      b = Mail::Address.new('Mikel Lindsaar <test@lindsaar.net>')
+      expect(a).to eq(b)
+    end
+
+    it "is equal to itself" do
+      a = Mail::Address.new('Mikel Lindsaar <test@lindsaar.net>')
+      expect(a).to eq(a)
+    end
   end
 
   describe "assigning values directly" do


### PR DESCRIPTION
This addition is extracted from https://github.com/rails/actionmailbox/blob/749e923539075eef407e5d9b8c7c151a3b3171d4/lib/action_mailbox/mail_ext/address_equality.rb
after seeing this issue rails/actionmailbox#6 about the desire to move the monkey patches to the mail gem.