### PR TITLE
Add Mail::YAML#load compatible with Psych 3.x and Psych 4.x.

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'mail/constants'
 require 'mail/utilities'
-require 'yaml'
+require 'mail/yaml'
 
 module Mail
   # The Message class provides a single point of access to all things to do with an
@@ -1841,7 +1841,7 @@ module Mail
     end
 
     def self.from_yaml(str)
-      hash = YAML.load(str)
+      hash = Mail::YAML.load(str)
       m = self.new(:headers => hash['headers'])
       hash.delete('headers')
       hash.each do |k,v|

--- a/lib/mail/yaml.rb
+++ b/lib/mail/yaml.rb
@@ -1,0 +1,16 @@
+require 'yaml'
+
+module Mail
+  module YAML
+    # unsafe loading compatible with Psych 3.x and Psych 4.x
+    if ::YAML.respond_to?(:unsafe_load)
+      def self.load(yaml)
+        ::YAML.unsafe_load(yaml)
+      end
+    else
+      def self.load(yaml)
+        ::YAML.load(yaml)
+      end
+    end
+  end
+end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -196,7 +196,7 @@ describe Mail::Message do
 
       it "should serialize the basic information to YAML" do
         yaml = @yaml_mail.to_yaml
-        yaml_output = YAML.load(yaml)
+        yaml_output = Mail::YAML.load(yaml)
         expect(yaml_output['headers']['To']).to       eq "someone@somewhere.com"
         expect(yaml_output['headers']['Cc']).to       eq "someoneelse@somewhere.com"
         expect(yaml_output['headers']['Subject']).to  eq "subject"
@@ -214,7 +214,7 @@ describe Mail::Message do
       it "should serialize a Message with a custom delivery_handler" do
         @yaml_mail.delivery_handler = DeliveryAgent
         yaml = @yaml_mail.to_yaml
-        yaml_output = YAML.load(yaml)
+        yaml_output = Mail::YAML.load(yaml)
         expect(yaml_output['delivery_handler']).to eq "DeliveryAgent"
       end
 
@@ -226,7 +226,7 @@ describe Mail::Message do
 
       it "should not deserialize a delivery_handler that does not exist" do
         yaml = @yaml_mail.to_yaml
-        yaml_hash = YAML.load(yaml)
+        yaml_hash = Mail::YAML.load(yaml)
         yaml_hash['delivery_handler'] = "NotARealClass"
         deserialized = Mail::Message.from_yaml(yaml_hash.to_yaml)
         expect(deserialized.delivery_handler).to be_nil
@@ -234,7 +234,7 @@ describe Mail::Message do
 
       it "should deserialize parts as an instance of Mail::PartsList" do
         yaml = @yaml_mail.to_yaml
-        yaml_hash = YAML.load(yaml)
+        yaml_hash = Mail::YAML.load(yaml)
         deserialized = Mail::Message.from_yaml(yaml_hash.to_yaml)
         expect(deserialized.parts).to be_kind_of(Mail::PartsList)
       end

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -95,6 +95,6 @@ describe "PartsList" do
 
   it "should have a round-tripping YAML serialization" do
     p = Mail::PartsList.new([1, 2])
-    expect(YAML.load(YAML.dump(p))).to eq(p)
+    expect(Mail::YAML.load(YAML.dump(p))).to eq(p)
   end
 end

--- a/spec/mail/yaml_spec.rb
+++ b/spec/mail/yaml_spec.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Mail::YAML do
+
+  describe "#load" do
+
+    it 'loads YAML' do
+      expect(Mail::YAML.load('{}')).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
This is 1:1 transition. It would be great to be able to use "safe" load, but since custom classes could be serialised, it is not easily possible for now.

Btw. the best would be to be able to migrate to Psych 4, but it seems impossible since EOL Rubies are supported.

@voxik @deivid-rodriguez