### PR TITLE
Support non-ASCII addresses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ elsif RUBY_VERSION < '2.2.2'
 end
 
 gem 'mini_mime'
+gem 'simpleidn'
 
 if RUBY_VERSION >= '2.0'
   gem 'byebug', :platforms => :mri

--- a/lib/mail.rb
+++ b/lib/mail.rb
@@ -8,6 +8,7 @@ module Mail # :doc:
   require 'uri'
   require 'net/smtp'
   require 'mini_mime'
+  require 'simpleidn'
 
   if RUBY_VERSION <= '1.8.6'
     begin

--- a/lib/mail/elements/address.rb
+++ b/lib/mail/elements/address.rb
@@ -71,6 +71,18 @@ module Mail
       end
     end
 
+    # Returns the address that is in the address itself with domain IDNA-encoded.
+    #
+    #  a = Address.new('Mikel Lindsaar (My email address) <mikel@tést.lindsaar.net>')
+    #  a.address_idna #=> 'mikel@xn--tst-bma.lindsaar.net'
+    def address_idna
+      if d = domain_idna
+        "#{local}@#{d}"
+      else
+        local
+      end
+    end
+
     # Provides a way to assign an address to an already made Mail::Address object.
     #
     #  a = Address.new
@@ -118,6 +130,17 @@ module Mail
     def domain(output_type = :decode)
       parse unless @parsed
       Encodings.decode_encode(strip_all_comments(get_domain), output_type) if get_domain
+    end
+
+    # Returns the domain part (the right hand side of the @ sign in the email address) of
+    # the address in IDNA encoding.
+    #
+    #  a = Address.new('Mikel Lindsaar (My email address) <mikel@tést.lindsaar.net>')
+    #  a.domain_idna #=> 'xn--tst-bma.lindsaar.net'
+    def domain_idna
+      if d = domain
+        Encodings.idna_encode(d)
+      end
     end
 
     # Returns an array of comments that are in the email, or nil if there

--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -339,5 +339,11 @@ module Mail
 
       yield RubyVer.string_byteslice(str, offset, chunksize)
     end
+
+    def Encodings.idna_encode(str)
+      return str if str.ascii_only?
+
+      SimpleIDN.to_ascii(str)
+    end
   end
 end

--- a/lib/mail/smtp_envelope.rb
+++ b/lib/mail/smtp_envelope.rb
@@ -43,12 +43,16 @@ module Mail
 
     private
       def validate_addr(addr_name, addr)
-        if addr.bytesize > MAX_ADDRESS_BYTESIZE
-          raise ArgumentError, "SMTP #{addr_name} address may not exceed #{MAX_ADDRESS_BYTESIZE} bytes: #{addr.inspect}"
-        end
-
         if /[\r\n]/ =~ addr
           raise ArgumentError, "SMTP #{addr_name} address may not contain CR or LF line breaks: #{addr.inspect}"
+        end
+
+        if !addr.ascii_only?
+          addr = Address.new(addr).address_idna
+        end
+
+        if addr.bytesize > MAX_ADDRESS_BYTESIZE
+          raise ArgumentError, "SMTP #{addr_name} address may not exceed #{MAX_ADDRESS_BYTESIZE} bytes: #{addr.inspect}"
         end
 
         addr

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 
   s.add_dependency('mini_mime', '>= 0.1.1')
+  s.add_dependency('simpleidn')
 
   s.add_development_dependency('bundler', '>= 1.0.3')
   s.add_development_dependency('rake', '> 0.8.7')

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -26,6 +26,12 @@ describe Mail::Address do
       end
     end
 
+    it "should allow us to instantiate an empty address object and call address_idna" do
+      [nil, '', ' '].each do |input|
+        expect(Mail::Address.new(input).address_idna).to be_nil
+      end
+    end
+
     it "should allow us to instantiate an empty address object and call local" do
       [nil, '', ' '].each do |input|
         expect(Mail::Address.new(input).local).to be_nil
