### PR TITLE
#join remove empty strings

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -39,7 +39,7 @@ module Mail
       else
         # Do join first incase we have been given an Array in Ruby 1.9
         if string.respond_to?(:join)
-          @raw_source = ::Mail::Utilities.to_crlf(string.join(''))
+          @raw_source = ::Mail::Utilities.to_crlf(string.join)
         elsif string.respond_to?(:to_s)
           @raw_source = ::Mail::Utilities.to_crlf(string.to_s)
         else

--- a/lib/mail/fields/parameter_hash.rb
+++ b/lib/mail/fields/parameter_hash.rb
@@ -31,7 +31,7 @@ module Mail
       if pairs.empty? # Just dealing with a single value pair
         super(exact || key_name)
       else # Dealing with a multiple value pair or a single encoded value pair
-        string = pairs.sort { |a,b| a.first.to_s <=> b.first.to_s }.map { |v| v.last }.join('')
+        string = pairs.sort_by { |a| a.first.to_s }.map { |v| v.last }.join
         if mt = string.match(/([\w\-]+)?'(\w\w)?'(.*)/)
           string = mt[3]
           encoding = mt[1]


### PR DESCRIPTION
.join('') allocates an empty string which isn't necessary especially on older rubies that don't support frozen string literals