### PR TITLE
Handle edge case where attachment part is missing filename

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -17,5 +17,7 @@ Compatibility:
 Features:
 * Message#inspect_structure and PartsList#inspect_structure pretty-print the hierarchy of message parts. (TylerRick)
 
+Bugs:
+* Handle case when attachment parts do not contain a filename or Content-Location header. (lao9)
 
 Please check [2-7-stable](https://github.com/mikel/mail/blob/2-7-stable/CHANGELOG.rdoc) for previous changes.

--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -93,6 +93,18 @@ module Mail
       @filename ||= parameters['filename'] || parameters['name']
     end
 
+    def attachment_name
+      case
+      when filename
+        @attachment_name = filename
+      when string && !non_attachment_types.include?(string)
+        @attachment_name = "untitled"
+      else
+        @attachment_name = nil
+      end
+      @attachment_name
+    end
+
     def encoded
       p = ";\r\n\s#{parameters.encoded}" if parameters && parameters.length > 0
       "#{name}: #{content_type}#{p}\r\n"
@@ -167,6 +179,10 @@ module Mail
       else
         'text/plain'
       end
+    end
+
+    def non_attachment_types
+      ['text/plain', 'text/html', 'text/enriched', 'application/x-yaml', 'multipart/alternative', 'multipart/mixed']
     end
   end
 end

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2119,6 +2119,7 @@ module Mail
       content_type_name = header[:content_type].filename rescue nil
       content_disp_name = header[:content_disposition].filename rescue nil
       content_loc_name  = header[:content_location].location rescue nil
+      content_type_attachment_name = header[:content_type].attachment_name rescue nil
       case
       when content_disposition && content_disp_name
         filename = content_disp_name
@@ -2126,6 +2127,8 @@ module Mail
         filename = content_type_name
       when content_location && content_loc_name
         filename = content_loc_name
+      when content_type && content_type_attachment_name
+        filename = content_type_attachment_name
       else
         filename = nil
       end

--- a/spec/fixtures/emails/attachment_emails/attachment_missing_filename.eml
+++ b/spec/fixtures/emails/attachment_emails/attachment_missing_filename.eml
@@ -1,0 +1,30 @@
+Mime-Version: 1.0 (Apple Message framework v730)
+Content-Type: multipart/mixed; boundary=Apple-Mail-13-196941151
+Message-Id: <9169D984-4E0B-45EF-82D4-8F5E53AD7012@example.com>
+From: foo@example.com
+Subject: testing
+Date: Mon, 6 Jun 2005 22:21:22 +0200
+To: blah@example.com
+
+
+--Apple-Mail-13-196941151
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+	charset=ISO-8859-1;
+	delsp=yes;
+	format=flowed
+
+This is the first part.
+
+--Apple-Mail-13-196941151
+Content-Type: image/jpeg
+Content-Transfer-Encoding: base64
+Content-ID: <qbFGyPQAS8>
+Content-Disposition: inline
+
+jamisSqGSIb3DQEHAqCAMIjamisxCzAJBgUrDgMCGgUAMIAGCSqGSjamisEHAQAAoIIFSjCCBUYw
+ggQujamisQICBD++ukQwDQYJKojamisNAQEFBQAwMTELMAkGA1UEBhMCRjamisAKBgNVBAoTA1RE
+QzEUMBIGjamisxMLVERDIE9DRVMgQ0jamisNMDQwMjI5MTE1OTAxWhcNMDYwMjamisIyOTAxWjCB
+gDELMAkGA1UEjamisEsxKTAnBgNVBAoTIEjamisuIG9yZ2FuaXNhdG9yaXNrIHRpbjamisRuaW5=
+
+--Apple-Mail-13-196941151--

--- a/spec/fixtures/emails/attachment_emails/attachment_with_filename.eml
+++ b/spec/fixtures/emails/attachment_emails/attachment_with_filename.eml
@@ -1,0 +1,30 @@
+Mime-Version: 1.0 (Apple Message framework v730)
+Content-Type: multipart/mixed; boundary=Apple-Mail-13-196941151
+Message-Id: <9169D984-4E0B-45EF-82D4-8F5E53AD7012@example.com>
+From: foo@example.com
+Subject: testing
+Date: Mon, 6 Jun 2005 22:21:22 +0200
+To: blah@example.com
+
+
+--Apple-Mail-13-196941151
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+	charset=ISO-8859-1;
+	delsp=yes;
+	format=flowed
+
+This is the first part.
+
+--Apple-Mail-13-196941151
+Content-Type: image/jpeg; filename="Photo25.jpg"
+Content-Transfer-Encoding: base64
+Content-ID: <qbFGyPQAS8>
+Content-Disposition: inline
+
+jamisSqGSIb3DQEHAqCAMIjamisxCzAJBgUrDgMCGgUAMIAGCSqGSjamisEHAQAAoIIFSjCCBUYw
+ggQujamisQICBD++ukQwDQYJKojamisNAQEFBQAwMTELMAkGA1UEBhMCRjamisAKBgNVBAoTA1RE
+QzEUMBIGjamisxMLVERDIE9DRVMgQ0jamisNMDQwMjI5MTE1OTAxWhcNMDYwMjamisIyOTAxWjCB
+gDELMAkGA1UEjamisEsxKTAnBgNVBAoTIEjamisuIG9yZ2FuaXNhdG9yaXNrIHRpbjamisRuaW5=
+
+--Apple-Mail-13-196941151--

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -674,6 +674,31 @@ describe Mail::ContentTypeField do
 
   end
 
+  describe "finding an attachment_name" do
+
+    it "should return the filename if there is a filename" do
+      string = %q{application/octet-stream; filename=mikel.jpg}
+      c = Mail::ContentTypeField.new(string)
+      expect(c.attachment_name).to eq 'mikel.jpg'
+    end
+
+    it "should return nil if it is missing a filename and not an attachment type" do
+      c = Mail::ContentTypeField.new(['text', 'html', {'charset' => 'UTF-8'}])
+      expect(c.attachment_name).to eq nil
+    end
+
+    it "should return nil if it is missing a filename and has no attachment type" do
+      c = Mail::ContentTypeField.new
+      expect(c.attachment_name).to eq nil
+    end
+
+    it "should return 'untitled' if it missing a filename and an attachment type" do
+      c = Mail::ContentTypeField.new('image/jpg')
+      expect(c.attachment_name).to eq 'untitled'
+    end
+
+  end
+
   describe "handling badly formated content-type fields" do
 
     it "should handle missing sub-type on a text content type" do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1432,7 +1432,7 @@ describe Mail::Message do
           part.body          = 'a' * 999
         end
         mail.encoded
-        
+
         expect(mail.parts.count).to eq(1)
         expect(mail.parts.last.content_transfer_encoding).to match(/7bit|8bit|binary/)
       end
@@ -1452,6 +1452,47 @@ describe Mail::Message do
           expect(subject.parts[0].header[:content_disposition].value).to eq("attachment; filename=blah.gz")
           expect(subject.parts[0].header[:content_description].value).to eq("Attachment has identical content to above foo.gz")
           expect(subject.parts[0].header[:content_transfer_encoding].value).to eq("base64")
+        end
+      end
+
+      describe "find_attachment" do
+        context "with content location" do
+          subject do
+            read_fixture('emails', 'attachment_emails', 'attachment_content_location.eml')
+          end
+
+          it "returns content location filename" do
+            expect(subject.parts[0].send(:find_attachment)).to eq(nil)
+            expect(subject.parts[0].attachment?).to eq(false)
+            expect(subject.parts[1].send(:find_attachment)).to eq("Photo25.jpg")
+            expect(subject.parts[1].attachment?).to eq(true)
+          end
+        end
+
+        context "with content type filename" do
+          subject do
+            read_fixture('emails', 'attachment_emails', 'attachment_with_filename.eml')
+          end
+
+          it "returns content type filename" do
+            expect(subject.parts[0].send(:find_attachment)).to eq(nil)
+            expect(subject.parts[0].attachment?).to eq(false)
+            expect(subject.parts[1].send(:find_attachment)).to eq("Photo25.jpg")
+            expect(subject.parts[1].attachment?).to eq(true)
+          end
+        end
+
+        context "without content location or filename" do
+          subject do
+            read_fixture('emails', 'attachment_emails', 'attachment_missing_filename.eml')
+          end
+
+          it "returns 'untitled' for missing attachment name" do
+            expect(subject.parts[0].send(:find_attachment)).to eq(nil)
+            expect(subject.parts[0].attachment?).to eq(false)
+            expect(subject.parts[1].send(:find_attachment)).to eq("untitled")
+            expect(subject.parts[1].attachment?).to eq(true)
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #1329 

Semi-inspired by [php-mime-mail-parser](https://github.com/php-mime-mail-parser/php-mime-mail-parser/blob/0c6ca18dec422b7f0be16c1b92219a3366c485a7/src/Parser.php#L504): 

Recommending that when the part is missing both content-location and filename, we check the type and provide a default filename if it is an attachment type.