### PR TITLE
Remove unused variables warnings

### DIFF
--- a/lib/mail/parsers/address_lists_parser.rb
+++ b/lib/mail/parsers/address_lists_parser.rb
@@ -31984,11 +31984,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/content_disposition_parser.rb
+++ b/lib/mail/parsers/content_disposition_parser.rb
@@ -583,11 +583,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/content_location_parser.rb
+++ b/lib/mail/parsers/content_location_parser.rb
@@ -589,7 +589,7 @@ begin
         return content_location if Mail::Utilities.blank?(data)
 
         # Parser state
-        disp_type_s = param_attr_s = param_attr = qstr_s = qstr = param_val_s = nil
+        qstr_s = nil
 
         # 5.1 Variables Used by Ragel
         p = 0
@@ -604,11 +604,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/content_transfer_encoding_parser.rb
+++ b/lib/mail/parsers/content_transfer_encoding_parser.rb
@@ -355,11 +355,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/content_type_parser.rb
+++ b/lib/mail/parsers/content_type_parser.rb
@@ -709,11 +709,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/date_time_parser.rb
+++ b/lib/mail/parsers/date_time_parser.rb
@@ -688,11 +688,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/envelope_from_parser.rb
+++ b/lib/mail/parsers/envelope_from_parser.rb
@@ -3238,11 +3238,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/message_ids_parser.rb
+++ b/lib/mail/parsers/message_ids_parser.rb
@@ -4845,11 +4845,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/mime_version_parser.rb
+++ b/lib/mail/parsers/mime_version_parser.rb
@@ -319,11 +319,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds  = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/phrase_lists_parser.rb
+++ b/lib/mail/parsers/phrase_lists_parser.rb
@@ -699,11 +699,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/lib/mail/parsers/received_parser.rb
+++ b/lib/mail/parsers/received_parser.rb
@@ -7511,11 +7511,9 @@ begin
         end
 
         begin
-          testEof = false
-          _slen, _trans, _keys, _inds, _acts, _nacts = nil
+          _slen, _trans, _keys, _inds, = nil
           _goto_level = 0
           _resume = 10
-          _eof_trans = 15
           _again = 20
           _test_eof = 30
           _out = 40

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -49,8 +49,6 @@ describe "SMTP Delivery Method" do
   end
 
   it "should not dot-stuff unterminated last line with no leading dot" do
-    body = "this is a test\n.\nonly a test"
-
     Mail.deliver do
       from 'from@example.com'
       to 'to@example.com'


### PR DESCRIPTION
This PR fixes #1384 removing warnings from unused variables.