### PR TITLE
Fix regression in content_type for text part after converted to multipart

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1771,7 +1771,7 @@ module Mail
     private_constant :MULTIPART_CONVERSION_CONTENT_FIELDS if respond_to?(:private_constant)
 
     def convert_to_multipart
-      text_part = Mail::Part.new(:body => body.decoded)
+      text_part = Mail::Part.new(:content_type => 'text/plain;', :body => body.decoded)
 
       MULTIPART_CONVERSION_CONTENT_FIELDS.each do |field_name|
         if value = send(field_name)

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1507,6 +1507,28 @@ RSpec.describe Mail::Message do
         end
       end
 
+      describe "add_file sets content_type from attachment" do
+        it "should work if set before body" do
+          m = Mail.new
+          m.add_file :filename=>'a.txt', :content=>'b'
+          m.body 'c'
+          expect(m.parts.first.content_type).to match(/text\/plain/)
+          expect(m.parts.first.body.encoded).to eq('b')
+          expect(m.parts.last.content_type).to match(/text\/plain/)
+          expect(m.parts.last.body.encoded).to eq('c')
+        end
+
+        it "should work if set after body" do
+          m = Mail.new
+          m.body 'c'
+          m.add_file :filename=>'a.txt', :content=>'b'
+          expect(m.parts.first.content_type).to match(/text\/plain/)
+          expect(m.parts.first.body.encoded).to eq('c')
+          expect(m.parts.last.content_type).to match(/text\/plain/)
+          expect(m.parts.last.body.encoded).to eq('b')
+        end
+      end
+
       describe "content-transfer-encoding" do
 
         it "should use 7bit for only US-ASCII chars" do


### PR DESCRIPTION
This was broken by 404ecdd290f89658fb05da02ea5b6139fd82ebdb.  It removed
the setting of the default :content_type entry for the text part, before
copying the content fields to the text part.  This puts back the setting
of the default :content_type entry for the text part.

In 2.7.1:

```ruby
m = Mail.new
m.body 'c'
m.add_file :filename=>'a.txt', :content=>'b'
m.parts.first.content_type =~ /text\/plain/ # => 0
```

Before this commit:

```ruby
m = Mail.new
m.body 'c'
m.add_file :filename=>'a.txt', :content=>'b'
m.parts.first.content_type =~ /text\/plain/ # => nil

m.encoded
m.parts.first.content_type =~/text\/plain/ # => 0
```

After this commit:

```ruby
m = Mail.new
m.body 'c'
m.add_file :filename=>'a.txt', :content=>'b'
m.parts.first.content_type =~ /text\/plain/ # => 0
```

Regression found by Roda's mailer plugin tests.