### PR TITLE
Remove unnecessary gemfile dependency on strscan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,3 @@ gem 'jruby-openssl', :platforms => :jruby
 gem 'mini_mime'
 
 gem 'byebug', :platforms => :mri
-
-gem "strscan", ">= 3.0.2.pre1"


### PR DESCRIPTION
The final version is out, so this is no longer necessary since Bundler will resolve to that automatically.