### PR TITLE
remove deprecated JRUBY_OPTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ rvm:
 
 env:
   global:
-    - JRUBY_OPTS="--server -J-Xms1500m -J-Xmx1500m -J-XX:+UseConcMarkSweepGC -J-XX:-UseGCOverheadLimit -J-XX:+CMSClassUnloadingEnabled"
     - RUBYOPT="-w"
   matrix:
     - MBCHARS=activesupport


### PR DESCRIPTION
Java HotSpot(TM) 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.


I think we can safely remove those options, tests on JRuby are still green