### PR TITLE
Rubydoc link is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Please do!  Contributing is easy in Mail.  Please read the [CONTRIBUTING.md](CON
 All major mail functions should be able to happen from the Mail module.
 So, you should be able to just <code>require 'mail'</code> to get started.
 
-`mail` is pretty well documented in its Ruby code.  You can look it up e.g. at [rubydoc.info](https://www.rubydoc.info/gems/mail).
+`mail` is pretty well documented in its Ruby code.  You can look it up e.g. at [rubydoc.info](https://www.rubydoc.info/github/mikel/mail).
 
 ### Making an email
 


### PR DESCRIPTION
The rubydoc link in README is not pointing to the correct page.