### PR TITLE
refactor: Use Ruby 2's __dir__ where possible

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -17,6 +17,7 @@ Code Improvements:
 * refactor: Use Dir.glob only once in gemspec's "files" directive @olleolleolle
 * Configure RSpec's zero-monkey patching mode @olleolleolle
 * Added support for JRuby 9.4 @mikel
+* Prefer `__dir__` @olleolleolle
 
 Bug Fixes:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 if !ENV["APPRAISAL_INITIALIZED"] && !ENV["CI"]
-  ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __FILE__)
+  ENV['BUNDLE_GEMFILE'] ||= File.expand_path('Gemfile', __dir__)
 end
 require 'rubygems'
 require 'bundler/setup'

--- a/lib/mail/multibyte/unicode.rb
+++ b/lib/mail/multibyte/unicode.rb
@@ -375,7 +375,7 @@ module Mail
 
         # Returns the directory in which the data files are stored
         def self.dirname
-          File.dirname(__FILE__) + '/../values/'
+          __dir__ + '/../values/'
         end
 
         # Returns the filename for the data file for this version

--- a/rakelib/corpus.rake
+++ b/rakelib/corpus.rake
@@ -3,7 +3,7 @@ require 'benchmark'
 namespace :corpus do
 
   task :load_mail do
-    require File.expand_path('../../spec/environment', __FILE__)
+    require File.expand_path('../spec/environment', __dir__)
     require 'mail'
   end
 

--- a/spec/environment.rb
+++ b/spec/environment.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 begin
   require 'byebug'

--- a/spec/mail/network/delivery_methods/file_delivery_spec.rb
+++ b/spec/mail/network/delivery_methods/file_delivery_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "SMTP Delivery Method" do
   end
 
   describe "general usage" do
-    tmpdir = File.expand_path('../../../../tmp/mail', __FILE__)
+    tmpdir = File.expand_path('../../../tmp/mail', __dir__)
 
     it "should send an email to a file" do
       Mail.defaults do

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "Mail" do
 
     it "should be able to change the delivery_method and pass in settings" do
       mail = Mail.new
-      tmpdir = File.expand_path('../../../tmp/mail', __FILE__)
+      tmpdir = File.expand_path('../../tmp/mail', __dir__)
       mail.delivery_method :file, :location => tmpdir
       expect(mail.delivery_method.class).to eq Mail::FileDelivery
       expect(mail.delivery_method.settings).to eql({:location => tmpdir,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,14 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require File.expand_path('../environment', __FILE__)
+require File.expand_path('environment', __dir__)
 
 unless defined?(MAIL_ROOT)
   $stderr.puts("Running Specs under Ruby Version #{RUBY_VERSION}")
-  MAIL_ROOT = File.join(File.dirname(__FILE__), '../')
+  MAIL_ROOT = File.join(__dir__, '../')
 end
 
 unless defined?(SPEC_ROOT)
-  SPEC_ROOT = File.join(File.dirname(__FILE__))
+  SPEC_ROOT = __dir__
 end
 
 unless defined?(MAIL_SPEC_SUITE_RUNNING)
@@ -17,7 +17,7 @@ unless defined?(MAIL_SPEC_SUITE_RUNNING)
 end
 
 require 'rspec'
-require File.join(File.dirname(__FILE__), 'matchers', 'break_down_to')
+require File.join(__dir__, 'matchers', 'break_down_to')
 
 require 'mail'
 


### PR DESCRIPTION
This PR introduces more usage of the [`__dir__`](https://www.rubydoc.info/stdlib/core/Kernel:__dir__) method.


