### PR TITLE
Add former default gems as a dependency for Ruby 3.1 compatibility

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 
   s.add_dependency('mini_mime', '>= 0.1.1')
+  s.add_dependency('net-smtp')
 
   s.add_development_dependency('bundler', '>= 1.0.3')
   s.add_development_dependency('rake', '> 0.8.7')

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency('mini_mime', '>= 0.1.1')
   s.add_dependency('net-smtp')
+  s.add_dependency('net-imap')
+  s.add_dependency('net-pop')
 
   s.add_development_dependency('bundler', '>= 1.0.3')
   s.add_development_dependency('rake', '> 0.8.7')


### PR DESCRIPTION
It was recently removed from the default gems:

  - https://bugs.ruby-lang.org/issues/17873
  - https://github.com/ruby/ruby/pull/4530

cc @mikel @jeremy 