### PR TITLE
CI: Test against Ruby 2.6.x and 2.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
   - jruby
   - jruby-head


### PR DESCRIPTION
Add Ruby 2.6.x and 2.7.x to Travis build matrix.