### PR TITLE
Configure RSpec's zero-monkey patching mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Mail.defaults do
   delivery_method :test # in practice you'd do this in spec_helper.rb
 end
 
-describe "sending an email" do
+RSpec.describe "sending an email" do
   include Mail::Matchers
 
   before(:each) do

--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -11,7 +11,7 @@ def check_decoded(actual, expected)
   expect(actual).to eq expected.dup.force_encoding(Encoding::BINARY)
 end
 
-describe "Attachments" do
+RSpec.describe "Attachments" do
 
   before(:each) do
     @mail = Mail.new
@@ -211,7 +211,7 @@ describe "Attachments" do
 
 end
 
-describe "reading emails with attachments" do
+RSpec.describe "reading emails with attachments" do
   describe "test emails" do
 
     it "should find the attachment using content location" do
@@ -311,7 +311,7 @@ limitMAIL
   end
 end
 
-describe "attachment order" do
+RSpec.describe "attachment order" do
   it "should be preserved instead  when content type exists" do
     mail = Mail.new do
       to "aaaa@aaaa.aaa"

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Body do
+RSpec.describe Mail::Body do
 
   # 3.5 Overall message syntax
   #

--- a/spec/mail/configuration_spec.rb
+++ b/spec/mail/configuration_spec.rb
@@ -9,7 +9,7 @@ class MyTestDeliveryMethod
   end
 end
 
-describe Mail::Configuration do
+RSpec.describe Mail::Configuration do
 
   describe "network configurations" do
 

--- a/spec/mail/core_extensions_spec.rb
+++ b/spec/mail/core_extensions_spec.rb
@@ -2,6 +2,6 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Object do
+RSpec.describe Object do
 
 end

--- a/spec/mail/elements/address_list_spec.rb
+++ b/spec/mail/elements/address_list_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::AddressList do
+RSpec.describe Mail::AddressList do
 
   describe "parsing" do
     it "should parse an address list" do

--- a/spec/mail/elements/address_spec.rb
+++ b/spec/mail/elements/address_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Address do
+RSpec.describe Mail::Address do
 
   describe "functionality" do
 

--- a/spec/mail/elements/date_time_element_spec.rb
+++ b/spec/mail/elements/date_time_element_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::DateTimeElement do
+RSpec.describe Mail::DateTimeElement do
 
   it "should parse a date" do
     date_text  = 'Wed, 27 Apr 2005 14:15:31 -0700'

--- a/spec/mail/elements/envelope_from_element_spec.rb
+++ b/spec/mail/elements/envelope_from_element_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::EnvelopeFromElement do
+RSpec.describe Mail::EnvelopeFromElement do
   
   describe "parsing a from envelope string" do
     it "should parse a full field" do

--- a/spec/mail/elements/message_ids_element_spec.rb
+++ b/spec/mail/elements/message_ids_element_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::MessageIdsElement do
+RSpec.describe Mail::MessageIdsElement do
 
   it "should parse a message_id" do
     msg_id_text  = '<1234@test.lindsaar.net>'

--- a/spec/mail/elements/phrase_list_spec.rb
+++ b/spec/mail/elements/phrase_list_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::PhraseList do
+RSpec.describe Mail::PhraseList do
 
   describe "parsing" do
     it "should parse a phrase list" do

--- a/spec/mail/elements/received_element_spec.rb
+++ b/spec/mail/elements/received_element_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ReceivedElement do
+RSpec.describe Mail::ReceivedElement do
 
   it "should raise an error if the input is nil" do
     received = Mail::ReceivedElement.new(nil)

--- a/spec/mail/encoding_spec.rb
+++ b/spec/mail/encoding_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "mail encoding" do
+RSpec.describe "mail encoding" do
 
   it "should allow you to assign an email-wide charset" do
     mail = Mail.new

--- a/spec/mail/encodings/base64_spec.rb
+++ b/spec/mail/encodings/base64_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Encodings::Base64 do
+RSpec.describe Mail::Encodings::Base64 do
   
   it "should encode base 64 from text" do
     result = "VGhpcyBpcyBhIHRlc3Q=\r\n"

