### PR TITLE
Only use dot-stuff workaround on old Ruby versions

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -17,5 +17,7 @@ Compatibility:
 Features:
 * Message#inspect_structure and PartsList#inspect_structure pretty-print the hierarchy of message parts. (TylerRick)
 
+Bugs:
+* Fix duplicate dots at beginning of lines. (c960657)
 
 Please check [2-7-stable](https://github.com/mikel/mail/blob/2-7-stable/CHANGELOG.rdoc) for previous changes.

--- a/lib/mail/network/delivery_methods/smtp_connection.rb
+++ b/lib/mail/network/delivery_methods/smtp_connection.rb
@@ -66,11 +66,7 @@ module Mail
       end
 
       def dot_stuff(message)
-        if message.end_with?("\r\n.")
-          message << "."
-        end
-
-        message
+        message.gsub(/(\r\n\.)([^\r\n]*$)/, '\1.\2')
       end
   end
 end

--- a/lib/mail/network/delivery_methods/smtp_connection.rb
+++ b/lib/mail/network/delivery_methods/smtp_connection.rb
@@ -50,15 +50,27 @@ module Mail
     # The from and to attributes are optional. If not set, they are retrieve from the Message.
     def deliver!(mail)
       envelope = Mail::SmtpEnvelope.new(mail)
-      response = smtp.sendmail(dot_stuff(envelope.message), envelope.from, envelope.to)
+      message = envelope.message
+      message = dot_stuff(message) if dot_stuff?
+      response = smtp.sendmail(message, envelope.from, envelope.to)
       settings[:return_response] ? response : self
     end
 
     private
-      # This is Net::SMTP's job, but before Ruby 2.x it does not dot-stuff
-      # an unterminated last line: https://bugs.ruby-lang.org/issues/9627
+      # Older versions of Net::SMTP does not dot-stuff an unterminated last line:
+      # https://bugs.ruby-lang.org/issues/9627
+      def dot_stuff?
+        RUBY_VERSION < "2.0.0" ||
+          RUBY_VERSION == "2.0.0" && RUBY_PATCHLEVEL < 576 ||
+          RUBY_VERSION >= "2.1.0" && RUBY_VERSION < "2.1.3"
+      end
+
       def dot_stuff(message)
-        message.gsub(/(\r\n\.)(\r\n|$)/, '\1.\2')
+        if message.end_with?("\r\n.")
+          message << "."
+        end
+
+        message
       end
   end
 end

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -15,16 +15,24 @@ describe "SMTP Delivery Method" do
     Mail.delivery_method.smtp.finish
   end
 
+  it "should not dot-stuff in recent Ruby versions" do
+    skip "is skipped on older Ruby versions" if RUBY_VERSION < '2.1.3'
+    expect(Mail.delivery_method.send(:dot_stuff?)).to eq false
+  end
+
   it "dot-stuff unterminated last line of the message" do
+    body = "this is a test\n.\nonly a test\n."
+
     Mail.deliver do
       from 'from@example.com'
       to 'to@example.com'
       subject 'dot-stuff last line'
-      body "this is a test\n.\nonly a test\n."
+      body body
     end
 
     message = MockSMTP.deliveries.first
-    expect(Mail.new(message).decoded).to eq("this is a test\n..\nonly a test\n..")
+    body << "." if Mail.delivery_method.send(:dot_stuff?)
+    expect(Mail.new(message).decoded).to eq(body)
   end
 
   it "should send an email using open SMTP connection" do

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -27,15 +27,18 @@ describe "SMTP Delivery Method" do
 
   describe "general usage" do
     it "dot-stuff unterminated last line of the message" do
+      body = "this is a test\n.\nonly a test\n."
+
       Mail.deliver do
         from 'from@example.com'
         to 'to@example.com'
         subject 'dot-stuff last line'
-        body "this is a test\n.\nonly a test\n."
+        body body
       end
 
       message = MockSMTP.deliveries.first
-      expect(Mail.new(message).decoded).to eq("this is a test\n..\nonly a test\n..")
+      body << "." if Mail::SMTPConnection.new(connection: Mail.delivery_method).send(:dot_stuff?)
+      expect(Mail.new(message).decoded).to eq(body)
     end
 
     it "should send emails from given settings" do

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -27,18 +27,17 @@ describe "SMTP Delivery Method" do
 
   describe "general usage" do
     it "dot-stuff unterminated last line of the message" do
-      body = "this is a test\n.\nonly a test\n."
+      skip "is skipped on Ruby versions without dot-stuff bug" unless Mail::SMTPConnection.new(connection: Mail.delivery_method).send(:dot_stuff?)
 
       Mail.deliver do
         from 'from@example.com'
         to 'to@example.com'
         subject 'dot-stuff last line'
-        body body
+        body "this is a test\n.\nonly a test\n... or is it?"
       end
 
       message = MockSMTP.deliveries.first
-      body << "." if Mail::SMTPConnection.new(connection: Mail.delivery_method).send(:dot_stuff?)
-      expect(Mail.new(message).decoded).to eq(body)
+      expect(Mail.new(message).decoded).to eq("this is a test\n.\nonly a test\n.... or is it?")
     end
 
     it "should send emails from given settings" do


### PR DESCRIPTION
In #683 a workaround was introduced for [broken dot-stuffing in Net::SMTP](https://bugs.ruby-lang.org/issues/9627) in older Ruby versions. However, the workaround is applied to all versions of Ruby, causing additional leading dots in the email being sent.

Also, this PR fixes a bug in the original workaround. We only need to do manual dot-stuffing if the last line of the email contains only a dot with no trailing newline. The tests imply that we also need to dot-stuff all lines with single dots, but that is wrong and also causes additional dots in the email being sent.

## Steps to reproduce
```
Mail.new do |m|
  m.from "from@example.com"
  m.to   "to@example.com"
  m.body ".foo\n."
end.deliver!
```

### Expected body (as displayed in email client)
```
.foo
.
```

### Actual body
```
.foo
..
```