### PR TITLE
Add default timeouts for SMTP

### DIFF
--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -88,8 +88,8 @@ module Mail
       :openssl_verify_mode  => nil,
       :ssl                  => nil,
       :tls                  => nil,
-      :open_timeout         => nil,
-      :read_timeout         => nil
+      :open_timeout         => 5,
+      :read_timeout         => 5
     }
 
     def initialize(values)


### PR DESCRIPTION
I get lots of reports of "stuck" Sidekiq jobs due to email delivery. SMTP servers in the wild are notoriously unreliable, e.g. spam honeypots can leave TCP connections lingering. We need network connection timeouts by default.