### PR TITLE
sudo: false is now deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 
 bundler_args: --without local_development


### PR DESCRIPTION
separated from https://github.com/mikel/mail/pull/1308

see for reference
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration