### PR TITLE
Add init_with method to Mail::Body

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -50,6 +50,11 @@ module Mail
       set_charset
     end
 
+    def init_with(coder)
+      coder.map.each { |k, v| instance_variable_set(:"@#{k}", v) }
+      @parts = Mail::PartsList.new(coder['parts'])
+    end
+
     # Matches this body with another body.  Also matches the decoded value of this
     # body with a string.
     # 

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -457,4 +457,12 @@ describe Mail::Body do
       expect(body.encoded).to eq 'The Body'
     end
   end
+
+  describe "Partslist empty" do
+    it "should not break on empty PartsList on body" do
+      body = Mail::Body.new('The Body')
+      body.sort_parts!
+      expect(body.parts.count).to eq 0
+    end
+  end
 end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -231,6 +231,13 @@ describe Mail::Message do
         expect(deserialized.delivery_handler).to be_nil
       end
 
+      it "should deserialize parts as an instance of Mail::PartsList" do
+        yaml = @yaml_mail.to_yaml
+        yaml_hash = YAML.load(yaml)
+        deserialized = Mail::Message.from_yaml(yaml_hash.to_yaml)
+        expect(deserialized.parts).to be_kind_of(Mail::PartsList)
+      end
+
       it "should handle multipart mail" do
         @yaml_mail.add_part Mail::Part.new(:content_type => 'text/html', :body => '<b>body</b>')
         deserialized = Mail::Message.from_yaml(@yaml_mail.to_yaml)

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -36,6 +36,12 @@ describe "PartsList" do
     expect(p.sort!(order)).to eq [plain_text_part, html_text_part, no_content_type_part]
   end
 
+  it "should not fail on empty PartsList" do
+    p = Mail::PartsList.new
+    order = ['text/plain']
+    p.sort!(order)
+  end
+
   it "should sort attachments to end" do
     p = Mail::PartsList.new
     order = ['text/plain', 'text/html']


### PR DESCRIPTION
Fixes the case where a `PartsList` gets serialized as an `Array`, but does not get correctly deserialized back to a `PartsList` instance. The `init_from` would ordinarily be added to the `PartsList` class but this does not work due to the use of `SerializeClass(Array)` so instead I assign it on deserialization of `Mail::Body`.

CC @jeremy

Related to https://github.com/mikel/mail/issues/1038