### PR TITLE
Fix case of MIME-Version header field name

### DIFF
--- a/lib/mail/fields/mime_version_field.rb
+++ b/lib/mail/fields/mime_version_field.rb
@@ -5,7 +5,7 @@ require 'mail/utilities'
 
 module Mail
   class MimeVersionField < NamedStructuredField #:nodoc:
-    NAME = 'Mime-Version'
+    NAME = 'MIME-Version'
 
     def self.singular?
       true

--- a/spec/mail/fields/mime_version_field_spec.rb
+++ b/spec/mail/fields/mime_version_field_spec.rb
@@ -89,7 +89,7 @@ describe Mail::MimeVersionField do
 
     it "should accept a string without the field name" do
       t = Mail::MimeVersionField.new('1.0')
-      expect(t.name).to eq 'Mime-Version'
+      expect(t.name).to eq 'MIME-Version'
       expect(t.value).to eq '1.0'
     end
 
@@ -148,7 +148,7 @@ describe Mail::MimeVersionField do
     
     it "should provide an encoded value" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
-      expect(t.encoded).to eq "Mime-Version: 1.0\r\n"
+      expect(t.encoded).to eq "MIME-Version: 1.0\r\n"
     end
 
     it "should provide an decoded value" do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1261,7 +1261,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_mime_version("3.0 (This is an unreal version number)")
-          expect(mail.to_s).to match(/Mime-Version: 3.0\r\n/)
+          expect(mail.to_s).to match(/MIME-Version: 3.0\r\n/)
         end
 
         it "should generate a mime version if nothing is passed to add_date" do
@@ -1272,7 +1272,7 @@ describe Mail::Message do
                body 'This is a body of the email'
           end
           mail.add_mime_version
-          expect(mail.to_s).to match(/Mime-Version: 1.0\r\n/)
+          expect(mail.to_s).to match(/MIME-Version: 1.0\r\n/)
         end
 
         it "should make an email and inject a mime_version if none was set if told to_s" do
@@ -1282,7 +1282,7 @@ describe Mail::Message do
             subject 'This is a test email'
                body 'This is a body of the email'
           end
-          expect(mail.to_s).to match(/Mime-Version: 1.0\r\n/)
+          expect(mail.to_s).to match(/MIME-Version: 1.0\r\n/)
         end
 
         it "should add the mime version to the message permanently once sent to_s" do


### PR DESCRIPTION
This changes the header field name `Mime-Version` to `MIME-Version`.

While an incorrect case here might not cause any trouble since header field names should be treated case-insensitively, the actual correct spelling of this header field is `MIME-Version` (see [RFC 2045](https://tools.ietf.org/html/rfc2045#section-4)).

More importantly I noticed that spam filters such as [Rspamd](https://rspamd.com) penalize emails with an incorrect case for header fields like this, see the screenshot below.

<img width="461" alt="rspamd" src="https://user-images.githubusercontent.com/962845/90314518-a6dc0b00-df14-11ea-9aab-5e0e9bceabdc.png">