### PR TITLE
Improve documentation

### DIFF
--- a/lib/mail/mail.rb
+++ b/lib/mail/mail.rb
@@ -152,7 +152,7 @@ module Mail
     retriever_method.first(*args, &block)
   end
 
-  # Receive the first email(s) from the default retriever
+  # Receive the last email(s) from the default retriever
   # See Mail::Retriever for a complete documentation.
   def self.last(*args, &block)
     retriever_method.last(*args, &block)

--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1892,7 +1892,7 @@ module Mail
       when !self.multipart?
         body.decoded
       else
-        raise NoMethodError, 'Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.'
+        raise NoMethodError, 'This message cannot be decoded as _entire_ message, try calling #decoded on the various fields and body or parts if it is a multipart message.'
       end
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1587,7 +1587,7 @@ describe Mail::Message do
           body '<h1>This is HTML</h1>'
         end
       end
-      expect { mail.decoded }.to raise_error(NoMethodError, 'Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.')
+      expect { mail.decoded }.to raise_error(NoMethodError, 'This message cannot be decoded as _entire_ message, try calling #decoded on the various fields and body or parts if it is a multipart message.')
     end
 
     it "should return the decoded body if you call decode and the message is not multipart" do


### PR DESCRIPTION
- fix a copy/paste error in Mail#last
- **prior to conversation:** fix #decode example in README. Here I am not 100% sure but calling #decode on a mail-object gives me `Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.`. Although I'd find it pretty cool if #decode gives me whatever text/body-part there is.
- **after conversation:** Slightly improved message of NoMethodError in `Message#decode`. Agreed on further improvements should include choosing a more distinct Error class.