### PR TITLE
Remove downcase! method from sanitize function in ContentTypeField

### DIFF
--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -123,12 +123,6 @@ module Mail
         gsub(/[; ]+/, '; '). #use '; ' as a separator (or EOL)
         gsub(/;\s*$/,'') #remove trailing to keep examples below
 
-      if val =~ /(boundary=(\S*))/i
-        val = "#{$`.downcase}boundary=#{$2}#{$'.downcase}"
-      else
-        val.downcase!
-      end
-
       case
       when val.chomp =~ /^\s*([\w\-]+)\/([\w\-]+)\s*;\s?(ISO[\w\-]+)$/i
         # Microsoft helper:

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -708,7 +708,7 @@ describe Mail::ContentTypeField do
     it "should handle 'text/plain;ISO-8559-1'" do
       c = Mail::ContentTypeField.new('text/plain;ISO-8559-1')
       expect(c.string).to eq 'text/plain'
-      expect(c.parameters['charset']).to eq 'iso-8559-1'
+      expect(c.parameters['charset']).to eq 'ISO-8559-1'
     end
 
     it "should handle 'text/plain; charset = \"iso-8859-1\"'" do
@@ -726,7 +726,7 @@ describe Mail::ContentTypeField do
     it 'should handle text/html; charset="charset="GB2312""' do
       c = Mail::ContentTypeField.new('text/html; charset="charset="GB2312""')
       expect(c.string).to eq 'text/html'
-      expect(c.parameters['charset']).to eq 'gb2312'
+      expect(c.parameters['charset']).to eq 'GB2312'
     end
 
     it "should handle application/octet-stream; name=archiveshelp1[1].htm" do


### PR DESCRIPTION
Fixes #1398

This change removes the sequence of code that downcases the Content-Type header value. If I should believe the specs, it should serve no purpose. Only 2 specs break because of the charset being returned in capital letters instead of downcased as before.

This fixes the problem is which encoding is broken by downcasing, such as the example with base64 provided in #1398