### PR TITLE
Add `delivery_interceptors` method to `Mail` class to fetch registered interceptors

### DIFF
--- a/lib/mail/mail.rb
+++ b/lib/mail/mail.rb
@@ -236,6 +236,11 @@ module Mail
     end
   end
 
+  # Returns a list of registered delivery interceptors.
+  def self.delivery_interceptors
+    @@delivery_interceptors
+  end
+
   protected
 
   RANDOM_TAG='%x%x_%x%x%d%x'

--- a/spec/mail/mail_spec.rb
+++ b/spec/mail/mail_spec.rb
@@ -32,4 +32,45 @@ describe "mail" do
     expect(wrap_method).to eq file_method
   end
 
+  describe "delivery_interceptors" do
+
+    class InterceptorAgentOne
+      @@intercept = false
+      def self.intercept=(val)
+        @@intercept = val
+      end
+      def self.delivering_email(mail)
+        if @@intercept
+          mail.to = 'bob@example.com'
+        end
+      end
+    end
+
+    class InterceptorAgentTwo
+      @@intercept = false
+      def self.intercept=(val)
+        @@intercept = val
+      end
+      def self.delivering_email(mail)
+        if @@intercept
+          mail.to = 'bob@example.com'
+        end
+      end
+    end
+
+    it "should return empty array if no interceptors have been registered" do
+      expect(Mail.delivery_interceptors).to eq []
+    end
+
+    it "should return array of registered delivery interceptors" do
+      Mail.register_interceptor(InterceptorAgentOne)
+      expect(Mail.delivery_interceptors).to eq [InterceptorAgentOne]
+      Mail.register_interceptor(InterceptorAgentTwo)
+      expect(Mail.delivery_interceptors).to eq [InterceptorAgentOne, InterceptorAgentTwo]
+      Mail.unregister_interceptor(InterceptorAgentOne)
+      expect(Mail.delivery_interceptors).to eq [InterceptorAgentTwo]
+    end
+
+  end
+
 end


### PR DESCRIPTION
Summary:

I've raised this PR in reference to this [PR](https://github.com/rails/rails/pull/44638) in rails and this [comment](https://github.com/rails/rails/pull/44638#issuecomment-1063326528) specifically in the PR.

This PR adds the `delivery_interceptors` method to the `Mail` class to fetch the registered interceptors. So instead of fetching like `Mail.class_variable_get(:@@delivery_interceptors)`, we can directly do `Mail.delivery_interceptors`.
