### PR TITLE
Adding suffix to FileDelivery

### DIFF
--- a/lib/mail/network/delivery_methods/file_delivery.rb
+++ b/lib/mail/network/delivery_methods/file_delivery.rb
@@ -22,7 +22,7 @@ module Mail
     attr_accessor :settings
 
     def initialize(values)
-      self.settings = { :location => './mails' }.merge!(values)
+      self.settings = { :location => './mails', :suffix => '' }.merge!(values)
     end
 
     def deliver!(mail)
@@ -35,7 +35,7 @@ module Mail
       end
 
       envelope.to.uniq.each do |to|
-        path = ::File.join(settings[:location], File.basename(to.to_s))
+        path = ::File.join(settings[:location], File.basename(to.to_s+settings[:suffix]))
 
         ::File.open(path, 'a') do |f|
           f.write envelope.message

--- a/lib/mail/network/delivery_methods/file_delivery.rb
+++ b/lib/mail/network/delivery_methods/file_delivery.rb
@@ -22,7 +22,7 @@ module Mail
     attr_accessor :settings
 
     def initialize(values)
-      self.settings = { :location => './mails', :suffix => '' }.merge!(values)
+      self.settings = { :location => './mails', :extension => '' }.merge!(values)
     end
 
     def deliver!(mail)
@@ -35,7 +35,7 @@ module Mail
       end
 
       envelope.to.uniq.each do |to|
-        path = ::File.join(settings[:location], File.basename(to.to_s+settings[:suffix]))
+        path = ::File.join(settings[:location], File.basename(to.to_s+settings[:extension]))
 
         ::File.open(path, 'a') do |f|
           f.write envelope.message

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -142,7 +142,7 @@ describe "Mail" do
       mail.delivery_method :file, :location => tmpdir
       expect(mail.delivery_method.class).to eq Mail::FileDelivery
       expect(mail.delivery_method.settings).to eql({:location => tmpdir,
-                                                    :suffix => ''})
+                                                    :extension => ''})
     end
 
     it "should not change the default when it changes the delivery_method" do

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -141,7 +141,8 @@ describe "Mail" do
       tmpdir = File.expand_path('../../../tmp/mail', __FILE__)
       mail.delivery_method :file, :location => tmpdir
       expect(mail.delivery_method.class).to eq Mail::FileDelivery
-      expect(mail.delivery_method.settings).to eql({:location => tmpdir})
+      expect(mail.delivery_method.settings).to eql({:location => tmpdir,
+                                                    :suffix => ''})
     end
 
     it "should not change the default when it changes the delivery_method" do


### PR DESCRIPTION
Using Rails, I often find myself having to rename the file to be able to open it in my favourite mail client to check the rendering.

This change automates adding a suffix. For example, '.eml' can be used for Apple Mail.