### PR TITLE
fix smtp timeouts

### DIFF
--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -125,8 +125,8 @@ module Mail
             end
           end
 
-          smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout]
-          smtp.read_timeout = settings[:read_timeout] if settings[:read_timeout]
+          smtp.open_timeout = settings[:open_timeout] if settings[:open_timeout] && smtp.respond_to?(:open_timeout)
+          smtp.read_timeout = settings[:read_timeout] if settings[:read_timeout] && smtp.respond_to?(:read_timeout)
         end
       end
 

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -49,8 +49,8 @@ describe "Mail" do
                                                 :openssl_verify_mode  => nil,
                                                 :ssl                  => nil,
                                                 :tls                  => nil,
-                                                :open_timeout         => nil,
-                                                :read_timeout         => nil })
+                                                :open_timeout         => 5,
+                                                :read_timeout         => 5 })
     end
 
     it "should set the retriever method" do


### PR DESCRIPTION
1/ fixes a test failure introduced by https://github.com/mikel/mail/pull/1427

2/ some old rubies don't support open_timeout