### PR TITLE
2.8.0.rc1 Regression: Preserve message-level charset when adding parts (related to Rails ActionMailer)

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2066,7 +2066,11 @@ module Mail
 
     def add_boundary
       unless body.boundary && boundary
-        header['content-type'] = 'multipart/mixed' unless header['content-type']
+        unless header['content-type']
+          _charset = charset
+          header['content-type'] = 'multipart/mixed'
+          header['content-type'].parameters[:charset] = _charset
+        end
         header['content-type'].parameters[:boundary] = ContentTypeField.generate_boundary
         body.boundary = boundary
       end

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -2041,6 +2041,39 @@ describe Mail::Message do
       expect(mail.charset).to eq 'ISO-8859-1'
       expect(p.charset).to eq nil
     end
+
+    it "should preserve the charset of the mail when nil vs UTF-8" do
+      mail = Mail.new
+      mail['charset'] = nil
+      expect(mail.charset).to eq nil
+      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'UTF-8')
+      expect(p.charset).to eq 'UTF-8'
+      mail.add_part(p)
+      expect(mail.charset).to eq nil
+      expect(p.charset).to eq 'UTF-8'
+    end
+
+    it "should preserve the charset of the mail when nil vs ISO-8859-1" do
+      mail = Mail.new
+      mail['charset'] = nil
+      expect(mail.charset).to eq nil
+      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'ISO-8859-1')
+      expect(p.charset).to eq 'ISO-8859-1'
+      mail.add_part(p)
+      expect(mail.charset).to eq nil
+      expect(p.charset).to eq 'ISO-8859-1'
+    end
+
+    it "should preserve the charset of the mail when nil vs nil" do
+      mail = Mail.new
+      mail['charset'] = nil
+      expect(mail.charset).to eq nil
+      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT')
+      expect(p.charset).to eq nil
+      mail.add_part(p)
+      expect(mail.charset).to eq nil
+      expect(p.charset).to eq nil
+    end
   end
 
   describe "ordering messages" do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1989,6 +1989,60 @@ describe Mail::Message do
     end
   end
 
+  describe "adding parts" do
+    it "should preserve the charset of the mail when UTF-8 vs UTF-8" do
+      mail = Mail.new
+      expect(mail.charset).to eq 'UTF-8'
+      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'UTF-8')
+      expect(p.charset).to eq 'UTF-8'
+      mail.add_part(p)
+      expect(mail.charset).to eq 'UTF-8'
+      expect(p.charset).to eq 'UTF-8'
+    end
+
+    it "should preserve the charset of the mail when UTF-8 vs ISO-8859-1" do
+      mail = Mail.new
+      expect(mail.charset).to eq 'UTF-8'
+      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'ISO-8859-1')
+      expect(p.charset).to eq 'ISO-8859-1'
+      mail.add_part(p)
+      expect(mail.charset).to eq 'UTF-8'
+      expect(p.charset).to eq 'ISO-8859-1'
+    end
+
+    it "should preserve the charset of the mail when UTF-8 vs nil" do
+      mail = Mail.new
+      expect(mail.charset).to eq 'UTF-8'
+      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT')
+      expect(p.charset).to eq nil
+      mail.add_part(p)
+      expect(mail.charset).to eq 'UTF-8'
+      expect(p.charset).to eq nil
+    end
+
+    it "should preserve the charset of the mail when ISO-8859-1 vs UTF-8" do
+      mail = Mail.new
+      mail['charset'] = 'ISO-8859-1'
+      expect(mail.charset).to eq 'ISO-8859-1'
+      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'UTF-8')
+      expect(p.charset).to eq 'UTF-8'
+      mail.add_part(p)
+      expect(mail.charset).to eq 'ISO-8859-1'
+      expect(p.charset).to eq 'UTF-8'
+    end
+
+    it "should preserve the charset of the mail when ISO-8859-1 vs nil" do
+      mail = Mail.new
+      mail['charset'] = 'ISO-8859-1'
+      expect(mail.charset).to eq 'ISO-8859-1'
+      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT')
+      expect(p.charset).to eq nil
+      mail.add_part(p)
+      expect(mail.charset).to eq 'ISO-8859-1'
+      expect(p.charset).to eq nil
+    end
+  end
+
   describe "ordering messages" do
     it "should put all attachments as the last item" do
       mail = Mail.new

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1989,90 +1989,21 @@ describe Mail::Message do
     end
   end
 
