### PR TITLE
Backport: Treat 'uuencode' as 'x-uuencode' for compatibility with some older ma…

### DIFF
--- a/lib/mail/encodings/unix_to_unix.rb
+++ b/lib/mail/encodings/unix_to_unix.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Mail
   module Encodings
-    module UnixToUnix
+    class UnixToUnix < TransferEncoding
       NAME = "x-uuencode"
 
       def self.decode(str)
@@ -13,6 +13,7 @@ module Mail
       end
 
       Encodings.register(NAME, self)
+      Encodings.register("uuencode", self)
     end
   end
 end

--- a/spec/mail/encodings/unix_to_unix_spec.rb
+++ b/spec/mail/encodings/unix_to_unix_spec.rb
@@ -11,6 +11,14 @@ describe Mail::Encodings::UnixToUnix do
     Mail::Encodings::UnixToUnix.encode(str)
   end
 
+  it "can transport x-uuencode" do
+    expect(Mail::Encodings::UnixToUnix.can_transport?('x-uuencode')).to be_truthy
+  end
+
+  it "can transport uuencode" do
+    expect(Mail::Encodings::UnixToUnix.can_transport?('uuencode')).to be_truthy
+  end
+
   it "decodes" do
     text = strip_heredoc(<<-TEXT)
       begin 644 Happy.txt


### PR DESCRIPTION
…ilers

Closes #878. Fixes #844.

<hr>

Hi there!

We over at [Zammad](https://github.com/zammad/zammad) use this great gem for processing incoming mails. Thanks a lot for providing and maintaining it! Unfortunately we have huge compatibility issues with the latest 2.7 branch and we hadn't had the time to look deeper into it yet. That's why we're still relying on 2.6. However, we now have the issue that we can't process  'uuencode' / 'x-uuencode'  `Content-Transfer-Encoding` mails. While investigating this issue we found out that it already has been [fixed 4 years ago](https://github.com/mikel/mail/commit/b196215806e57db011fe9a8bf8532777ea60fa5d) in master/2.7 but was never backported to 2.6.
That's the purpose of this PR: [Cherry-picking the fix](https://github.com/zammad-deps/mail/commit/33a8a94028937e8664a7499d3486ffed59b898e6) from 2.7 into 2.6.

We would greatly appreciate a backport (and a new 2.6 release) so we can remove [our fork](https://github.com/zammad-deps/mail/tree/2-6-stable-878-844) and keep the original 2.6 version as a dependency while figuring things out with 2.7. 👨‍🔬