### PR TITLE
Always add Net::SMTP.default_ssl_context#cert_store

### DIFF
--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -143,6 +143,7 @@ module Mail
         context.verify_mode = openssl_verify_mode if openssl_verify_mode
         context.ca_path = settings[:ca_path] if settings[:ca_path]
         context.ca_file = settings[:ca_file] if settings[:ca_file]
+        context.cert_store = OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE
         context
       end
   end

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -206,6 +206,38 @@ describe "SMTP Delivery Method" do
 
       expect { mail.deliver! }.not_to raise_error
     end
+
+    it 'should set OpenSSL default cert store when using TLS' do
+      context = OpenSSL::SSL::SSLContext.new
+      allow(Net::SMTP).to receive(:default_ssl_context).and_return(context)
+      expect(context).to receive(:cert_store=).with(OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE).at_least(1)
+
+      mail = Mail.deliver do
+        from    'roger@moore.com'
+        to      'marcel@amont.com'
+        subject 'invalid RFC2822'
+      end
+
+      expect { mail.deliver! }.not_to raise_error
+    end
+  end
+
+  describe 'without TLS' do
+    it 'should not call ssl_context' do
+      Mail.defaults do
+        delivery_method :smtp, :address => 'smtp.mockup.com', :port => 587, :enable_starttls_auto => false
+      end
+
+      expect(Net::SMTP).to_not receive(:default_ssl_context)
+
+      mail = Mail.deliver do
+        from    'roger@moore.com'
+        to      'marcel@amont.com'
+        subject 'Testing without TLS'
+      end
+
+      expect { mail.deliver! }.not_to raise_error
+    end
   end
 
   describe "enabling STARTTLS" do


### PR DESCRIPTION
**(Following up on an old PR (https://github.com/mikel/mail/pull/1089)**

I encountered the following error after setting `ActionMailer::Base.smtp_settings#openssl_verify_mode` to 'peer':

`SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)`

The way to fix this for me is manually setting the smtp_settings' ca_file, but the ca_file is an [undocumented configuration parameter](https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration) and thus not really clear to users.

I have now monkey patched my application with the change from this PR. Adding this as a default parameter does not harm the existing behaviour as far as I have found going through code and manual testing.