### PR TITLE
Fix typo in comment

### DIFF
--- a/lib/mail/multibyte/chars.rb
+++ b/lib/mail/multibyte/chars.rb
@@ -316,7 +316,7 @@ module Mail #:nodoc:
       #
       # Example:
       #   s = 'こんにちは'
-      #   s.mb_chars.limit(7) # => "こに"
+      #   s.mb_chars.limit(7) # => "こん"
       def limit(limit)
         slice(0...translate_offset(limit))
       end


### PR DESCRIPTION
```
irb(main):012:0> s=Mail::Multibyte.mb_chars("こんにちは")
=> #<Mail::Multibyte::Chars:0x00007fc6b18490c0 @wrapped_string="こんにちは">
irb(main):013:0> s.limit(7)
=> #<Mail::Multibyte::Chars:0x00007fc6b1839300 @wrapped_string="こん">
```