### PR TITLE
When parsing UTF-7, do not raise exceptions (except for B encodings)

### DIFF
--- a/spec/fixtures/emails/multi_charset/quoted-printable.eml
+++ b/spec/fixtures/emails/multi_charset/quoted-printable.eml
@@ -1,0 +1,4 @@
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+Valid: =E6=98=AF Invalid: =E6

--- a/spec/fixtures/emails/multi_charset/utf7.eml
+++ b/spec/fixtures/emails/multi_charset/utf7.eml
@@ -1,0 +1,3 @@
+Content-Type: text/plain; charset="utf-7"
+
+Valid: &Zi8- Invalid: &5g-

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -403,6 +403,16 @@ describe Mail::Message do
       expect(raw_message.encoding).to eq original_encoding if raw_message.respond_to?(:encoding)
     end
 
+    it "should parse utf-7 email without raising exceptions" do
+      mail = read_fixture('emails', 'multi_charset', 'utf7.eml')
+      expect(mail.decoded.chomp).to eq "Valid: 是 Invalid: �"
+    end
+
+    it "should parse quoted-printable email without raising exceptions" do
+      mail = read_fixture('emails', 'multi_charset', 'quoted-printable.eml')
+      expect(mail.decoded.chomp).to eq "Valid: 是 Invalid: �"
+    end
+
     if '1.9+'.respond_to?(:encoding)
       it "should be able to normalize CRLFs on non-UTF8 encodings" do
         File.open(fixture_path('emails', 'multi_charset', 'japanese_shift_jis.eml'), 'rb') do |io|


### PR DESCRIPTION
Fixes #1404 by removing UTF-7 encoding exceptions, calling `transcode_to_scrubbed_utf8` like most of the other code, without changing the behavior of B encodings.

Note: it's kind of ugly to have two versions of such an unusual decoding method, and I'm not sure that the kind of UTF-7 encoding supported by the Mail gem is valid for email bodies, but this at least should allow email to be processed without raising exceptions.