### PR TITLE
add `an_attachment_with_mime_type` option to check mime_type of attachments

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -16,6 +16,7 @@ Compatibility:
 
 Features:
 * Message#inspect_structure and PartsList#inspect_structure pretty-print the hierarchy of message parts. (TylerRick)
+* `an_attachment_with_mime_type` matcher added to match attachments by mime type
 
 
 Please check [2-7-stable](https://github.com/mikel/mail/blob/2-7-stable/CHANGELOG.rdoc) for previous changes.

--- a/README.md
+++ b/README.md
@@ -645,6 +645,12 @@ describe "sending an email" do
   # ... or any attachment
   it { is_expected.to have_sent_email.with_attachments(any_attachment) }
 
+  # ... or attachment with filename
+  it { is_expected.to have_sent_email.with_attachments(an_attachment_with_filename('file.txt')) }
+
+  # ... or attachment with mime_type
+  it { is_expected.to have_sent_email.with_attachments(an_attachment_with_mime_type('application/pdf')) }
+
   # ... by array of attachments
   it { is_expected.to have_sent_email.with_attachments([my_attachment1, my_attachment2]) } #note that order is important
 

--- a/lib/mail/matchers/attachment_matchers.rb
+++ b/lib/mail/matchers/attachment_matchers.rb
@@ -9,6 +9,10 @@ module Mail
       AttachmentFilenameMatcher.new(filename)
     end
 
+    def an_attachment_with_mime_type(filename)
+      AttachmentMimeTypeMatcher.new(filename)
+    end
+
     class AnyAttachmentMatcher
       def ===(other)
         other.attachment?
@@ -23,6 +27,17 @@ module Mail
 
       def ===(other)
         other.attachment? && other.filename == filename
+      end
+    end
+
+    class AttachmentMimeTypeMatcher
+      attr_reader :mime_type
+      def initialize(mime_type)
+        @mime_type = mime_type
+      end
+
+      def ===(other)
+        other.attachment? && other.mime_type == mime_type
       end
     end
   end

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -176,6 +176,10 @@ describe "have_sent_email" do
         it { is_expected.to have_sent_email.with_attachments(an_attachment_with_filename(first_attachment.filename)) }
       end
 
+      context 'matching by mimetype' do
+        it { is_expected.to have_sent_email.with_attachments(an_attachment_with_mime_type(first_attachment.mime_type)) }
+      end
+
       context 'single attachment passed' do
         it { is_expected.to have_sent_email.with_attachments(first_attachment) }
       end


### PR DESCRIPTION
thought this would be useful.

I have been following the contribution instructions as far as I can

> Tell me you have tested it against more than one version of Ruby, RVM is great for this. I test against 7 rubies before I push into master.

I tried to test against rubies 1.8.7 and 1.9.3 but was stuck on:

```
→ gem install bundler:2.0.2
Fetching: bundler-2.0.2.gem (100%)
ERROR:  Error installing bundler:
        bundler requires Ruby version >= 2.3.0.
```
all specs pass for ruby 2.6.5 and ruby 2.5.0  

I could not install dependencies for anything less than ruby 2.5.0 due to issues like the folllowing:

```
byebug-11.1.1 requires ruby version >= 2.4.0, which is incompatible with the current version, ruby 2.3.0p0
```

```
rufo-0.11.0 requires ruby version >= 2.4.5, which is incompatible with the current version, ruby 2.4.0p0
```

> Use good, idiomatic, structured and modular code

I copied the existing format precisely

> Include tests that fail without your code, and pass with it

have double checked that they fail appropriately

> Update the documentation, the surrounding one, examples elsewhere, guides, whatever is affected by your contribution

Have updated the README and CHANGELOG