### PR TITLE
Ensure lib is on the load path in mail.gemspec

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -1,4 +1,5 @@
-require './lib/mail/version'
+$LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
+require 'mail/version'
 
 Gem::Specification.new do |s|
   s.name        = "mail"


### PR DESCRIPTION
The current gemspec cannot be executed by native ruby code as `lib` is not yet on the load path. The only reason this currently with bundler is that it is "stubbed" and bundler otherwise fixes other path issues. Here's an example after you remove bundler's stubbing:

```ruby
mkdir -p /tmp/da5e922c690a8d15ac3c8578981b3d4d; cd /tmp/da5e922c690a8d15ac3c8578981b3d4d
echo "source 'https://rubygems.org'" >> Gemfile
echo "gem 'mail', github: 'mikel/mail'" >> Gemfile
bundle install

echo "require 'mail'; puts 'worked'" >> main.rb

# Go into the mail gem directory and remove the changes to mail.gemspec that bundler makes
cd $(bundle info mail --path)
git stash
cd -

bundle exec ruby main.rb
```

If you run this code you'll get an error:

```
$ bundle exec ruby main.rb
Invalid gemspec in [/Users/rschneeman/.gem/ruby/2.7.1/bundler/gems/mail-8fbb17d4d536/mail.gemspec]: cannot load such file -- ./lib/mail/version
Traceback (most recent call last):
  24: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
  23: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
  22: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/setup.rb:10:in `<top (required)>'
  21: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/ui/shell.rb:88:in `silence'
  20: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/ui/shell.rb:136:in `with_level'
  19: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/setup.rb:10:in `block in <top (required)>'
  18: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler.rb:149:in `setup'
  17: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/runtime.rb:20:in `setup'
  16: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/runtime.rb:101:in `block in definition_method'
  15: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/definition.rb:226:in `requested_specs'
  14: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/definition.rb:237:in `specs_for'
  13: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/definition.rb:170:in `specs'
  12: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/spec_set.rb:80:in `materialize'
  11: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/spec_set.rb:80:in `map!'
  10: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/spec_set.rb:83:in `block in materialize'
   9: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/lazy_specification.rb:75:in `__materialize__'
   8: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/git.rb:168:in `specs'
   7: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/path.rb:105:in `local_specs'
   6: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/git.rb:201:in `load_spec_files'
   5: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/path.rb:170:in `load_spec_files'
   4: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/path.rb:170:in `each'
   3: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/path.rb:171:in `block in load_spec_files'
   2: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/source/git.rb:320:in `load_gemspec'
   1: from /Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/bundler/stub_specification.rb:9:in `from_stub'
/Users/rschneeman/.rubies/ruby-2.7.1/lib/ruby/2.7.0/rubygems/stub_specification.rb:158:in `name': undefined method `name' for nil:NilClass (NoMethodError)
```

Previously in #1411 I updated the require to be a `require_relative` but this doesn't work with 1.9 and 1.8 so I switched back to the "old" way of manually unshifting lib onto the path.