### PR TITLE
refactor: Use Dir.glob only once in gemspec's "files" directive

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc')
   s.add_development_dependency('rufo')
 
-  s.files = %w[ README.md MIT-LICENSE ] + Dir.glob("lib/**/*")
+  s.files = Dir.glob(%w[ README.md MIT-LICENSE lib/**/* ])
 end


### PR DESCRIPTION
This PR changes just one thing, how a list is expressed. For readability, I guess.