### PR TITLE
Do not mutate argument hashes in retriever methods

### DIFF
--- a/lib/mail/network/retriever_methods/base.rb
+++ b/lib/mail/network/retriever_methods/base.rb
@@ -11,8 +11,8 @@ module Mail
     #   count: number of emails to retrieve. The default value is 1.
     #   order: order of emails returned. Possible values are :asc or :desc. Default value is :asc.
     #
-    def first(options = {}, &block)
-      options ||= {}
+    def first(options = nil, &block)
+      options = options ? Hash[options] : {}
       options[:what] = :first
       options[:count] ||= 1
       find(options, &block)
@@ -24,8 +24,8 @@ module Mail
     #   count: number of emails to retrieve. The default value is 1.
     #   order: order of emails returned. Possible values are :asc or :desc. Default value is :asc.
     #
-    def last(options = {}, &block)
-      options ||= {}
+    def last(options = nil, &block)
+      options = options ? Hash[options] : {}
       options[:what] = :last
       options[:count] ||= 1
       find(options, &block)
@@ -36,8 +36,8 @@ module Mail
     # Possible options:
     #   order: order of emails returned. Possible values are :asc or :desc. Default value is :asc.
     #
-    def all(options = {}, &block)
-      options ||= {}
+    def all(options = nil, &block)
+      options = options ? Hash[options] : {}
       options[:count] = :all
       find(options, &block)
     end
@@ -53,8 +53,8 @@ module Mail
     #   delete_after_find: flag for whether to delete each retreived email after find. Default
     #           is true. Call #find if you would like this to default to false.
     #
-    def find_and_delete(options = {}, &block)
-      options ||= {}
+    def find_and_delete(options = nil, &block)
+      options = options ? Hash[options] : {}
       options[:delete_after_find] ||= true
       find(options, &block)      
     end 

--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -70,7 +70,7 @@ module Mail
     #           The default is 'ALL'
     #   search_charset: charset to pass to IMAP server search. Omitted by default. Example: 'UTF-8' or 'ASCII'.
     #
-    def find(options={}, &block)
+    def find(options=nil, &block)
       options = validate_options(options)
 
       start do |imap|
@@ -142,7 +142,7 @@ module Mail
 
       # Set default options
       def validate_options(options)
-        options ||= {}
+        options = options ? Hash[options] : {}
         options[:mailbox] ||= 'INBOX'
         options[:count]   ||= 10
         options[:order]   ||= :asc

--- a/lib/mail/network/retriever_methods/pop3.rb
+++ b/lib/mail/network/retriever_methods/pop3.rb
@@ -57,7 +57,7 @@ module Mail
     #   delete_after_find: flag for whether to delete each retreived email after find. Default
     #           is false. Use #find_and_delete if you would like this to default to true.
     #
-    def find(options = {}, &block)
+    def find(options = nil, &block)
       options = validate_options(options)
       
       start do |pop3|
@@ -113,7 +113,7 @@ module Mail
   
     # Set default options
     def validate_options(options)
-      options ||= {}
+      options = options ? Hash[options] : {}
       options[:count] ||= 10
       options[:order] ||= :asc
       options[:what]  ||= :first

--- a/lib/mail/network/retriever_methods/test_retriever.rb
+++ b/lib/mail/network/retriever_methods/test_retriever.rb
@@ -17,7 +17,8 @@ module Mail
       @@emails = []
     end
 
-    def find(options = {}, &block)
+    def find(options = nil, &block)
+      options = options ? Hash[options] : {}
       options[:count] ||= :all
       options[:order] ||= :asc
       options[:what] ||= :first

--- a/spec/mail/network/retriever_methods/imap_spec.rb
+++ b/spec/mail/network/retriever_methods/imap_spec.rb
@@ -76,6 +76,10 @@ describe "IMAP Retriever" do
   end
 
   describe "find and options" do
+    it "should work with a frozen hash argument" do
+      messages = Mail.find({:count => :all, :what => :last, :order => :asc}.freeze)
+      expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }
+    end
     it "should handle the :count option" do
       messages = Mail.find(:count => :all, :what => :last, :order => :asc)
       expect(messages.map { |m| m.raw_source }).to eq MockIMAP.examples.map { |m| m.attr['RFC822'] }

--- a/spec/mail/network/retriever_methods/pop3_spec.rb
+++ b/spec/mail/network/retriever_methods/pop3_spec.rb
@@ -46,6 +46,11 @@ describe "POP3 Retriever" do
 
   describe "find and options" do
 
+    it "should work with a frozen hash argument" do
+      messages = Mail.find({:count => :all, :what => :last, :order => :asc}.freeze)
+      expect(messages.map { |m| m.raw_source }.sort).to eq MockPOP3.popmails.map { |p| p.pop }
+    end
+
     it "should handle the :count option" do
       messages = Mail.find(:count => :all, :what => :last, :order => :asc)
       expect(messages.map { |m| m.raw_source }.sort).to eq MockPOP3.popmails.map { |p| p.pop }

--- a/spec/mail/network/retriever_methods/test_retriever_spec.rb
+++ b/spec/mail/network/retriever_methods/test_retriever_spec.rb
@@ -37,6 +37,14 @@ describe "Test Retriever" do
       @emails = populate(15)
     end
 
+    it "should work with frozen hash arguments" do
+      expect(Mail.find({:count => 1}.freeze)).to eq @emails.first
+      expect(Mail.first({}.freeze)).to eq @emails.first
+      expect(Mail.last({}.freeze)).to eq @emails.last
+      expect(Mail.all({}.freeze)).to eq @emails
+      expect(Mail.find_and_delete({}.freeze)).to eq @emails
+    end
+
     it "should handle the :count option" do
       expect(Mail.find(:count => :all)).to eq @emails
       expect(Mail.find(:count => 1)).to eq @emails.first


### PR DESCRIPTION
This fixes usage with frozen hash arguments.