### PR TITLE
Improve Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Please do!  Contributing is easy in Mail.  Please read the CONTRIBUTING.md docum
 All major mail functions should be able to happen from the Mail module.
 So, you should be able to just <code>require 'mail'</code> to get started.
 
+`mail` is pretty well documented in its Ruby code.  You can look it up e.g. at [rubydoc.info](https://www.rubydoc.info/gems/mail).
+
 ### Making an email
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ I have tried to simplify it some:
 
 ## Contributing
 
-Please do!  Contributing is easy in Mail.  Please read the CONTRIBUTING.md document for more info
+Please do!  Contributing is easy in Mail.  Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document for more info.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ mail.cc              #=> 'sam@test.lindsaar.net'
 mail.subject         #=> "This is the subject"
 mail.date.to_s       #=> '21 Nov 1997 09:55:06 -0600'
 mail.message_id      #=> '<4D6AA7EB.6490534@xxx.xxx>'
-mail.decoded         #=> 'This is the body of the email...
+mail.body.decoded    #=> 'This is the body of the email...
 ```
 
 Many more methods available.

--- a/README.md
+++ b/README.md
@@ -284,15 +284,25 @@ mail.delivery_method :logger
 mail.delivery_method :logger, logger: other_logger, severity: :debug
 ```
 
-### Getting Emails from a POP Server:
+### Getting Emails from a POP or IMAP Server:
 
 You can configure Mail to receive email using <code>retriever_method</code>
 within <code>Mail.defaults</code>:
 
 ```ruby
+# e.g. POP3
 Mail.defaults do
   retriever_method :pop3, :address    => "pop.gmail.com",
                           :port       => 995,
+                          :user_name  => '<username>',
+                          :password   => '<password>',
+                          :enable_ssl => true
+end
+
+# IMAP
+Mail.defaults do
+  retriever_method :imap, :address    => "imap.mailbox.org",
+                          :port       => 993,
                           :user_name  => '<username>',
                           :password   => '<password>',
                           :enable_ssl => true

--- a/lib/mail/mail.rb
+++ b/lib/mail/mail.rb
@@ -152,7 +152,7 @@ module Mail
     retriever_method.first(*args, &block)
   end
 
-  # Receive the first email(s) from the default retriever
+  # Receive the last email(s) from the default retriever
   # See Mail::Retriever for a complete documentation.
   def self.last(*args, &block)
     retriever_method.last(*args, &block)


### PR DESCRIPTION
- fix a copy/paste error in Mail#last
- fix #decode example in README. Here I am not 100% sure but calling #decode on a mail-object gives me `Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.`. Although I'd find it pretty cool if #decode gives me whatever text/body-part there is.