-  describe "adding parts" do
-    it "should preserve the charset of the mail when UTF-8 vs UTF-8" do
-      mail = Mail.new
-      expect(mail.charset).to eq 'UTF-8'
-      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'UTF-8')
-      expect(p.charset).to eq 'UTF-8'
-      mail.add_part(p)
-      expect(mail.charset).to eq 'UTF-8'
-      expect(p.charset).to eq 'UTF-8'
-    end
-
-    it "should preserve the charset of the mail when UTF-8 vs ISO-8859-1" do
-      mail = Mail.new
-      expect(mail.charset).to eq 'UTF-8'
-      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'ISO-8859-1')
-      expect(p.charset).to eq 'ISO-8859-1'
-      mail.add_part(p)
-      expect(mail.charset).to eq 'UTF-8'
-      expect(p.charset).to eq 'ISO-8859-1'
-    end
-
-    it "should preserve the charset of the mail when UTF-8 vs nil" do
-      mail = Mail.new
-      expect(mail.charset).to eq 'UTF-8'
-      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT')
-      expect(p.charset).to eq nil
-      mail.add_part(p)
-      expect(mail.charset).to eq 'UTF-8'
-      expect(p.charset).to eq nil
-    end
-
-    it "should preserve the charset of the mail when ISO-8859-1 vs UTF-8" do
-      mail = Mail.new
-      mail['charset'] = 'ISO-8859-1'
-      expect(mail.charset).to eq 'ISO-8859-1'
-      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'UTF-8')
-      expect(p.charset).to eq 'UTF-8'
-      mail.add_part(p)
-      expect(mail.charset).to eq 'ISO-8859-1'
-      expect(p.charset).to eq 'UTF-8'
-    end
-
-    it "should preserve the charset of the mail when ISO-8859-1 vs nil" do
-      mail = Mail.new
-      mail['charset'] = 'ISO-8859-1'
-      expect(mail.charset).to eq 'ISO-8859-1'
-      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT')
-      expect(p.charset).to eq nil
-      mail.add_part(p)
-      expect(mail.charset).to eq 'ISO-8859-1'
-      expect(p.charset).to eq nil
-    end
-
-    it "should preserve the charset of the mail when nil vs UTF-8" do
-      mail = Mail.new
-      mail['charset'] = nil
-      expect(mail.charset).to eq nil
-      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'UTF-8')
-      expect(p.charset).to eq 'UTF-8'
-      mail.add_part(p)
-      expect(mail.charset).to eq nil
-      expect(p.charset).to eq 'UTF-8'
-    end
-
-    it "should preserve the charset of the mail when nil vs ISO-8859-1" do
-      mail = Mail.new
-      mail['charset'] = nil
-      expect(mail.charset).to eq nil
-      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => 'ISO-8859-1')
-      expect(p.charset).to eq 'ISO-8859-1'
-      mail.add_part(p)
-      expect(mail.charset).to eq nil
-      expect(p.charset).to eq 'ISO-8859-1'
-    end
-
-    it "should preserve the charset of the mail when nil vs nil" do
-      mail = Mail.new
-      mail['charset'] = nil
-      expect(mail.charset).to eq nil
-      p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT')
-      expect(p.charset).to eq nil
-      mail.add_part(p)
-      expect(mail.charset).to eq nil
-      expect(p.charset).to eq nil
+  describe "adding parts should preserve the charset of the mail" do
+    charsets = ['UTF-8', 'ISO-8859-1', nil]
+    charsets.each do |mail_charset|
+      charsets.each do |part_charset|
+        it "when #{mail_charset || 'nil'} vs #{part_charset || 'nil'}" do
+          mail = Mail.new
+          mail['charset'] = mail_charset
+          expect(mail.charset).to eq mail_charset
+          p = Mail::Part.new(:content_type => 'text/html', :body => 'HTML TEXT', :charset => part_charset)
+          expect(p.charset).to eq part_charset
+          mail.add_part(p)
+          expect(mail.charset).to eq mail_charset
+          expect(p.charset).to eq part_charset
+        end
+      end
     end
   end
 


### PR DESCRIPTION
**Please also backport to 2.8.x stable branch**

## Summary

Version 2.8.0.rc1 has a regression where `charset=UTF-8` is omitted from the `Content-Type` header in multi-part (text + html) mails. Due to this regression, some of our Japanese customers reported their legacy mail clients had garbled characters. It appears the legacy mail clients assume some other encoding besides UTF-8 if it's not present (probably Shift-JIS in our case).

The fix I've proposed here doesn't appear to alter any existing behavior.

## Details

In `ActionMailer::Base`, there is [this code](https://github.com/rails/rails/blob/e4ec2cbb494f6ec7dda227b05ba8a1ec8675c796/actionmailer/lib/action_mailer/base.rb#L1032):

```
          container = Mail::Part.new
          container.content_type = "multipart/alternative"
          responses.each { |r| insert_part(container, r, m.charset) }
          m.add_part(container)
```

On Mail 2.8.0.rc1, adding both an HTML and Text part (i.e. in the standard Rails way, no special code) will inadvertently clear the charset on the parent `Message`. In the final rendered mail, it causes `charset=UTF-8` to be omitted the `Content-Type` header. Compare as follows:

**2.7.x:**

```
----==_mimepart_62c78ac27c197_36459c77334
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: base64

DQrkuojntITnorrlrpoNCg0K44GK5a6i5qeY44Gu44GU5LqI57SE44GM56K65a6a6Ie044GX44G+...
```

**2.8.0.rc1:**
```
----==_mimepart_62c78ac27de6f_a2459c7627b
Content-Type: text/plain
Content-Transfer-Encoding: base64

DQrkuojntITnorrlrpoNCg0K44GK5a6i5qeY44Gu44GU5LqI57SE44GM56K65a6a6Ie044GX44G+...
```