### PR TITLE
Fix multipart parsing

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -272,7 +272,7 @@ module Mail
       parts_regex = /
         (?:                    # non-capturing group
           \A                |  # start of string OR
-          \r\n                 # line break
+          \r?\n                # line break
          )
         (
           --#{Regexp.escape(boundary || "")}  # boundary delimiter

--- a/spec/fixtures/emails/attachment_emails/attachment_pdf_lf.eml
+++ b/spec/fixtures/emails/attachment_emails/attachment_pdf_lf.eml
@@ -36,12 +36,14 @@ Content-Type: multipart/mixed;
 X-Virus-Scanned: amavisd-new at textdrive.com
 
 ------=_Part_2192_32400445.1115745999735
-Content-Type: text/plain; charset=ISO-8859-1
+Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 Content-Disposition: inline
 
 Just attaching another PDF, here, to see what the message looks like,
 and to see if I can figure out what is going wrong here.
+
+Plus some non-ascii téxt.
 
 ------=_Part_2192_32400445.1115745999735
 Content-Type: application/pdf; name="broken.pdf"


### PR DESCRIPTION
When there's a LF format, and non-ascii characters the parsing doesn't
work.