### PR TITLE
support MS950 encoding

### DIFF
--- a/lib/mail/version_specific/ruby_1_9.rb
+++ b/lib/mail/version_specific/ruby_1_9.rb
@@ -236,6 +236,10 @@ module Mail
       when 'latin2'
         Encoding::ISO_8859_2
 
+      # Microsoft-specific alias for CP950 (Traditional Chinese)
+      when 'ms950'
+        Encoding::CP950
+
       else
         charset
       end

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -207,6 +207,7 @@ describe "mail encoding" do
         "latin2" => Encoding::ISO_8859_2,
         "ISO_8859-1" => Encoding::ISO_8859_1,
         "cp-850" => Encoding::CP850,
+        "MS950" => Encoding::CP950,
         "" => Encoding::BINARY
       }.each do |from, to|
         it "should support #{from}" do


### PR DESCRIPTION
Thie pull request fixes #1406 

```ruby
Mail::Encodings.value_decode '=?MS950?B?rue26aWrrEapssS1ue6nvaXms3G5SLNX?= =?MS950?B?wMvBfLFNsM/Ay8F8pEirSL1jpmGnfcXn?= =?MS950?B?w9KhXaa5q0il86ywqHSyzqbbsMq1b7Bl?= =?MS950?B?oUG90MJJv++kVaTos3O1sqFBpMWmXrRfKQ==?='"
# => 桃園市政府警察局交通違規檢舉專區檢舉人信箱地址驗證（此信件為系統自動發送，請點選下方連結，勿回復)
```

It seems like there are 2 places where we can put the test. I picked the first one, let me know if there is a better place for testing.

https://github.com/mikel/mail/blob/8fbb17d4d5364c77cc870769d451bc2739b3a8ce/spec/mail/encoding_spec.rb#L206-L216

https://github.com/mikel/mail/blob/8fbb17d4d5364c77cc870769d451bc2739b3a8ce/spec/mail/encodings_spec.rb#L952-L964