### PR TITLE
Fix invalid byte sequence error

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -129,7 +129,7 @@ module Mail
         str = charset_encoder.encode(str, charset)
       end
       transcode_to_scrubbed_utf8(str)
-    rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
+    rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError, Encoding::InvalidByteSequenceError
       warn "Encoding conversion failed #{$!}"
       str.dup.force_encoding(Encoding::UTF_8)
     end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -211,6 +211,12 @@ describe Mail::Encodings do
         string = '=?GB2312?B?6V8=?='.dup.force_encoding('us-ascii')
         expect(Mail::Encodings.value_decode(string)).to eq("開")
       end
+
+      it "should decode an invalid utf-7 byte sequence" do
+        string = "=?utf-7?B?aVBhZHMsIE1hY0Jvb2tzLCAmIG1vcmUgdXAgdG8gOTArQUNVLSBPZmY=?="
+        result = "iPads, MacBooks, & more up to 90+ACU- Off"
+        expect(Mail::Encodings.value_decode(string)).to eq(result)
+      end
     end
   end
 


### PR DESCRIPTION
This fixes an error where decoding a UTF-7 string raised an
`Encoding::InvalidByteSequenceError`. The resulting string isn't
perfect. There's some weird characters, but the result is better than
the alternative.