### PR TITLE
Correct ActiveSupport version for Ruby 2.5/2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ if RUBY_VERSION < '1.9.3'
   gem 'i18n', '< 0.7'
 elsif RUBY_VERSION < '2.2.2'
   gem 'activesupport', '< 5'
-elsif RUBY_VERSION < '2.5.0'
+elsif RUBY_VERSION < '2.7.0'
   gem 'activesupport', '< 6'
 else
   gem 'activesupport', :git => 'https://github.com/rails/rails', :branch => 'main'


### PR DESCRIPTION
Fix failures on master for:

- [Ruby 2.5](https://github.com/mikel/mail/runs/3947941756?check_suite_focus=true)
- [Ruby 2.6](https://github.com/mikel/mail/runs/3947941783?check_suite_focus=true)