### PR TITLE
Handle multiple invalid values for singular fields

### DIFF
--- a/lib/mail/field.rb
+++ b/lib/mail/field.rb
@@ -143,6 +143,10 @@ module Mail
         warn "WARNING: Ignoring unparsable header #{raw_field.inspect}: #{error.class}: #{error.message}"
         nil
       end
+
+      def field_class_for(name) #:nodoc:
+        FIELDS_MAP[name.to_s.downcase]
+      end
     end
 
     attr_reader :unparsed_value
@@ -263,15 +267,11 @@ module Mail
     def parse_field(name, value, charset)
       value = unfold(value) if value.is_a?(String)
 
-      if klass = field_class_for(name)
+      if klass = self.class.field_class_for(name)
         klass.parse(value, charset)
       else
         OptionalField.parse(name, value, charset)
       end
-    end
-
-    def field_class_for(name)
-      FIELDS_MAP[name.to_s.downcase]
     end
 
     # 2.2.3. Long Header Fields

--- a/lib/mail/field_list.rb
+++ b/lib/mail/field_list.rb
@@ -69,10 +69,18 @@ module Mail
 
     def select_fields(field_name)
       fields = select { |f| f.responsible_for? field_name }
-      if fields.size > 1 && fields.any?(&:singular?)
+      if fields.size > 1 && singular?(field_name)
         Array(fields.detect { |f| f.errors.size == 0 } || fields.first)
       else
         fields
+      end
+    end
+
+    def singular?(field_name)
+      if klass = Mail::Field.field_class_for(field_name)
+        klass.singular?
+      else
+        false
       end
     end
   end

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -315,6 +315,26 @@ describe "Test emails" do
       end
     end
 
+   describe "handling multiple content-disposition with all of them invalid" do
+      before(:each) do
+        @message = read_fixture('emails', 'error_emails', 'multiple_invalid_content_dispositions.eml')
+      end
+
+      it "should parse the email and encode without crashing" do
+        expect { @message.encoded }.not_to raise_error
+      end
+
+      it "should recognise the email as not attachment" do
+        expect(@message.attachment?).to be_falsey
+        expect(@message.has_attachments?).to be_falsey
+      end
+
+      it "should return one invalid Content-Disposition value" do
+        expect(@message[:content_disposition].errors).to_not be_empty
+        expect(@message.content_disposition).to eq "invalid"
+      end
+    end
+
   end
 
   describe "empty address lists" do


### PR DESCRIPTION
This is a follow-up to https://github.com/mikel/mail/pull/1431. In that PR we handled multiple values for singular fields when some of these multiple values were valid. In this case we handle multiple values, all of them invalid. In that case, we can't trust any of the individual instanced fields to respond to #singular?, since they won't be singular, they will be `UnstructuredField`. Then, when trying to fetch the value via `Mail::Message#<field_name>`, we'll get a
```
undefined method `default' for #<Array:0x00007f40da2f2f70> Did you mean? to_default_s
```
error again, as we'd select all invalid fields for the singular field, returning an array instead of a container that knows how to handle multiple values.

To prevent this, we ask the class for the field name we're parsing instead of relying on the field we might have failed to parse into the right class.
