### PR TITLE
Have Mail.deliver method uphold settings[:return_response]

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -249,13 +249,13 @@ module Mail
     #  mail.deliver
     def deliver
       inform_interceptors
-      if delivery_handler
+      response = if delivery_handler
         delivery_handler.deliver_mail(self) { do_delivery }
       else
         do_delivery
       end
       inform_observers
-      self
+      delivery_method.settings[:return_response] ? response : self
     end
 
     # This method bypasses checking perform_deliveries and raise_delivery_errors,


### PR DESCRIPTION
I have updated this method to have consistent behavior with deliver!

This follows up on issue https://github.com/mikel/mail/issues/1225

Does this look like something you would be willing to merge in? Or are there any issues that I missed.

Currently 4 tests failing after the update
```
rspec ./spec/mail/network_spec.rb:259 # Mail deliveries perform_deliveries should call deliver! on the delivery method by default
rspec ./spec/mail/network_spec.rb:266 # Mail deliveries perform_deliveries should not call deliver if perform deliveries is set to false
rspec ./spec/mail/network_spec.rb:317 # Mail deliveries raise_delivery_errors should not pass on delivery errors if raised raise_delivery_errors is set to false
rspec ./spec/mail/network_spec.rb:349 # Mail deliveries delivery_handler mail only call its delivery_method once
```

I can fix tests once I get some initial feedback