### PR TITLE
Use full path for ragel svg task

### DIFF
--- a/tasks/ragel.rake
+++ b/tasks/ragel.rake
@@ -17,11 +17,11 @@ rule %r|_parser\.rb\z| => '%X.rl' do |t|
 end
 
 # Dot files for Ragel parsers
-rule %r|_parser\.dot\z| => '.rl' do |t|
+rule %r|_parser\.dot\z| => '%X.rl' do |t|
   sh "ragel -s -V -o #{t.name} #{t.source}"
 end
 
-rule %r|_parser\.svg\z| => '.dot' do |t|
+rule %r|_parser\.svg\z| => '%X.dot' do |t|
   sh "dot -v -Tsvg -Goverlap=scale -o #{t.name} #{t.source}"
 end
 


### PR DESCRIPTION
Currently the ragel:svg task is broken. We need to use the full path
because of a change to Rake in https://github.com/ruby/rake/pull/39.

We already changed this for the ragel:generate task in
https://github.com/mikel/mail/commit/20ffe29a45f96ba3bd9447571e0593f938a36c0e