--- a/spec/mail/encodings/quoted_printable_spec.rb
+++ b/spec/mail/encodings/quoted_printable_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Encodings::QuotedPrintable do
+RSpec.describe Mail::Encodings::QuotedPrintable do
   
   it "should encode quoted printable from text" do
     result = "This is\r\na test=\r\n"

--- a/spec/mail/encodings/transfer_encoding_spec.rb
+++ b/spec/mail/encodings/transfer_encoding_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Encodings::TransferEncoding do
+RSpec.describe Mail::Encodings::TransferEncoding do
   it "accepts blank message_encoding" do
     expect(described_class.negotiate('', '7bit', '')).to eq Mail::Encodings::SevenBit
     expect(described_class.negotiate('', '8bit', '')).to eq Mail::Encodings::EightBit

--- a/spec/mail/encodings/unix_to_unix_spec.rb
+++ b/spec/mail/encodings/unix_to_unix_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Encodings::UnixToUnix do
+RSpec.describe Mail::Encodings::UnixToUnix do
   def decode(str)
     Mail::Encodings::UnixToUnix.decode(str)
   end

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Encodings do
+RSpec.describe Mail::Encodings do
 
   describe "base64 Encoding" do
 

--- a/spec/mail/example_emails_spec.rb
+++ b/spec/mail/example_emails_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "Test emails" do
+RSpec.describe "Test emails" do
 
   describe "from RFC2822" do
 

--- a/spec/mail/field_list_spec.rb
+++ b/spec/mail/field_list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::FieldList do
+RSpec.describe Mail::FieldList do
   it "should be able to add new fields" do
     fl = Mail::FieldList.new
     fl << Mail::Field.parse("To: mikel@me.com")

--- a/spec/mail/field_spec.rb
+++ b/spec/mail/field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Field do
+RSpec.describe Mail::Field do
 
   describe 'parsing' do
     it "parses full header fields" do

--- a/spec/mail/fields/address_container_spec.rb
+++ b/spec/mail/fields/address_container_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe 'AddressContainer' do
+RSpec.describe 'AddressContainer' do
   it "should allow you to append an address to an address field result" do
     m = Mail.new("To: mikel@test.lindsaar.net")
     expect(m.to).to eq ['mikel@test.lindsaar.net']

--- a/spec/mail/fields/bcc_field_spec.rb
+++ b/spec/mail/fields/bcc_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::BccField do
+RSpec.describe Mail::BccField do
   
   #    The "Bcc:" field (where the "Bcc" means "Blind Carbon Copy") contains
   #    addresses of recipients of the message whose addresses are not to be

--- a/spec/mail/fields/cc_field_spec.rb
+++ b/spec/mail/fields/cc_field_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 #    addresses of others who are to receive the message, though the
 #    content of the message may not be directed at them.
 
-describe Mail::CcField do
+RSpec.describe Mail::CcField do
   
   describe "initialization" do
 

--- a/spec/mail/fields/comments_field_spec.rb
+++ b/spec/mail/fields/comments_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::CommentsField do
+RSpec.describe Mail::CommentsField do
   # 
   # comments        =       "Comments:" unstructured CRLF
   

--- a/spec/mail/fields/common_address_spec.rb
+++ b/spec/mail/fields/common_address_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::CommonAddressField do
+RSpec.describe Mail::CommonAddressField do
 
   describe "address handling" do
 

--- a/spec/mail/fields/common_date_spec.rb
+++ b/spec/mail/fields/common_date_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::CommonDateField do
+RSpec.describe Mail::CommonDateField do
   describe "encoding and decoding fields" do
     it "should allow us to encode an date field" do
       field = Mail::DateField.new('12 Aug 2009 00:00:02 GMT')

--- a/spec/mail/fields/common_field_spec.rb
+++ b/spec/mail/fields/common_field_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'mail/fields/common_field'
 
-describe Mail::CommonField do
+RSpec.describe Mail::CommonField do
 
   describe "multi-charset support" do
 

