### PR TITLE
Address spec failures since default timeouts added

### DIFF
--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -49,8 +49,8 @@ describe "Mail" do
                                                 :openssl_verify_mode  => nil,
                                                 :ssl                  => nil,
                                                 :tls                  => nil,
-                                                :open_timeout         => nil,
-                                                :read_timeout         => nil })
+                                                :open_timeout         => 5,
+                                                :read_timeout         => 5 })
     end
 
     it "should set the retriever method" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,8 @@ end
 
 # Original mockup from ActionMailer
 class MockSMTP
+  attr_accessor :open_timeout, :read_timeout
+
   def self.deliveries
     @@deliveries
   end


### PR DESCRIPTION
This pull request addresses these RSpec failures.

Follow up #1427, which added the default timeouts

* Steps to reproduce

```ruby
bundle install
bundle exec rspec ./spec/mail/network/delivery_methods/smtp_spec.rb
bundle exec rspec ./spec/mail/network_spec.rb
```

* Failed specs without this commit

```ruby
$ bundle exec rspec ./spec/mail/network/delivery_methods/smtp_spec.rb
Running Specs under Ruby Version 3.0.1
Running Specs for Mail Version 2.8.0.edge
*..FFFFFFF.F........

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) SMTP Delivery Method general usage dot-stuff unterminated last line of the message
     # is skipped on Ruby versions without dot-stuff bug
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:29


Failures:

  1) SMTP Delivery Method general usage should be able to return actual SMTP protocol response
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055a9dca59ed0>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:2141:in `do_delivery'
     # ./lib/mail/message.rb:255:in `deliver'
     # ./lib/mail/mail.rb:133:in `deliver'
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:78:in `block (3 levels) in <top (required)>'

  2) SMTP Delivery Method enabling tls should use OpenSSL::SSL::VERIFY_NONE if a context
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055a9dcb0b7c0>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:2141:in `do_delivery'
     # ./lib/mail/message.rb:255:in `deliver'
     # ./lib/mail/mail.rb:133:in `deliver'
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:105:in `block (3 levels) in <top (required)>'

  3) SMTP Delivery Method enabling tls should ignore OpenSSL::SSL::VERIFY_NONE if it is 0
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055a9dcb122c8>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:2141:in `do_delivery'
     # ./lib/mail/message.rb:255:in `deliver'
     # ./lib/mail/mail.rb:133:in `deliver'
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:122:in `block (3 levels) in <top (required)>'

  4) SMTP Delivery Method enabling ssl should use OpenSSL::SSL::VERIFY_NONE if a context
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055a9dcb18038>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:2141:in `do_delivery'
     # ./lib/mail/message.rb:255:in `deliver'
     # ./lib/mail/mail.rb:133:in `deliver'
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:146:in `block (3 levels) in <top (required)>'

  5) SMTP Delivery Method enabling ssl should ignore OpenSSL::SSL::VERIFY_NONE if it is 0
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055a9dcb2aaf8>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:2141:in `do_delivery'
     # ./lib/mail/message.rb:255:in `deliver'
     # ./lib/mail/mail.rb:133:in `deliver'
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:163:in `block (3 levels) in <top (required)>'

  6) SMTP Delivery Method enabling ssl should not set verify mode when none is given
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055a9dcaf88c8>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:2141:in `do_delivery'
     # ./lib/mail/message.rb:255:in `deliver'
     # ./lib/mail/mail.rb:133:in `deliver'
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:181:in `block (3 levels) in <top (required)>'

  7) SMTP Delivery Method enabling ssl should set verify mode if one is given
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055a9dca93db0>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:2141:in `do_delivery'
     # ./lib/mail/message.rb:255:in `deliver'
     # ./lib/mail/mail.rb:133:in `deliver'
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:203:in `block (3 levels) in <top (required)>'

  8) SMTP Delivery Method enabling STARTTLS should allow forcing STARTTLS
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055a9dcab0410>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:269:in `deliver!'
     # ./spec/mail/network/delivery_methods/smtp_spec.rb:243:in `block (3 levels) in <top (required)>'

Finished in 0.08895 seconds (files took 0.13099 seconds to load)
20 examples, 8 failures, 1 pending

Failed examples:

