### PR TITLE
Handle multiple singular headers when one of them is invalid

### DIFF
--- a/lib/mail/field_list.rb
+++ b/lib/mail/field_list.rb
@@ -10,13 +10,8 @@ module Mail
       any? { |f| f.responsible_for? field_name }
     end
 
-    def select_fields(field_name)
-      select { |f| f.responsible_for? field_name }
-    end
-
     def get_field(field_name)
       fields = select_fields(field_name)
-
       case fields.size
       when 0; nil
       when 1; fields.first
@@ -68,6 +63,17 @@ module Mail
 
     def summary
       map { |f| "<#{f.name}: #{f.value}>" }.join(", ")
+    end
+
+    private
+
+    def select_fields(field_name)
+      fields = select { |f| f.responsible_for? field_name }
+      if fields.size > 1 && fields.any?(&:singular?)
+        Array(fields.detect { |f| f.errors.size == 0 } || fields.first)
+      else
+        fields
+      end
     end
   end
 end

--- a/lib/mail/header.rb
+++ b/lib/mail/header.rb
@@ -228,10 +228,6 @@ module Mail
       self.fields = @raw_source.split(Constants::HEADER_SPLIT)
     end
 
-    def select_fields_for(name)
-      fields.select_fields { |f| f.responsible_for?(name) }
-    end
-
 
     # Enumerable support. Yield each field in order.
     def each(&block)

--- a/spec/fixtures/emails/error_emails/multiple_references_with_one_invalid.eml
+++ b/spec/fixtures/emails/error_emails/multiple_references_with_one_invalid.eml
@@ -1,0 +1,27 @@
+From: <redacted@flashmail.net>
+Subject: Redacted
+To: <redacted@Enron.com>
+Message-ID: <105647271315.NCV17523@x263.net>
+MIME-version: 1.0
+Content-Type: multipart/alternative; boundary="----_001_5973_47T00ZN9.15SY2428"
+References: <foo@bar.net>
+References: <baz@bar.net>, <invalid.   
+something@bar.net>
+
+This is a multi-part message in MIME format.
+
+------_001_5973_47T00ZN9.15SY2428
+Content-Type: text/plain;
+  charset="utf-8"
+Content-Transfer-Encoding: 7Bit
+
+foo
+
+------_001_5973_47T00ZN9.15SY2428
+Content-Type: text/html;
+  charset="utf-8"
+Content-Transfer-Encoding: 7Bit
+
+<p>foo</p>
+
+------_001_5973_47T00ZN9.15SY2428--

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -301,6 +301,20 @@ describe "Test emails" do
       end
     end
 
+    describe "handling multiple references with one of them invalid" do
+      before(:each) do
+        @message = read_fixture('emails', 'error_emails', 'multiple_references_with_one_invalid.eml')
+      end
+
+      it "should parse the email and encode without crashing" do
+        expect { @message.encoded }.not_to raise_error
+      end
+
+      it "should return the valid References value" do
+        expect(@message.references).to eq "foo@bar.net"
+      end
+    end
+
   end
 
   describe "empty address lists" do


### PR DESCRIPTION
Singular header fields are supposed to be replaced when inserted in the header's field list, as there can be only one of their type:
https://github.com/mikel/mail/blob/466876dbe9ff5d3b140b7a13cdd3eb6b6879d8f6/lib/mail/field_list.rb#L27-L33


However, if we happen to encounter an invalid field among the duplicate ones, we'll fail to parse it and we'll keep it
as `UnstructuredField`. Since `UnstructuredField` isn't _singular_, we won't replace the previous one we had for this header, they'll be stored separately in the field list. 

Then, later when fetching the field from the field list via `#get_field`, we'll find the valid and invalid ones, and for singular
fields, this will raise a
```
undefined method `default' for #<Array:0x00007f40da2f2f70> Did you mean? to_default_s
```
since we'll be returning an array instead of a proper container or list that knows how to handle multiple values.

This commit handles this case by checking when getting multiple values, whether one of them is singular and if this is the case, returning the first one without errors, or if there's none without errors, the first one.

Another approach to handle this could have been in the inserting phase. After parsing the field, or perhaps on parsing the field, we'd check whether the field class for the field name is singular and if the field itself is singular. If not, we don't add it to the field list. 
