### PR TITLE
Capitalization of MIME-Header

### DIFF
--- a/lib/mail/fields/mime_version_field.rb
+++ b/lib/mail/fields/mime_version_field.rb
@@ -5,7 +5,7 @@ require 'mail/utilities'
 
 module Mail
   class MimeVersionField < NamedStructuredField #:nodoc:
-    NAME = 'Mime-Version'
+    NAME = 'MIME-Version'
 
     def self.singular?
       true


### PR DESCRIPTION
The term "MIME" needs to capitalized as in the [RFC](https://tools.ietf.org/html/rfc2045) stated. A header in your notation will lead to a higher spam score in Rspamd: `MV_CASE (0.5)`