--- a/spec/mail/fields/common_message_id_spec.rb
+++ b/spec/mail/fields/common_message_id_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'mail/fields/common_message_id_field'
 
-describe Mail::CommonMessageIdField do
+RSpec.describe Mail::CommonMessageIdField do
 
   describe "encoding and decoding fields" do
 

--- a/spec/mail/fields/content_description_field_spec.rb
+++ b/spec/mail/fields/content_description_field_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ContentDescriptionField do
+RSpec.describe Mail::ContentDescriptionField do
   # Content-Description Header Field
   #
   # The ability to associate some descriptive information with a given

--- a/spec/mail/fields/content_disposition_field_spec.rb
+++ b/spec/mail/fields/content_disposition_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ContentDispositionField do
+RSpec.describe Mail::ContentDispositionField do
 
   describe "initialization" do
 

--- a/spec/mail/fields/content_id_field_spec.rb
+++ b/spec/mail/fields/content_id_field_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ContentIdField do
+RSpec.describe Mail::ContentIdField do
   # Content-ID Header Field
   #
   # In constructing a high-level user agent, it may be desirable to allow

--- a/spec/mail/fields/content_location_field_spec.rb
+++ b/spec/mail/fields/content_location_field_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ContentLocationField do
+RSpec.describe Mail::ContentLocationField do
 
   # Content-Location Header Field
   # 

--- a/spec/mail/fields/content_transfer_encoding_field_spec.rb
+++ b/spec/mail/fields/content_transfer_encoding_field_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ContentTransferEncodingField do
+RSpec.describe Mail::ContentTransferEncodingField do
 
   # Content-Transfer-Encoding Header Field
   #

--- a/spec/mail/fields/content_type_field_spec.rb
+++ b/spec/mail/fields/content_type_field_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ContentTypeField do
+RSpec.describe Mail::ContentTypeField do
   # Content-Type Header Field
   #
   # The purpose of the Content-Type field is to describe the data

--- a/spec/mail/fields/date_field_spec.rb
+++ b/spec/mail/fields/date_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::DateField do
+RSpec.describe Mail::DateField do
   #    The origination date field consists of the field name "Date" followed
   #    by a date-time specification.
   #

--- a/spec/mail/fields/envelope_spec.rb
+++ b/spec/mail/fields/envelope_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Envelope do
+RSpec.describe Mail::Envelope do
   # From RFC4155 The application/mbox Media Type
   #
   #   o Each message in the mbox database MUST be immediately preceded

--- a/spec/mail/fields/from_field_spec.rb
+++ b/spec/mail/fields/from_field_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 #
 # from            =       "From:" mailbox-list CRLF
 
-describe Mail::FromField do
+RSpec.describe Mail::FromField do
 
   describe "initialization" do
 

--- a/spec/mail/fields/in_reply_to_field_spec.rb
+++ b/spec/mail/fields/in_reply_to_field_spec.rb
@@ -10,7 +10,7 @@ require 'spec_helper'
 #    the parent messages, then the new message will have no "In-Reply-To:"
 #    field.
 
-describe Mail::InReplyToField do
+RSpec.describe Mail::InReplyToField do
 
   describe "initialization" do
     it "should initialize" do

--- a/spec/mail/fields/keywords_field_spec.rb
+++ b/spec/mail/fields/keywords_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::KeywordsField do
+RSpec.describe Mail::KeywordsField do
 
   describe "initializing" do
     

--- a/spec/mail/fields/message_id_field_spec.rb
+++ b/spec/mail/fields/message_id_field_spec.rb
@@ -53,7 +53,7 @@ require 'spec_helper'
 #    "Message-ID:" field changes, not any particular syntactic difference
 #    that appears (or does not appear) in the message.
 
-describe Mail::MessageIdField do
+RSpec.describe Mail::MessageIdField do
 
   describe "initialization" do
 

--- a/spec/mail/fields/mime_version_field_spec.rb
+++ b/spec/mail/fields/mime_version_field_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::MimeVersionField do
+RSpec.describe Mail::MimeVersionField do
   # MIME-Version Header Field
   # 
   # Since RFC 822 was published in 1982, there has really been only one

