### PR TITLE
Cherry-pick fix for Mail::PhraseListsElement to the 2.7 stable branch

### DIFF
--- a/lib/mail/parsers/phrase_lists_parser.rb
+++ b/lib/mail/parsers/phrase_lists_parser.rb
@@ -869,7 +869,7 @@ module Mail::Parsers
       end
 
       if p != eof || cs < 42
-        raise Mail::Field::IncompleteParseError.new(Mail::PhraseListsElement, data, p)
+        raise Mail::Field::IncompleteParseError.new(Mail::PhraseList, data, p)
       end
 
       phrase_lists

--- a/lib/mail/parsers/phrase_lists_parser.rl
+++ b/lib/mail/parsers/phrase_lists_parser.rl
@@ -74,7 +74,7 @@ module Mail::Parsers
       %%write exec;
 
       if p != eof || cs < %%{ write first_final; }%%
-        raise Mail::Field::IncompleteParseError.new(Mail::PhraseListsElement, data, p)
+        raise Mail::Field::IncompleteParseError.new(Mail::PhraseList, data, p)
       end
 
       phrase_lists

--- a/spec/mail/fields/keywords_field_spec.rb
+++ b/spec/mail/fields/keywords_field_spec.rb
@@ -44,6 +44,10 @@ describe Mail::KeywordsField do
       expect(k.keywords).to eq ['these, are keywords (another comment to be ignored)', 'so there (This is an irrelevant comment)']
     end
     
+    it "should raise ParseError when value is invalid" do
+      k = Mail::KeywordsField.new('Not: Valid')
+      expect { k.keywords }.to raise_error(Mail::Field::ParseError)
+    end
   end
   
   describe "encoding and decoding" do


### PR DESCRIPTION
This PR fixes #1238 and #1286. 

7c2bc2e4ac2760061 already fixed the Mail::PhraseListsElement issue on `master`. This PR cherry-picks the fix for `2-7-stable`.    

The RSpec test is entirely from [dariota](https://github.com/dariota)'s comment here: https://github.com/mikel/mail/issues/1286#issuecomment-435841211