### PR TITLE
Do not alter "name" field of Content-Type header

### DIFF
--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -125,6 +125,10 @@ module Mail
 
       if val =~ /(boundary=(\S*))/i
         val = "#{$`.downcase}boundary=#{$2}#{$'.downcase}"
+      elsif val =~ /(name=(\S*))/i
+        val = "#{$`.downcase}name=#{$2}#{$'.downcase}"
+      elsif val =~ /(filename=(\S*))/i
+        val = "#{$`.downcase}filename=#{$2}#{$'.downcase}"
       else
         val.downcase!
       end

--- a/lib/mail/fields/content_type_field.rb
+++ b/lib/mail/fields/content_type_field.rb
@@ -123,12 +123,8 @@ module Mail
         gsub(/[; ]+/, '; '). #use '; ' as a separator (or EOL)
         gsub(/;\s*$/,'') #remove trailing to keep examples below
 
-      if val =~ /(boundary=(\S*))/i
-        val = "#{$`.downcase}boundary=#{$2}#{$'.downcase}"
-      elsif val =~ /(name=(\S*))/i
-        val = "#{$`.downcase}name=#{$2}#{$'.downcase}"
-      elsif val =~ /(filename=(\S*))/i
-        val = "#{$`.downcase}filename=#{$2}#{$'.downcase}"
+      if val =~ /((boundary|name|filename)=(\S*))/i
+        val = "#{$`.downcase}#{$2}=#{$3}#{$'.downcase}"
       else
         val.downcase!
       end

--- a/spec/fixtures/emails/attachment_emails/attachment_with_base64_encoded_name.eml
+++ b/spec/fixtures/emails/attachment_emails/attachment_with_base64_encoded_name.eml
@@ -1,0 +1,47 @@
+From xxxxxxxxx.xxxxxxx@gmail.com Sun May  8 19:07:09 2005
+Return-Path: <xxxxxxxxx.xxxxxxx@gmail.com>
+Message-ID: <e85734b90505081209eaaa17b@mail.gmail.com>
+Date: Sun, 8 May 2005 14:09:11 -0500
+From: xxxxxxxxx xxxxxxx <xxxxxxxxx.xxxxxxx@gmail.com>
+Reply-To: xxxxxxxxx xxxxxxx <xxxxxxxxx.xxxxxxx@gmail.com>
+To: xxxxx xxxx <xxxxx@xxxxxxxxx.com>
+Subject: Fwd: Signed email causes file attachments
+In-Reply-To: <F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@mac.com>
+Mime-Version: 1.0
+Content-Type: multipart/mixed; 
+	boundary="----=_Part_5028_7368284.1115579351471"
+References: <F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@mac.com>
+
+------=_Part_5028_7368284.1115579351471
+Content-Type: text/plain; charset=ISO-8859-1
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+We should not include these files or vcards as attachments.
+
+---------- Forwarded message ----------
+From: xxxxx xxxxxx <xxxxxxxx@xxx.com>
+Date: May 8, 2005 1:17 PM
+Subject: Signed email causes file attachments
+To: xxxxxxx@xxxxxxxxxx.com
+
+
+Hi,
+
+Test attachments with Base64 encoded filename.
+
+
+------=_Part_5028_7368284.1115579351471
+Content-Type: application/pdf; name==?utf-8?B?VGhpcyBpcyBhIHRlc3QucGRm?=
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename==?utf-8?B?VGhpcyBpcyBhIHRlc3QucGRm?=
+
+MIAGCSqGSIb3DQEHAqCAMIACAQExCzAJBgUrDgMCGgUAMIAGCSqGSIb3DQEHAQAAoIIGFDCCAs0w
+ggI2oAMCAQICAw5c+TANBgkqhkiG9w0BAQQFADBiMQswCQYDVQQGEwJaQTElMCMGA1UEChMcVGhh
+d3RlIENvbnN1bHRpbmcgKFB0eSkgTHRkLjEsMCoGA1UEAxMjVGhhd3RlIFBlcnNvbmFsIEZyZWVt
+YWlsIElzc3VpbmcgQ0EwHhcNMDUwMzI5MDkzOTEwWhcNMDYwMzI5MDkzOTEwWjBCMR8wHQYDVQQD
+ExZUaGF3dGUgRnJlZW1haWwgTWVtYmVyMR8wHQYJKoZIhvcNAQkBFhBzbWhhdW5jaEBtYWMuY29t
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAn90dPsYS3LjfMY211OSYrDQLzwNYPlAL
+7+/0XA+kdy8/rRnyEHFGwhNCDmg0B6pxC7z3xxJD/8GfCd+IYUUNUQV5m9MkxfP9pTVXZVIYLaBw
+------=_Part_5028_7368284.1115579351471--
+

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -259,6 +259,13 @@ describe "reading emails with attachments" do
       expect(result).to eq expected
     end
 
+    it "should find an attachment that has an base64 encoded name value" do
+      mail = read_fixture('emails/attachment_emails/attachment_with_base64_encoded_name.eml')
+      expect(mail.attachments.length).to eq 1
+      result = mail.attachments[0].filename
+      expect(result).to eq "This is a test.pdf"
+    end
+
     it "should find an attachment that has a name not surrounded by quotes" do
       mail = read_fixture('emails/attachment_emails/attachment_with_unquoted_name.eml')
       expect(mail.attachments.length).to eq 1


### PR DESCRIPTION
When Content-Type header parser fails, it tries to sanitize the value
and then parse it again. One step of the sanitization process was to
lowercase its value, which could change the meaning of "name" and
"filename" fields as upper and lower case characters represent
different things.