--- a/spec/mail/fields/parameter_hash_spec.rb
+++ b/spec/mail/fields/parameter_hash_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'mail/fields/parameter_hash'
 
-describe Mail::ParameterHash do
+RSpec.describe Mail::ParameterHash do
   it "should return the values in the hash" do
     hash = Mail::ParameterHash.new
     hash.merge!({'value1' => 'one', 'value2' => 'two'})

--- a/spec/mail/fields/received_field_spec.rb
+++ b/spec/mail/fields/received_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ReceivedField do
+RSpec.describe Mail::ReceivedField do
 
   it "should initialize" do
     expect { Mail::ReceivedField.new("from localhost (localhost [127.0.0.1]) by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)") }.not_to raise_error

--- a/spec/mail/fields/references_field_spec.rb
+++ b/spec/mail/fields/references_field_spec.rb
@@ -13,7 +13,7 @@ require 'spec_helper'
 #    or "Message-ID:" fields, then the new message will have no
 #    "References:" field.
 
-describe Mail::ReferencesField do
+RSpec.describe Mail::ReferencesField do
 
   it "should initialize" do
     expect { Mail::ReferencesField.new("<1234@test.lindsaar.net>") }.not_to raise_error

--- a/spec/mail/fields/reply_to_field_spec.rb
+++ b/spec/mail/fields/reply_to_field_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 # reply-to        =       "Reply-To:" address-list CRLF
 # 
 
-describe Mail::ReplyToField do
+RSpec.describe Mail::ReplyToField do
   
   describe "initialization" do
 

--- a/spec/mail/fields/resent_bcc_field_spec.rb
+++ b/spec/mail/fields/resent_bcc_field_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 # 
 # resent-bcc      =       "Resent-Bcc:" (address-list / [CFWS]) CRLF
 
-describe Mail::ResentBccField do
+RSpec.describe Mail::ResentBccField do
   
   describe "initialization" do
 

--- a/spec/mail/fields/resent_cc_field_spec.rb
+++ b/spec/mail/fields/resent_cc_field_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 # 
 # resent-cc       =       "Resent-Cc:" address-list CRLF
 
-describe Mail::ResentCcField do
+RSpec.describe Mail::ResentCcField do
   
   describe "initialization" do
 

