### PR TITLE
fix actionmailer spec

### DIFF
--- a/spec/travis-actionmailer.sh
+++ b/spec/travis-actionmailer.sh
@@ -4,6 +4,7 @@ set -v -e
 git clone --depth=1 https://github.com/rails/rails.git -b master
 cd rails
 echo -e "\ngem 'mail', path: '../'" >> Gemfile
-bundle update --source mail
+gem update bundler
+bundle update --bundler --source mail
 cd actionmailer
 bundle exec rake test


### PR DESCRIPTION
fixes

   /home/travis/.rvm/rubies/ruby-2.5.5/lib/ruby/2.5.0/rubygems.rb:284:in `find_spec_for_exe': Could not find 'bundler' (1.17.3) required by your /home/travis/build/mikel/mail/rails/Gemfile.lock. (Gem::GemNotFoundException)
   To update to the latest version installed on your system, run `bundle update --bundler`.
   To install the missing version, run `gem install bundler:1.17.3`
