### PR TITLE
Change require in gemspec to require_relative

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -1,4 +1,4 @@
-require './lib/mail/version'
+require_relative './lib/mail/version'
 
 Gem::Specification.new do |s|
   s.name        = "mail"


### PR DESCRIPTION
This gemspec cannot be executed by native ruby code as `lib` is not yet on the load path. The only reason this currently with bundler is that it is "stubbed" and bundler otherwise fixes other path issues. Here's an example after you remove bundler's stubbing:

```
mktmpdir
echo "source 'https://rubygems.org'" >> Gemfile
echo "gem 'mail', github: 'mikel/mail'" >> Gemfile
bundle install

echo "require 'mail'; puts 'worked'" >> main.rb

# Go into the mail gem directory and remove the changes to mail.gemspec that bundler makes
cd $(bundle info mail --path)
git stash
cd -

bundle exec ruby main.rb
```

If you run this code you'll get an error:

```
$ bundle exec ruby main.rb
Invalid gemspec in [/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/mail-8fbb17d4d536/mail.gemspec]: cannot load such file -- ./lib/mail/version
Traceback (most recent call last):
  24: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
  23: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
  22: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/setup.rb:10:in `<top (required)>'
  21: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/ui/shell.rb:88:in `silence'
  20: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/ui/shell.rb:136:in `with_level'
  19: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/setup.rb:10:in `block in <top (required)>'
  18: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler.rb:149:in `setup'
  17: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/runtime.rb:20:in `setup'
  16: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/runtime.rb:101:in `block in definition_method'
  15: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/definition.rb:226:in `requested_specs'
  14: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/definition.rb:237:in `specs_for'
  13: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/definition.rb:170:in `specs'
  12: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/spec_set.rb:80:in `materialize'
  11: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/spec_set.rb:80:in `map!'
  10: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/spec_set.rb:83:in `block in materialize'
   9: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/lazy_specification.rb:75:in `__materialize__'
   8: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/git.rb:168:in `specs'
   7: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/path.rb:105:in `local_specs'
   6: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/git.rb:201:in `load_spec_files'
   5: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/path.rb:170:in `load_spec_files'
   4: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/path.rb:170:in `each'
   3: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/path.rb:171:in `block in load_spec_files'
   2: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/git.rb:320:in `load_gemspec'
   1: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/stub_specification.rb:9:in `from_stub'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/stub_specification.rb:158:in `name': undefined method `name' for nil:NilClass (NoMethodError)
```

Updating to a `require_relative` fixes the issue and `require_relative` is faster since it doesn't have to search the load path.

FWIW when bundle generates a new gem it also uses `require_relative`:

```
$ bundle gem mygem
Creating gem 'mygem'...
MIT License enabled in config
Code of conduct enabled in config
      create  mygem/Gemfile
      create  mygem/lib/mygem.rb
      create  mygem/lib/mygem/version.rb
      create  mygem/mygem.gemspec
      create  mygem/Rakefile
      create  mygem/README.md
      create  mygem/bin/console
      create  mygem/bin/setup
      create  mygem/.gitignore
      create  mygem/.travis.yml
      create  mygem/.rspec
      create  mygem/spec/spec_helper.rb
      create  mygem/spec/mygem_spec.rb
      create  mygem/LICENSE.txt
      create  mygem/CODE_OF_CONDUCT.md
Initializing git repo in /private/tmp/a7541bce67e048081127ebd8d13375a1/mygem
Gem 'mygem' was successfully created. For more information on making a RubyGem visit https://bundler.io/guides/creating_gem.html
$ cd mygem
$ cat mygem.gemspec
require_relative 'lib/mygem/version'

Gem::Specification.new do |spec|
  spec.name          = "mygem"
  spec.version       = Mygem::VERSION
  spec.authors       = ["schneems"]
  spec.email         = ["richard.schneeman+foo@gmail.com"]

  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
  spec.description   = %q{TODO: Write a longer description or delete this line.}
  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
  spec.license       = "MIT"
  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")

  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"

  spec.metadata["homepage_uri"] = spec.homepage
  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."

  # Specify which files should be added to the gem when it is released.
  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
  end
  spec.bindir        = "exe"
  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
  spec.require_paths = ["lib"]
end
```