rspec ./spec/mail/network/delivery_methods/smtp_spec.rb:73 # SMTP Delivery Method general usage should be able to return actual SMTP protocol response
rspec ./spec/mail/network/delivery_methods/smtp_spec.rb:97 # SMTP Delivery Method enabling tls should use OpenSSL::SSL::VERIFY_NONE if a context
rspec ./spec/mail/network/delivery_methods/smtp_spec.rb:114 # SMTP Delivery Method enabling tls should ignore OpenSSL::SSL::VERIFY_NONE if it is 0
rspec ./spec/mail/network/delivery_methods/smtp_spec.rb:138 # SMTP Delivery Method enabling ssl should use OpenSSL::SSL::VERIFY_NONE if a context
rspec ./spec/mail/network/delivery_methods/smtp_spec.rb:155 # SMTP Delivery Method enabling ssl should ignore OpenSSL::SSL::VERIFY_NONE if it is 0
rspec ./spec/mail/network/delivery_methods/smtp_spec.rb:172 # SMTP Delivery Method enabling ssl should not set verify mode when none is given
rspec ./spec/mail/network/delivery_methods/smtp_spec.rb:190 # SMTP Delivery Method enabling ssl should set verify mode if one is given
rspec ./spec/mail/network/delivery_methods/smtp_spec.rb:227 # SMTP Delivery Method enabling STARTTLS should allow forcing STARTTLS
```

```ruby
$ bundle exec rspec ./spec/mail/network_spec.rb
Running Specs under Ruby Version 3.0.1
Running Specs for Mail Version 2.8.0.edge
.F..............FF.................

Failures:

  1) Mail default delivery and retriever methods should default to settings for smtp
     Failure/Error:
       expect(Mail.delivery_method.settings).to eql({:address              => "localhost",
                                                 :port                 => 25,
                                                 :domain               => 'localhost.localdomain',
                                                 :user_name            => nil,
                                                 :password             => nil,
                                                 :authentication       => nil,
                                                 :enable_starttls_auto => true,
                                                 :enable_starttls      => nil,
                                                 :openssl_verify_mode  => nil,
                                                 :ssl                  => nil,

       expected: {:address=>"localhost", :authentication=>nil, :domain=>"localhost.localdomain", :enable_starttls=>nil...ify_mode=>nil, :password=>nil, :port=>25, :read_timeout=>nil, :ssl=>nil, :tls=>nil, :user_name=>nil}
            got: {:address=>"localhost", :authentication=>nil, :domain=>"localhost.localdomain", :enable_starttls=>nil...erify_mode=>nil, :password=>nil, :port=>25, :read_timeout=>5, :ssl=>nil, :tls=>nil, :user_name=>nil}

       (compared using eql?)

       Diff:

       @@ -3,11 +3,11 @@
        :domain => "localhost.localdomain",
        :enable_starttls => nil,
        :enable_starttls_auto => true,
       -:open_timeout => nil,
       +:open_timeout => 5,
        :openssl_verify_mode => nil,
        :password => nil,
        :port => 25,
       -:read_timeout => nil,
       +:read_timeout => 5,
        :ssl => nil,
        :tls => nil,
        :user_name => nil,

     # ./spec/mail/network_spec.rb:41:in `block (3 levels) in <top (required)>'

  2) Mail sending emails via SMTP should deliver a mail message
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055eb30c23e10>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:2141:in `do_delivery'
     # ./lib/mail/message.rb:255:in `deliver'
     # ./lib/mail/mail.rb:133:in `deliver'
     # ./spec/mail/network_spec.rb:187:in `block (3 levels) in <top (required)>'

  3) Mail sending emails via SMTP should deliver itself
     Failure/Error: smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]

     NoMethodError:
       undefined method `open_timeout=' for #<MockSMTP:0x000055eb30d3fbf0>
     # ./lib/mail/network/delivery_methods/smtp.rb:128:in `block in build_smtp_session'
     # <internal:kernel>:90:in `tap'
     # ./lib/mail/network/delivery_methods/smtp.rb:113:in `build_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
     # ./lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
     # ./lib/mail/message.rb:269:in `deliver!'
     # ./spec/mail/network_spec.rb:209:in `block (3 levels) in <top (required)>'

Finished in 0.11973 seconds (files took 0.13051 seconds to load)
35 examples, 3 failures

Failed examples:

rspec ./spec/mail/network_spec.rb:39 # Mail default delivery and retriever methods should default to settings for smtp
rspec ./spec/mail/network_spec.rb:186 # Mail sending emails via SMTP should deliver a mail message
rspec ./spec/mail/network_spec.rb:200 # Mail sending emails via SMTP should deliver itself

$
```