### PR TITLE
Adding a part should not reset the mail's charset to nil

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -1496,7 +1496,7 @@ module Mail
     # Returns the character set defined in the content type field
     def charset
       if @header
-        has_content_type? ? content_type_parameters['charset'] : @charset
+        has_content_type? && !multipart? ? content_type_parameters['charset'] : @charset
       else
         @charset
       end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1450,6 +1450,14 @@ describe Mail::Message do
         expect(mail.parts.last.content_transfer_encoding).to match(/7bit|8bit|binary/)
       end
 
+      describe 'charset' do
+        it 'should return a default value for multipart mails' do
+          mail = Mail.new
+          mail.add_part(Mail::Part.new(body: 'PLAIN TEXT', content_type: 'text/plain'))
+          expect(mail.charset).to eq 'UTF-8'
+        end
+      end
+
       describe 'charset=' do
         before do
           @mail = Mail.new do


### PR DESCRIPTION
The PR https://github.com/mikel/mail/pull/1145 introduced a [breaking change](https://github.com/mikel/mail/pull/1145/files#diff-ea29154b6b75ca19a09c77672897b2673bc6f691d9f6e6ed81b057c1acb96023L2088) in `master`, where adding parts to a `Mail` resets the default `charset` to nil. 

This PR restores the behaviour from [`2-7-stable`](https://github.com/mikel/mail/blob/7c43c84c16f017e0ff5e5c9962f6a1d842301ee3/lib/mail/message.rb#L2087) and allows us to use the edge version of `mail` with rails 7 without any patch.

cc @jeremy 