@@ -35,6 +41,12 @@ describe Mail::Address do
     it "should allow us to instantiate an empty address object and call domain" do
       [nil, '', ' '].each do |input|
         expect(Mail::Address.new(input).domain).to be_nil
+      end
+    end
+
+    it "should allow us to instantiate an empty address object and call domain_idna" do
+      [nil, '', ' '].each do |input|
+        expect(Mail::Address.new(input).domain_idna).to be_nil
       end
     end
 
@@ -119,7 +131,14 @@ describe Mail::Address do
       expect(a.domain).to eq result
     end
 
-    it "should give back the formated address" do
+    it "should give back the IDNA-encoded domain" do
+      parse_text = 'Mikel Lindsaar <test@lindsäär.net>'
+      result     = 'xn--lindsr-fuaa.net'
+      a          = Mail::Address.new(parse_text)
+      expect(a.domain_idna).to eq result
+    end
+
+    it "should give back the formatted address" do
       parse_text = 'Mikel Lindsaar <test@lindsaar.net>'
       result     = 'Mikel Lindsaar <test@lindsaar.net>'
       a          = Mail::Address.new(parse_text)

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -966,4 +966,12 @@ describe Mail::Encodings do
       end
     end
   end
+
+  describe "IDNA encoding" do
+    it "should encode a string correctly" do
+      raw = 'tést.example.com'
+      encoded = 'xn--tst-bma.example.com'
+      expect(Mail::Encodings.idna_encode(raw)).to eq encoded
+    end
+  end
 end

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -262,6 +262,19 @@ describe "SMTP Delivery Method" do
       expect(MockSMTP.deliveries[0][2]).to eq %w(smtp_to@someemail.com)
     end
 
+    it "IDNA-encodes non-ASCII From and To addresses" do
+      Mail.defaults do
+        delivery_method :smtp, :idna => true
+      end
+
+      Mail.deliver do
+        to "tö@soméemail.com"
+        from "fröm@soméemail.com"
+      end
+      expect(MockSMTP.deliveries[0][1]).to eq 'fröm@xn--somemail-d1a.com'
+      expect(MockSMTP.deliveries[0][2]).to eq %w(tö@xn--somemail-d1a.com)
+    end
+
     it "supports the null sender in the envelope from address" do
       Mail.deliver do
         to "to@someemail.com"


### PR DESCRIPTION
The first internationalized domains (IDNs) were registered around 2003. It took more than a decade for web browsers to gain sufficient support to make these domains generally useful, but today you can announce an IDN domain to the general public and expect them to be able to connect to your website.

This is not the case for email. The standards for using IDNs for email came much later and they are still not supported by many email clients and software libraries. Let's fix that, so that eventually – many years from now – people can use their non-ASCII address everywhere like any other email address.

[RFC 6531](https://datatracker.ietf.org/doc/html/rfc) describes how to handle non-ASCII email addresses on the SMTP level using the `SMTPUTF8` SMTP extension. Unfortunately, `Net::SMTP` does not support passing parameters for `RCPT TO` which is required for `SMTPUTF8`. I have submitted [a patch](https://bugs.ruby-lang.org/issues/17047) for this, but the maintainers do not seem interested.

But even without `SMTPUTF8` support we can still get far:

With this PR, the domain of the SMTP envelope sender and recipient is IDNA-encoded, making the email address appear like any other ASCII email to the SMTP server. The SMTP envelope sender and recipient are never shown to end-users, so there is no UX reason not to do this encoding. Even if the SMTP server has support for non-ASCII domains, there is no drawback from doing the IDNA-encoding in the client – the two encodings are equivalent from a routing perspective.

This PR does not affect email addresses with non-ASCII characters in the local part. But even today, they might just work – not because email servers intentionally support internationalized email addresses, but simply because they pass on the local part verbatimly to the remote server.

If my PR for `Net::SMTP` is eventually accepted, this library could skip the IDNA-encoding and instead pass the `SMTPUTF8` parameter for servers announcing support for this extension. At least for addresses with a non-ASCII local part, this would probably improve deliverability.