--- a/spec/mail/fields/resent_date_field_spec.rb
+++ b/spec/mail/fields/resent_date_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ResentDateField do
+RSpec.describe Mail::ResentDateField do
   it "should initialize" do
     expect { Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT") }.not_to raise_error
   end

--- a/spec/mail/fields/resent_from_field_spec.rb
+++ b/spec/mail/fields/resent_from_field_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 # 
 # resent-from     =       "Resent-From:" mailbox-list CRLF
 
-describe Mail::ResentFromField do
+RSpec.describe Mail::ResentFromField do
   
   describe "initialization" do
 

--- a/spec/mail/fields/resent_message_id_field_spec.rb
+++ b/spec/mail/fields/resent_message_id_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ResentMessageIdField do
+RSpec.describe Mail::ResentMessageIdField do
 
   it "should initialize" do
     expect { Mail::ResentMessageIdField.new("<1234@test.lindsaar.net>") }.not_to raise_error

--- a/spec/mail/fields/resent_sender_field_spec.rb
+++ b/spec/mail/fields/resent_sender_field_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 # resent-sender   =       "Resent-Sender:" mailbox CRLF
-describe Mail::ResentSenderField do
+RSpec.describe Mail::ResentSenderField do
   let :field do
     Mail::ResentSenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
   end

--- a/spec/mail/fields/resent_to_field_spec.rb
+++ b/spec/mail/fields/resent_to_field_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 # 
 # resent-to       =       "Resent-To:" address-list CRLF
 
-describe Mail::ResentToField do
+RSpec.describe Mail::ResentToField do
   
   describe "initialization" do
 

--- a/spec/mail/fields/return_path_field_spec.rb
+++ b/spec/mail/fields/return_path_field_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ReturnPathField do
+RSpec.describe Mail::ReturnPathField do
   it "should allow you to specify a field" do
     rp = Mail::ReturnPathField.new('mikel@test.lindsaar.net')
     expect(rp.address).to eq 'mikel@test.lindsaar.net'

--- a/spec/mail/fields/sender_field_spec.rb
+++ b/spec/mail/fields/sender_field_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 # sender          =       "Sender:" mailbox CRLF
-describe Mail::SenderField do
+RSpec.describe Mail::SenderField do
   let :field do
     Mail::SenderField.new('Mikel Lindsaar <mikel@test.lindsaar.net>')
   end

--- a/spec/mail/fields/structured_field_spec.rb
+++ b/spec/mail/fields/structured_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::StructuredField do
+RSpec.describe Mail::StructuredField do
 
   describe "initialization" do
     

--- a/spec/mail/fields/to_field_spec.rb
+++ b/spec/mail/fields/to_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::ToField do
+RSpec.describe Mail::ToField do
   # 
   #    The "To:" field contains the address(es) of the primary recipient(s)
   #    of the message.

--- a/spec/mail/fields/unstructured_field_spec.rb
+++ b/spec/mail/fields/unstructured_field_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::UnstructuredField do
+RSpec.describe Mail::UnstructuredField do
 
   describe "initialization" do
 

--- a/spec/mail/header_spec.rb
+++ b/spec/mail/header_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Header do
+RSpec.describe Mail::Header do
 
   describe "initialization" do
 

--- a/spec/mail/mail_spec.rb
+++ b/spec/mail/mail_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "mail" do
+RSpec.describe "mail" do
   
   it "should be able to be instantiated" do
     expect { Mail }.not_to raise_error

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Message do
+RSpec.describe Mail::Message do
 
   def basic_email
     "To: mikel\r\nFrom: bob\r\nSubject: Hello!\r\n\r\nemail message\r\n"

--- a/spec/mail/mime_messages_spec.rb
+++ b/spec/mail/mime_messages_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "MIME Emails" do
+RSpec.describe "MIME Emails" do
 
     describe "general helper methods" do
 

--- a/spec/mail/multibyte_spec.rb
+++ b/spec/mail/multibyte_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'mail/multibyte/chars'
 
-describe Mail::Multibyte::Chars do
+RSpec.describe Mail::Multibyte::Chars do
   it "should upcase" do
     chars = described_class.new('Laurent, où sont les tests ?')
     expect(chars.upcase).to eq("LAURENT, OÙ SONT LES TESTS ?")

--- a/spec/mail/multipart_report_spec.rb
+++ b/spec/mail/multipart_report_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "multipart/report emails" do
+RSpec.describe "multipart/report emails" do
   
   it "should know if it is a multipart report type" do
     mail = read_fixture('emails', 'multipart_report_emails', 'report_422.eml')

--- a/spec/mail/network/delivery_methods/exim_spec.rb
+++ b/spec/mail/network/delivery_methods/exim_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "exim delivery agent" do
+RSpec.describe "exim delivery agent" do
   let :mail do
     Mail.new do
       from    'roger@test.lindsaar.net'

--- a/spec/mail/network/delivery_methods/file_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/file_delivery_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "SMTP Delivery Method" do
+RSpec.describe "SMTP Delivery Method" do
 
   before(:each) do
     # Reset all defaults back to an original state

--- a/spec/mail/network/delivery_methods/logger_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/logger_delivery_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'logger'
 require 'stringio'
 
-describe "Logger Delivery Method" do
+RSpec.describe "Logger Delivery Method" do
   before(:each) do
     # Reset all defaults back to original state
     Mail.defaults do

--- a/spec/mail/network/delivery_methods/sendmail_spec.rb
+++ b/spec/mail/network/delivery_methods/sendmail_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Sendmail do
+RSpec.describe Mail::Sendmail do
   let :mail do
     Mail.new do
       from    'roger@test.lindsaar.net'

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "SMTP Delivery Method" do
+RSpec.describe "SMTP Delivery Method" do
 
   before(:each) do
     Mail.defaults do

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "SMTP Delivery Method" do
+RSpec.describe "SMTP Delivery Method" do
 
   before(:each) do
     # Reset all defaults back to original state

--- a/spec/mail/network/delivery_methods/test_mailer_spec.rb
+++ b/spec/mail/network/delivery_methods/test_mailer_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "Mail::TestMailer" do
+RSpec.describe "Mail::TestMailer" do
   before(:each) do
     # Reset all defaults back to original state
     Mail.defaults do

--- a/spec/mail/network/retriever_methods/imap_spec.rb
+++ b/spec/mail/network/retriever_methods/imap_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "IMAP Retriever" do
+RSpec.describe "IMAP Retriever" do
 
   before(:each) do
     Mail.defaults do

--- a/spec/mail/network/retriever_methods/pop3_spec.rb
+++ b/spec/mail/network/retriever_methods/pop3_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "POP3 Retriever" do
+RSpec.describe "POP3 Retriever" do
 
   before(:each) do
     # Reset all defaults back to original state

--- a/spec/mail/network/retriever_methods/test_retriever_spec.rb
+++ b/spec/mail/network/retriever_methods/test_retriever_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "Test Retriever" do
+RSpec.describe "Test Retriever" do
 
   before(:each) do
     Mail.defaults do

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -6,7 +6,7 @@ class MyDelivery; def initialize(settings); end; end
 
 class MyRetriever; def initialize(settings); end; end
 
-describe "Mail" do
+RSpec.describe "Mail" do
 
   before(:each) do
     # Reset all defaults back to original state

--- a/spec/mail/parsers/address_lists_parser_spec.rb
+++ b/spec/mail/parsers/address_lists_parser_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "AddressListsParser" do
+RSpec.describe "AddressListsParser" do
   it "should parse an address" do
     text = 'Mikel Lindsaar <test@lindsaar.net>, Friends: test2@lindsaar.net, Ada <test3@lindsaar.net>;'
     a = Mail::Parsers::AddressListsParser

--- a/spec/mail/parsers/content_transfer_encoding_parser_spec.rb
+++ b/spec/mail/parsers/content_transfer_encoding_parser_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "ContentTransferEncodingParser" do
+RSpec.describe "ContentTransferEncodingParser" do
 
   it "should work" do
     text = "quoted-printable"

--- a/spec/mail/part_spec.rb
+++ b/spec/mail/part_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::Part do
+RSpec.describe Mail::Part do
 
   it "should not add a default Content-ID" do
     part = Mail::Part.new

--- a/spec/mail/parts_list_spec.rb
+++ b/spec/mail/parts_list_spec.rb
@@ -3,7 +3,7 @@
 
 require 'spec_helper'
 
-describe "PartsList" do
+RSpec.describe "PartsList" do
   it "should return itself on sort" do
     p = Mail::PartsList.new
     p << 2

--- a/spec/mail/round_tripping_spec.rb
+++ b/spec/mail/round_tripping_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "Round Tripping" do
+RSpec.describe "Round Tripping" do
 
   it "should round trip a basic email" do
     mail = Mail.new('Subject: FooBar')

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "Utilities Module" do
+RSpec.describe "Utilities Module" do
 
   include Mail::Utilities
 

--- a/spec/mail/yaml_spec.rb
+++ b/spec/mail/yaml_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Mail::YAML do
+RSpec.describe Mail::YAML do
 
   describe "#load" do
 

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe "have_sent_email" do
+RSpec.describe "have_sent_email" do
   include Mail::Matchers
 
   let(:include_attachments) { true }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ $stderr.puts("Running Specs for Mail Version #{Mail::VERSION::STRING}")
 
 RSpec.configure do |c|
   c.mock_with :rspec
+  c.disable_monkey_patching!
   c.include(CustomMatchers)
 
   require 'rspec-benchmark'


### PR DESCRIPTION
This PR fixes #1484 by configuring RSpec in a way that "stops exposing DSL globally".