### PR TITLE
Mail::Message#content_type_parameters: return an empty hash when there’s no Content-Type

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1521,7 +1521,7 @@ module Mail
 
     # Returns the content type parameters
     def content_type_parameters
-      has_content_type? ? header[:content_type].parameters : nil rescue nil
+      has_content_type? ? header[:content_type].parameters : {} rescue {}
     end
 
     # Returns true if the message is multipart
@@ -1581,7 +1581,7 @@ module Mail
 
     # Returns the current boundary for this message part
     def boundary
-      content_type_parameters ? content_type_parameters['boundary'] : nil
+      content_type_parameters['boundary']
     end
 
     # Returns a parts list object of all the parts in the message

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1413,6 +1413,10 @@ describe Mail::Message do
           expect(mail.content_type_parameters).to eql({"charset" => "UTF-8"})
         end
 
+        it "should return an empty hash of content type parameters when there is no content type" do
+          mail = Mail.new
+          expect(mail.content_type_parameters).to eql({})
+        end
       end
 
       it "rfc2046 can be decoded" do
@@ -1445,7 +1449,7 @@ describe Mail::Message do
           part.body          = 'a' * 999
         end
         mail.encoded
-        
+
         expect(mail.parts.count).to eq(1)
         expect(mail.parts.last.content_transfer_encoding).to match(/7bit|8bit|binary/)
       end
@@ -1465,19 +1469,19 @@ describe Mail::Message do
             end
           end
         end
-        
+
         it "should not add an empty charset header" do
           @mail.charset = nil
-          
+
           expect(@mail.multipart?).to eq true
           expect(@mail.parts.count).to eq 2
           expect(@mail.encoded.scan(/charset=UTF-8/).count).to eq 2
         end
-        
+
         it "should remove the charset header" do
           @mail.charset = 'iso-8859-1'
           @mail.charset = nil
-          
+
           expect(@mail.encoded.scan(/charset=UTF-8/).count).to eq 2
           expect(@mail.encoded.scan(/charset=iso-8859-1/).count).to eq 0
         end


### PR DESCRIPTION
Allow callers to index into `content_type_parameters` unconditionally.

```ruby
# Before:
mail.content_type_parameters[:start] unless mail.content_type_parameters.nil?
mail.content_type_parameters&.[](:start)
mail.content_type_parameters&.fetch(:start, nil)
(mail.content_type_parameters || {})[:start]

if parameters = mail.content_type_parameters
  parameters[:start]
end

# After:
mail.content_type_parameters[:start]
```