### PR TITLE
Use RSpec output matcher and do not redefine Kernel#warn in specs

### DIFF
--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -6,8 +6,11 @@ describe Mail::Field do
 
   describe 'parsing' do
     it "parses full header fields" do
-      expect($stderr).to_not receive(:puts)
-      field = Mail::Field.parse('To: Mikel')
+      field = nil
+      expect {
+        field = Mail::Field.parse('To: Mikel')
+      }.to_not output.to_stderr
+
       expect(field.name).to eq 'To'
       expect(field.value).to eq 'Mikel'
       if field.value.respond_to?(:encoding)

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -139,8 +139,9 @@ describe Mail::Message do
     end
 
     it "should not raise a warning on having non US-ASCII characters in the header (should just handle it)" do
-      expect($stderr).not_to receive(:puts)
-      read_fixture('emails', 'plain_emails', 'raw_email_string_in_date_field.eml')
+      expect {
+        read_fixture('emails', 'plain_emails', 'raw_email_string_in_date_field.eml')
+      }.to_not output.to_stderr
     end
 
     it "should raise a warning (and keep parsing) on having an incorrectly formatted header" do
@@ -1322,8 +1323,7 @@ describe Mail::Message do
           body = "This is plain text US-ASCII"
           mail = Mail.new
           mail.body = body
-          expect($stderr).not_to receive(:puts)
-          mail.to_s
+          expect { mail.to_s }.to_not output.to_stderr
         end
 
         it "should set the content type to text/plain; charset=us-ascii" do
@@ -1354,8 +1354,12 @@ describe Mail::Message do
           mail = Mail.new
           mail.body = body
           mail.content_transfer_encoding = "8bit"
-          expect($stderr).to receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
-          expect(mail.to_s).to match(%r{|Content-Type: text/plain; charset=UTF-8|})
+
+          result = nil
+          expect {
+            result = mail.to_s
+          }.to output(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./).to_stderr
+          expect(result).to match(%r{|Content-Type: text/plain; charset=UTF-8|})
         end
 
         it "should raise a warning if there is no charset parameter and there is non ascii chars and default to text/plain, UTF-8" do
@@ -1364,8 +1368,12 @@ describe Mail::Message do
           mail.body = body
           mail.content_type = "text/plain"
           mail.content_transfer_encoding = "8bit"
-          expect($stderr).to receive(:puts).with(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./m)
-          expect(mail.to_s).to match(%r{|Content-Type: text/plain; charset=UTF-8|})
+
+          result = nil
+          expect {
+            result = mail.to_s
+          }.to output(/Non US-ASCII detected and no charset defined.\nDefaulting to UTF-8, set your own if this is incorrect./).to_stderr
+          expect(result).to match(%r{|Content-Type: text/plain; charset=UTF-8|})
         end
 
         it "should not raise a warning if there is no charset parameter and the content-type is not text" do
@@ -1374,8 +1382,7 @@ describe Mail::Message do
           mail.body = body
           mail.content_type = "image/png"
           mail.content_transfer_encoding = "8bit"
-          expect($stderr).to_not receive(:puts)
-          mail.to_s
+          expect { mail.to_s }.to_not output.to_stderr
         end
 
         it "should not raise a warning if there is a charset defined and there is non ascii chars" do
@@ -1384,8 +1391,7 @@ describe Mail::Message do
           mail.body = body
           mail.content_transfer_encoding = "8bit"
           mail.content_type = "text/plain; charset=UTF-8"
-          expect($stderr).not_to receive(:puts)
-          mail.to_s
+          expect { mail.to_s }.to_not output.to_stderr
         end
 
         it "should be able to set a content type with an array and hash" do

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -618,8 +618,7 @@ describe "MIME Emails" do
         mail.body = body
         mail.charset = 'UTF-8'
         mail.add_file fixture_path('attachments', 'test.png')
-        expect($stderr).not_to receive(:puts)
-        mail.to_s
+        expect { mail.to_s }.to_not output.to_stderr
       end
 
 

--- a/spec/mail/part_spec.rb
+++ b/spec/mail/part_spec.rb
@@ -77,8 +77,8 @@ describe Mail::Part do
 
   describe "parts that have a missing header" do
     it "should not try to init a header if there is none" do
-      expect($stderr).not_to receive(:puts)
-      Mail::Part.new(Mail::Utilities.to_crlf(<<PARTEND))
+      expect {
+        Mail::Part.new(Mail::Utilities.to_crlf(<<PARTEND))
 
 The original message was received at Mon, 24 Dec 2007 10:03:47 +1100
 from 60-0-0-146.static.tttttt.com.au [60.0.0.146]
@@ -101,6 +101,7 @@ This message has been scanned for viruses and
 dangerous content by MailScanner, and is
 believed to be clean.
 PARTEND
+       }.to_not output.to_stderr
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -314,9 +314,3 @@ class Net::IMAP
     MockIMAP.new
   end
 end
-
-module Kernel
-  def warn(m)
-    $stderr.puts(m)
-  end
-end


### PR DESCRIPTION
#1105 worked around by redefining `Kernel#warn` but that definition is incompatible with recent `Kernel#warn` which accepts keyword arguments (`:uplevel`), and of course it's best to not redefine core methods.
For example, an issue with that redefinition is https://github.com/oracle/truffleruby/issues/1900.

The RSpec [`output` matcher](https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/output-matcher) makes it possible to be agnostic to how warnings are emitted, and just assert the output on `$stderr`.

cc @jeremyevans 