### PR TITLE
[Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.

### DIFF
--- a/lib/mail/body.rb
+++ b/lib/mail/body.rb
@@ -1,28 +1,28 @@
 # encoding: utf-8
 # frozen_string_literal: true
 module Mail
-  
+
   # = Body
-  # 
+  #
   # The body is where the text of the email is stored.  Mail treats the body
   # as a single object.  The body itself has no information about boundaries
   # used in the MIME standard, it just looks at its content as either a single
   # block of text, or (if it is a multipart message) as an array of blocks of text.
-  # 
+  #
   # A body has to be told to split itself up into a multipart message by calling
   # #split with the correct boundary.  This is because the body object has no way
   # of knowing what the correct boundary is for itself (there could be many
   # boundaries in a body in the case of a nested MIME text).
-  # 
+  #
   # Once split is called, Mail::Body will slice itself up on this boundary,
   # assigning anything that appears before the first part to the preamble, and
   # anything that appears after the closing boundary to the epilogue, then
   # each part gets initialized into a Mail::Part object.
-  # 
+  #
   # The boundary that is used to split up the Body is also stored in the Body
-  # object for use on encoding itself back out to a string.  You can 
+  # object for use on encoding itself back out to a string.  You can
   # overwrite this if it needs to be changed.
-  # 
+  #
   # On encoding, the body will return the preamble, then each part joined by
   # the boundary, followed by a closing boundary string and then the epilogue.
   class Body
@@ -57,15 +57,15 @@ module Mail
 
     # Matches this body with another body.  Also matches the decoded value of this
     # body with a string.
-    # 
+    #
     # Examples:
-    # 
+    #
     #   body = Mail::Body.new('The body')
     #   body == body #=> true
-    #   
+    #
     #   body = Mail::Body.new('The body')
     #   body == 'The body' #=> true
-    #   
+    #
     #   body = Mail::Body.new("VGhlIGJvZHk=\n")
     #   body.encoding = 'base64'
     #   body == "The body" #=> true
@@ -76,28 +76,28 @@ module Mail
         super
       end
     end
-    
+
     # Accepts a string and performs a regular expression against the decoded text
-    # 
+    #
     # Examples:
-    # 
+    #
     #   body = Mail::Body.new('The body')
     #   body =~ /The/ #=> 0
-    #   
+    #
     #   body = Mail::Body.new("VGhlIGJvZHk=\n")
     #   body.encoding = 'base64'
     #   body =~ /The/ #=> 0
     def =~(regexp)
       self.decoded =~ regexp
     end
-    
+
     # Accepts a string and performs a regular expression against the decoded text
-    # 
+    #
     # Examples:
-    # 
+    #
     #   body = Mail::Body.new('The body')
     #   body.match(/The/) #=> #<MatchData "The">
-    #   
+    #
     #   body = Mail::Body.new("VGhlIGJvZHk=\n")
     #   body.encoding = 'base64'
     #   body.match(/The/) #=> #<MatchData "The">
@@ -125,7 +125,7 @@ module Mail
     def set_sort_order(order)
       @part_sort_order = order
     end
-    
+
     # Allows you to sort the parts according to the default sort order, or the sort order you
     # set with :set_sort_order.
     #
@@ -137,7 +137,7 @@ module Mail
       end
       @parts.sort!(@part_sort_order)
     end
-    
+
     def negotiate_best_encoding(message_encoding, allowed_encodings = nil)
       Mail::Encodings::TransferEncoding.negotiate(message_encoding, encoding, raw_source, allowed_encodings)
     end
@@ -164,7 +164,7 @@ module Mail
           # Cannot decode, so skip normalization
           raw_source
         else
-          # Decode then encode to normalize and allow transforming 
+          # Decode then encode to normalize and allow transforming
           # from base64 to Q-P and vice versa
           decoded = dec.decode(raw_source)
           if defined?(Encoding) && charset && charset != "US-ASCII"
@@ -183,7 +183,7 @@ module Mail
         Encodings.get_encoding(encoding).decode(raw_source)
       end
     end
-    
+
     def to_s
       decoded
     end
@@ -289,11 +289,11 @@ module Mail
       end
       parts.map(&:first)
     end
-    
+
     def crlf_boundary
       "\r\n--#{boundary}\r\n"
     end
-    
+
     def end_boundary
       "\r\n--#{boundary}--\r\n"
     end

--- a/lib/mail/field_list.rb
+++ b/lib/mail/field_list.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 module Mail
 
-  # Field List class provides an enhanced array that keeps a list of 
+  # Field List class provides an enhanced array that keeps a list of
   # email fields in order.  And allows you to insert new fields without
   # having to worry about the order they will appear in.
   class FieldList < Array

--- a/lib/mail/mail.rb
+++ b/lib/mail/mail.rb
@@ -3,45 +3,45 @@
 module Mail
 
   # Allows you to create a new Mail::Message object.
-  # 
+  #
   # You can make an email via passing a string or passing a block.
-  # 
+  #
   # For example, the following two examples will create the same email
   # message:
-  # 
+  #
   # Creating via a string:
-  # 
+  #
   #  string = "To: mikel@test.lindsaar.net\r\n"
   #  string << "From: bob@test.lindsaar.net\r\n"
   #  string << "Subject: This is an email\r\n"
   #  string << "\r\n"
   #  string << "This is the body"
   #  Mail.new(string)
-  # 
+  #
   # Or creating via a block:
-  # 
+  #
   #  message = Mail.new do
   #    to 'mikel@test.lindsaar.net'
   #    from 'bob@test.lindsaar.net'
   #    subject 'This is an email'
   #    body 'This is the body'
   #  end
-  # 
+  #
   # Or creating via a hash (or hash like object):
-  # 
+  #
   #  message = Mail.new({:to => 'mikel@test.lindsaar.net',
   #                      'from' => 'bob@test.lindsaar.net',
   #                      :subject => 'This is an email',
   #                      :body => 'This is the body' })
-  # 
+  #
   # Note, the hash keys can be strings or symbols, the passed in object
   # does not need to be a hash, it just needs to respond to :each_pair
   # and yield each key value pair.
-  # 
+  #
   # As a side note, you can also create a new email through creating
   # a Mail::Message object directly and then passing in values via string,
   # symbol or direct method calls.  See Mail::Message for more information.
-  # 
+  #
   #  mail = Mail.new
   #  mail.to = 'mikel@test.lindsaar.net'
   #  mail[:from] = 'bob@test.lindsaar.net'
@@ -54,20 +54,20 @@ module Mail
   # Sets the default delivery method and retriever method for all new Mail objects.
   # The delivery_method and retriever_method default to :smtp and :pop3, with defaults
   # set.
-  # 
+  #
   # So sending a new email, if you have an SMTP server running on localhost is
   # as easy as:
-  # 
+  #
   #   Mail.deliver do
   #     to      'mikel@test.lindsaar.net'
   #     from    'bob@test.lindsaar.net'
   #     subject 'hi there!'
   #     body    'this is a body'
   #   end
-  # 
+  #
   # If you do not specify anything, you will get the following equivalent code set in
   # every new mail object:
-  # 
+  #
   #   Mail.defaults do
   #     delivery_method :smtp, { :address              => "localhost",
   #                              :port                 => 25,
@@ -76,14 +76,14 @@ module Mail
   #                              :password             => nil,
   #                              :authentication       => nil,
   #                              :enable_starttls_auto => true  }
-  # 
+  #
   #     retriever_method :pop3, { :address             => "localhost",
   #                               :port                => 995,
   #                               :user_name           => nil,
   #                               :password            => nil,
   #                               :enable_ssl          => true }
   #   end
-  # 
+  #
   #   Mail.delivery_method.new  #=> Mail::SMTP instance
   #   Mail.retriever_method.new #=> Mail::POP3 instance
   #
@@ -91,9 +91,9 @@ module Mail
   # a per email basis, you can override the method:
   #
   #   mail.delivery_method :smtp
-  # 
+  #
   # Or you can override the method and pass in settings:
-  # 
+  #
   #   mail.delivery_method :smtp, :address => 'some.host'
   def self.defaults(&block)
     Configuration.instance.instance_eval(&block)
@@ -112,21 +112,21 @@ module Mail
   # Send an email using the default configuration.  You do need to set a default
   # configuration first before you use self.deliver, if you don't, an appropriate
   # error will be raised telling you to.
-  # 
+  #
   # If you do not specify a delivery type, SMTP will be used.
-  # 
+  #
   #  Mail.deliver do
   #   to 'mikel@test.lindsaar.net'
   #   from 'ada@test.lindsaar.net'
   #   subject 'This is a test email'
   #   body 'Not much to say here'
   #  end
-  # 
+  #
   # You can also do:
-  # 
+  #
   #  mail = Mail.read('email.eml')
   #  mail.deliver!
-  # 
+  #
   # And your email object will be created and sent.
   def self.deliver(*args, &block)
     mail = self.new(args, &block)
@@ -190,7 +190,7 @@ module Mail
 
   # You can register an object to be informed of every email that is sent through
   # this method.
-  # 
+  #
   # Your object needs to respond to a single method #delivered_email(mail)
   # which receives the email that is sent.
   def self.register_observer(observer)
@@ -208,7 +208,7 @@ module Mail
   # You can register an object to be given every mail object that will be sent,
   # before it is sent.  So if you want to add special headers or modify any
   # email that gets sent through the Mail library, you can do so.
-  # 
+  #
   # Your object needs to respond to a single method #delivering_email(mail)
   # which receives the email that is about to be sent.  Make your modifications
   # directly to this object.

--- a/lib/mail/network/delivery_methods/file_delivery.rb
+++ b/lib/mail/network/delivery_methods/file_delivery.rb
@@ -4,12 +4,12 @@ require 'mail/smtp_envelope'
 module Mail
   # FileDelivery class delivers emails into multiple files based on the destination
   # address.  Each file is appended to if it already exists.
-  # 
+  #
   # So if you have an email going to fred@test, bob@test, joe@anothertest, and you
   # set your location path to /path/to/mails then FileDelivery will create the directory
   # if it does not exist, and put one copy of the email in three files, called
   # by their message id
-  # 
+  #
   # Make sure the path you specify with :location is writable by the Ruby process
   # running Mail.
   class FileDelivery

--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -3,18 +3,18 @@ require 'mail/smtp_envelope'
 
 module Mail
   # == Sending Email with SMTP
-  # 
+  #
   # Mail allows you to send emails using SMTP.  This is done by wrapping Net::SMTP in
   # an easy to use manner.
-  # 
+  #
   # === Sending via SMTP server on Localhost
-  # 
+  #
   # Sending locally (to a postfix or sendmail server running on localhost) requires
   # no special setup.  Just to Mail.deliver &block or message.deliver! and it will
   # be sent in this method.
-  # 
+  #
   # === Sending via MobileMe
-  # 
+  #
   #   Mail.defaults do
   #     delivery_method :smtp, { :address              => "smtp.me.com",
   #                              :port                 => 587,
@@ -24,9 +24,9 @@ module Mail
   #                              :authentication       => 'plain',
   #                              :enable_starttls_auto => true  }
   #   end
-  # 
+  #
   # === Sending via GMail
-  # 
+  #
   #   Mail.defaults do
   #     delivery_method :smtp, { :address              => "smtp.gmail.com",
   #                              :port                 => 587,
@@ -48,30 +48,30 @@ module Mail
   # verify mode constant (OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER),
   # or a string containing the name of an OpenSSL verify mode (none, peer).
   #
-  # === Others 
-  # 
+  # === Others
+  #
   # Feel free to send me other examples that were tricky
-  # 
+  #
   # === Delivering the email
-  # 
+  #
   # Once you have the settings right, sending the email is done by:
-  # 
+  #
   #   Mail.deliver do
   #     to 'mikel@test.lindsaar.net'
   #     from 'ada@test.lindsaar.net'
   #     subject 'testing sendmail'
   #     body 'testing sendmail'
   #   end
-  # 
+  #
   # Or by calling deliver on a Mail message
-  # 
+  #
   #   mail = Mail.new do
   #     to 'mikel@test.lindsaar.net'
   #     from 'ada@test.lindsaar.net'
   #     subject 'testing sendmail'
   #     body 'testing sendmail'
   #   end
-  # 
+  #
   #   mail.deliver!
   class SMTP
     attr_accessor :settings

--- a/lib/mail/network/delivery_methods/smtp_connection.rb
+++ b/lib/mail/network/delivery_methods/smtp_connection.rb
@@ -3,39 +3,39 @@ require 'mail/smtp_envelope'
 
 module Mail
   # == Sending Email with SMTP
-  # 
+  #
   # Mail allows you to send emails using an open SMTP connection.  This is done by
   # passing a created Net::SMTP object.  This way we can get better performance to
   # our local mail server by reducing the number of connections at any one time.
   #
   # === Sending via SMTP server on Localhost
-  # 
+  #
   # To send mail open a connection with Net::Smtp using any options you like
   # === Delivering the email
-  # 
+  #
   # Once you have the settings right, sending the email is done by:
   #
   #   smtp_conn = Net::SMTP.start(settings[:address], settings[:port])
   #   Mail.defaults do
   #     delivery_method :smtp_connection, { :connection => smtp_conn }
   #   end
-  # 
+  #
   #   Mail.deliver do
   #     to 'mikel@test.lindsaar.net'
   #     from 'ada@test.lindsaar.net'
   #     subject 'testing sendmail'
   #     body 'testing sendmail'
   #   end
-  # 
+  #
   # Or by calling deliver on a Mail message
-  # 
+  #
   #   mail = Mail.new do
   #     to 'mikel@test.lindsaar.net'
   #     from 'ada@test.lindsaar.net'
   #     subject 'testing sendmail'
   #     body 'testing sendmail'
   #   end
-  # 
+  #
   #   mail.deliver!
   class SMTPConnection
     attr_accessor :smtp, :settings

--- a/lib/mail/network/delivery_methods/test_mailer.rb
+++ b/lib/mail/network/delivery_methods/test_mailer.rb
@@ -4,7 +4,7 @@ require 'mail/smtp_envelope'
 module Mail
   # The TestMailer is a bare bones mailer that does nothing.  It is useful
   # when you are testing.
-  # 
+  #
   # It also provides a template of the minimum methods you require to implement
   # if you want to make a custom mailer for Mail
   class TestMailer
@@ -14,11 +14,11 @@ module Mail
     end
 
     # Allows you to over write the default deliveries store from an array to some
-    # other object.  If you just want to clear the store, 
+    # other object.  If you just want to clear the store,
     # call TestMailer.deliveries.clear.
-    # 
+    #
     # If you place another object here, please make sure it responds to:
-    # 
+    #
     # * << (message)
     # * clear
     # * length

--- a/lib/mail/network/retriever_methods/base.rb
+++ b/lib/mail/network/retriever_methods/base.rb
@@ -17,7 +17,7 @@ module Mail
       options[:count] ||= 1
       find(options, &block)
     end
-    
+
     # Get the most recent received email(s)
     #
     # Possible options:
@@ -30,7 +30,7 @@ module Mail
       options[:count] ||= 1
       find(options, &block)
     end
-    
+
     # Get all emails.
     #
     # Possible options:
@@ -42,7 +42,7 @@ module Mail
       find(options, &block)
     end
 
-    # Find emails in the mailbox, and then deletes them. Without any options, the 
+    # Find emails in the mailbox, and then deletes them. Without any options, the
     # five last received emails are returned.
     #
     # Possible options:
@@ -56,8 +56,8 @@ module Mail
     def find_and_delete(options = nil, &block)
       options = options ? Hash[options] : {}
       options[:delete_after_find] ||= true
-      find(options, &block)      
-    end 
+      find(options, &block)
+    end
 
   end
 

--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -29,7 +29,7 @@ module Mail
   #   order:   order of emails returned. Possible values are :asc or :desc. Default value is :asc.
   #   count:   number of emails to retrieve. The default value is 10. A value of 1 returns an
   #            instance of Message, not an array of Message instances.
-  #   keys:    are passed as criteria to the SEARCH command.  They can either be a string holding the entire search string, 
+  #   keys:    are passed as criteria to the SEARCH command.  They can either be a string holding the entire search string,
   #            or a single-dimension array of search keywords and arguments.  Refer to  [IMAP] section 6.4.4 for a full list
   #            The default is 'ALL'
   #
@@ -38,7 +38,7 @@ module Mail
   #
   class IMAP < Retriever
     require 'net/imap' unless defined?(Net::IMAP)
-    
+
     def initialize(values)
       self.settings = { :address              => "localhost",
                         :port                 => 143,
@@ -65,7 +65,7 @@ module Mail
     #              This is helpful when you don't want your messages to be set to read automatically. Default is false.
     #   delete_after_find: flag for whether to delete each retreived email after find. Default
     #           is false. Use #find_and_delete if you would like this to default to true.
-    #   keys:   are passed as criteria to the SEARCH command.  They can either be a string holding the entire search string, 
+    #   keys:   are passed as criteria to the SEARCH command.  They can either be a string holding the entire search string,
     #           or a single-dimension array of search keywords and arguments.  Refer to  [IMAP] section 6.4.4 for a full list
     #           The default is 'ALL'
     #   search_charset: charset to pass to IMAP server search. Omitted by default. Example: 'UTF-8' or 'ASCII'.

--- a/lib/mail/network/retriever_methods/pop3.rb
+++ b/lib/mail/network/retriever_methods/pop3.rb
@@ -6,9 +6,9 @@ module Mail
   # Each email retrieved (RFC2822) is given as an instance of +Message+.
   #
   # While being retrieved, emails can be yielded if a block is given.
-  # 
+  #
   # === Example of retrieving Emails from GMail:
-  # 
+  #
   #   Mail.defaults do
   #     retriever_method :pop3, { :address             => "pop.gmail.com",
   #                               :port                => 995,
@@ -16,22 +16,22 @@ module Mail
   #                               :password            => '<password>',
   #                               :enable_ssl          => true }
   #   end
-  # 
+  #
   #   Mail.all    #=> Returns an array of all emails
   #   Mail.first  #=> Returns the first unread email
   #   Mail.last   #=> Returns the last unread email
-  # 
+  #
   # You can also pass options into Mail.find to locate an email in your pop mailbox
   # with the following options:
-  # 
+  #
   #   what:  last or first emails. The default is :first.
   #   order: order of emails returned. Possible values are :asc or :desc. Default value is :asc.
   #   count: number of emails to retrieve. The default value is 10. A value of 1 returns an
   #          instance of Message, not an array of Message instances.
-  # 
+  #
   #   Mail.find(:what => :first, :count => 10, :order => :asc)
   #   #=> Returns the first 10 emails in ascending order
-  # 
+  #
   class POP3 < Retriever
     require 'net/pop' unless defined?(Net::POP)
 
@@ -44,9 +44,9 @@ module Mail
                         :enable_ssl           => false,
                         :read_timeout         => nil }.merge!(values)
     end
-    
+
     attr_accessor :settings
-    
+
     # Find emails in a POP3 mailbox. Without any options, the 5 last received emails are returned.
     #
     # Possible options:
@@ -59,18 +59,18 @@ module Mail
     #
     def find(options = nil, &block)
       options = validate_options(options)
-      
+
       start do |pop3|
         mails = pop3.mails
         pop3.reset # Clears all "deleted" marks. This prevents non-explicit/accidental deletions due to server settings.
         mails.sort! { |m1, m2| m2.number <=> m1.number } if options[:what] == :last
         mails = mails.first(options[:count]) if options[:count].is_a? Integer
-        
+
         if options[:what].to_sym == :last && options[:order].to_sym == :desc ||
            options[:what].to_sym == :first && options[:order].to_sym == :asc ||
           mails.reverse!
         end
-        
+
         if block_given?
           mails.each do |mail|
             new_message = Mail.new(mail.pop)
@@ -86,11 +86,11 @@ module Mail
           end
           emails.size == 1 && options[:count] == 1 ? emails.first : emails
         end
-        
+
       end
     end
-    
-    # Delete all emails from a POP3 server   
+
+    # Delete all emails from a POP3 server
     def delete_all
       start do |pop3|
         unless pop3.mails.empty?
@@ -108,9 +108,9 @@ module Mail
         yield pop3
       end
     end
-    
+
   private
-  
+
     # Set default options
     def validate_options(options)
       options = options ? Hash[options] : {}
@@ -120,18 +120,18 @@ module Mail
       options[:delete_after_find] ||= false
       options
     end
-  
+
     # Start a POP3 session and ensure that it will be closed in any case. Any messages
     # marked for deletion via #find_and_delete or with the :delete_after_find option
     # will be deleted when the session is closed.
     def start(config = Configuration.instance, &block)
       raise ArgumentError.new("Mail::Retrievable#pop3_start takes a block") unless block_given?
-    
+
       pop3 = Net::POP3.new(settings[:address], settings[:port], false)
       pop3.enable_ssl(OpenSSL::SSL::VERIFY_NONE) if settings[:enable_ssl]
       pop3.read_timeout = settings[:read_timeout] if settings[:read_timeout]
       pop3.start(settings[:user_name], settings[:password])
-    
+
       yield pop3
     ensure
       if defined?(pop3) && pop3 && pop3.started?

--- a/lib/mail/part.rb
+++ b/lib/mail/part.rb
@@ -9,31 +9,31 @@ module Mail
     # into the Header.  The ContentIdField object will automatically generate
     # a unique content ID if you try and encode it or output it to_s without
     # specifying a content id.
-    # 
+    #
     # It will preserve the content ID you specify if you do.
     def add_content_id(content_id_val = '')
       header['content-id'] = content_id_val
     end
-    
+
     # Returns true if the part has a content ID field, the field may or may
     # not have a value, but the field exists or not.
     def has_content_id?
       header.has_content_id?
     end
-    
+
     def cid
       add_content_id unless has_content_id?
       Utilities.uri_escape(Utilities.unbracket(content_id))
     end
-    
+
     def url
       "cid:#{cid}"
     end
-    
+
     def inline?
       header[:content_disposition].disposition_type == 'inline' if header[:content_disposition].respond_to?(:disposition_type)
     end
-    
+
     def add_required_fields
       super
       add_content_id if !has_content_id? && inline?
@@ -42,15 +42,15 @@ module Mail
     def add_required_message_fields
       # Override so we don't add Date, MIME-Version, or Message-ID.
     end
-    
+
     def delivery_status_report_part?
       (main_type =~ /message/i && sub_type =~ /delivery-status/i) && body =~ /Status:/
     end
-    
+
     def delivery_status_data
       delivery_status_report_part? ? parse_delivery_status_report : {}
     end
-    
+
     def bounced?
       if action.is_a?(Array)
         !!(action.first =~ /failed/i)
@@ -58,18 +58,18 @@ module Mail
         !!(action =~ /failed/i)
       end
     end
-    
-    
+
+
     # Either returns the action if the message has just a single report, or an
     # array of all the actions, one for each report
     def action
       get_return_values('action')
     end
-    
+
     def final_recipient
       get_return_values('final-recipient')
     end
-    
+
     def error_status
       get_return_values('status')
     end
@@ -77,17 +77,17 @@ module Mail
     def diagnostic_code
       get_return_values('diagnostic-code')
     end
-    
+
     def remote_mta
       get_return_values('remote-mta')
     end
-    
+
     def retryable?
       !(error_status =~ /^5/)
     end
 
     private
-    
+
     def get_return_values(key)
       if delivery_status_data[key].is_a?(Array)
         delivery_status_data[key].map { |a| a.value }
@@ -97,7 +97,7 @@ module Mail
         nil
       end
     end
-    
+
     # A part may not have a header.... so, just init a body if no header
     def parse_message
       header_part, body_part = raw_source.split(/#{Constants::LAX_CRLF}#{Constants::WSP}*#{Constants::LAX_CRLF}/m, 2)
@@ -109,11 +109,11 @@ module Mail
         self.body   = raw_source
       end
     end
-    
+
     def parse_delivery_status_report
       @delivery_status_data ||= Header.new(body.to_s.gsub("\r\n\r\n", "\r\n"))
     end
 
   end
-  
+
 end

--- a/spec/mail/elements/envelope_from_element_spec.rb
+++ b/spec/mail/elements/envelope_from_element_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 RSpec.describe Mail::EnvelopeFromElement do
-  
+
   describe "parsing a from envelope string" do
     it "should parse a full field" do
       expect { Mail::EnvelopeFromElement.new("mikel@test.lindsaar.net  Mon Aug  7 00:39:21 2009") }.not_to raise_error

--- a/spec/mail/encodings/base64_spec.rb
+++ b/spec/mail/encodings/base64_spec.rb
@@ -7,20 +7,20 @@ RSpec.describe Mail::Encodings::Base64 do
     result = "VGhpcyBpcyBhIHRlc3Q=\r\n"
     expect(Mail::Encodings::Base64.encode('This is a test')).to eq result
   end
-  
+
   it "should decode base 64 text" do
     result = 'This is a test'
     expect(Mail::Encodings::Base64.decode("VGhpcyBpcyBhIHRlc3Q=\n")).to eq result
   end
-  
+
   it "should encode base 64 from binary" do
     result = "AAAAAA==\r\n"
     expect(Mail::Encodings::Base64.encode("\000\000\000\000")).to eq result
   end
-  
+
   it "should decode base 64 text" do
     result = "\000\000\000\000"
     expect(Mail::Encodings::Base64.decode("AAAAAA==\n")).to eq result
   end
-  
+
 end

--- a/spec/mail/encodings/quoted_printable_spec.rb
+++ b/spec/mail/encodings/quoted_printable_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 RSpec.describe Mail::Encodings::QuotedPrintable do
-  
+
   it "should encode quoted printable from text" do
     result = "This is\r\na test=\r\n"
     expect(Mail::Encodings::QuotedPrintable.encode("This is\na test")).to eq result

--- a/spec/mail/fields/bcc_field_spec.rb
+++ b/spec/mail/fields/bcc_field_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Mail::BccField do
   #    copies were sent to someone.  Which method to use with "Bcc:" fields
   #    is implementation dependent, but refer to the "Security
   #    Considerations" section of this document for a discussion of each.
-  
+
   describe "initialization" do
 
     it "should initialize" do
@@ -56,12 +56,12 @@ RSpec.describe Mail::BccField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return nothing by default on encoded as Bcc should not be in the mail" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq ""
@@ -72,19 +72,19 @@ RSpec.describe Mail::BccField do
       t.include_in_headers = true
       expect(t.encoded).to eq "Bcc: sam@me.com\r\n"
     end
-    
+
     it "should return the encoded line when requested to include in headers" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       t.include_in_headers = true
       expect(t.encoded).to eq "Bcc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
     it "should return the decoded line" do
       t = Mail::BccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.decoded).to eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
-    
+
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/cc_field_spec.rb
+++ b/spec/mail/fields/cc_field_spec.rb
@@ -41,28 +41,28 @@ RSpec.describe Mail::CcField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return the encoded line for one address" do
       t = Mail::CcField.new('sam@me.com')
       expect(t.encoded).to eq "Cc: sam@me.com\r\n"
     end
-    
+
     it "should return the encoded line" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq "Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
     it "should return the decoded line" do
       t = Mail::CcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.decoded).to eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
-    
+
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/comments_field_spec.rb
+++ b/spec/mail/fields/comments_field_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Mail::CommentsField do
   # 
   # comments        =       "Comments:" unstructured CRLF
-  
+
   it "should initialize" do
     expect { Mail::CommentsField.new("this is a comment") }.not_to raise_error
   end
@@ -15,6 +15,6 @@ RSpec.describe Mail::CommentsField do
     expect(t.name).to eq 'Comments'
     expect(t.value).to eq 'this is a comment'
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/content_description_field_spec.rb
+++ b/spec/mail/fields/content_description_field_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Mail::ContentDescriptionField do
   # set, although the mechanism specified in RFC 2047 may be used for
   # non-US-ASCII Content-Description values.
   #
-  
+
   describe "initialization" do
 
     it "should initialize" do

--- a/spec/mail/fields/content_id_field_spec.rb
+++ b/spec/mail/fields/content_id_field_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Mail::ContentIdField do
     end
 
   end
-  
+
   describe "ensuring only one message ID" do
 
     it "should not accept a string with multiple message IDs but only return the first" do
@@ -88,7 +88,7 @@ RSpec.describe Mail::ContentIdField do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
       expect(m.encoded).to eq "Content-ID: <1234@test.lindsaar.net>\r\n"
     end
-    
+
     it "should respond to :responsible_for?" do
       m = Mail::ContentIdField.new('<1234@test.lindsaar.net>')
       expect(m).to respond_to(:responsible_for?)
@@ -100,7 +100,7 @@ RSpec.describe Mail::ContentIdField do
       m = Mail::ContentIdField.new
       expect(Mail::Utilities.blank?(m.content_id)).not_to be_truthy
     end
-    
+
     it "should generate a random message ID" do
       m = Mail::ContentIdField.new
       1.upto(100) do

--- a/spec/mail/fields/content_location_field_spec.rb
+++ b/spec/mail/fields/content_location_field_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 RSpec.describe Mail::ContentLocationField do
 
   # Content-Location Header Field
-  # 
+  #
   describe "initialization" do
 
     it "should initialize" do
@@ -30,12 +30,12 @@ RSpec.describe Mail::ContentLocationField do
   end
 
   describe "parsing the value" do
-    
+
     it "should return an encoding string unquoted" do
       t = Mail::ContentLocationField.new('"A quoted filename.jpg"')
       expect(t.location).to eq 'A quoted filename.jpg'
     end
-    
+
   end
 
 end

--- a/spec/mail/fields/in_reply_to_field_spec.rb
+++ b/spec/mail/fields/in_reply_to_field_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
-# 
+#
 #    The "In-Reply-To:" field will contain the contents of the "Message-
 #    ID:" field of the message to which this one is a reply (the "parent
 #    message").  If there is more than one parent message, then the "In-
@@ -23,12 +23,12 @@ RSpec.describe Mail::InReplyToField do
       expect(t.value).to eq '<1234@test.lindsaar.net>'
       expect(t.message_id).to eq '1234@test.lindsaar.net'
     end
-    
+
     it "should provide encoded" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
       expect(t.encoded).to eq "In-Reply-To: <1234@test.lindsaar.net>\r\n"
     end
-    
+
     it "should handle many encoded message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
       expect(t.encoded).to eq "In-Reply-To: <1234@test.lindsaar.net>\r\n <4567@test.lindsaar.net>\r\n"
@@ -43,18 +43,18 @@ RSpec.describe Mail::InReplyToField do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net>')
       expect(t.decoded).to eq "<1234@test.lindsaar.net>"
     end
-    
+
     it "should handle many decoded message IDs" do
       t = Mail::InReplyToField.new('<1234@test.lindsaar.net> <4567@test.lindsaar.net>')
       expect(t.decoded).to eq '<1234@test.lindsaar.net> <4567@test.lindsaar.net>'
     end
-    
+
     it "should handle an empty value" do
       t = Mail::InReplyToField.new('')
       expect(t.name).to eq 'In-Reply-To'
       expect(t.decoded).to be_nil
     end
-    
+
   end
 
   describe "handlign multiple message ids" do

--- a/spec/mail/fields/keywords_field_spec.rb
+++ b/spec/mail/fields/keywords_field_spec.rb
@@ -5,47 +5,47 @@ require 'spec_helper'
 RSpec.describe Mail::KeywordsField do
 
   describe "initializing" do
-    
+
     it "should initialize" do
       expect { Mail::KeywordsField.new("this, is, email") }.not_to raise_error
     end
-    
+
     it "should accept a string without the field name" do
       k = Mail::KeywordsField.new('these are keywords, so there')
       expect(k.name).to eq 'Keywords'
       expect(k.value).to eq 'these are keywords, so there'
     end
-    
+
   end
-  
+
   describe "giving a list of keywords" do
     it "should return a list of keywords" do
       k = Mail::KeywordsField.new('these are keywords, so there')
       expect(k.keywords).to eq ['these are keywords', 'so there']
     end
-    
+
     it "should handle phrases" do
       k = Mail::KeywordsField.new('"these, are keywords", so there')
       expect(k.keywords).to eq ['these, are keywords', 'so there']
     end
-    
+
     it "should handle comments" do
       k = Mail::KeywordsField.new('"these, are keywords", so there (This is an irrelevant comment)')
       expect(k.keywords).to eq ['these, are keywords', 'so there (This is an irrelevant comment)']
     end
-    
+
     it "should handle comments" do
       k = Mail::KeywordsField.new('"these, are keywords", so there (This is an irrelevant comment)')
       expect(k.keywords).to eq ['these, are keywords', 'so there (This is an irrelevant comment)']
     end
-    
+
     it "should handle comments in quotes" do
       k = Mail::KeywordsField.new('"these, are keywords (another comment to be ignored)", so there (This is an irrelevant comment)')
       expect(k.keywords).to eq ['these, are keywords (another comment to be ignored)', 'so there (This is an irrelevant comment)']
     end
-    
+
   end
-  
+
   describe "encoding and decoding" do
     it "should encode" do
       k = Mail::KeywordsField.new('these are keywords, so there')

--- a/spec/mail/fields/message_id_field_spec.rb
+++ b/spec/mail/fields/message_id_field_spec.rb
@@ -2,34 +2,34 @@
 # frozen_string_literal: true
 require 'spec_helper'
 # 3.6.4. Identification fields
-#  
+#
 #   Though optional, every message SHOULD have a "Message-ID:" field.
 #   Furthermore, reply messages SHOULD have "In-Reply-To:" and
 #   "References:" fields as appropriate, as described below.
-#   
+#
 #   The "Message-ID:" field contains a single unique message identifier.
 #   The "References:" and "In-Reply-To:" field each contain one or more
 #   unique message identifiers, optionally separated by CFWS.
-#   
+#
 #   The message identifier (msg-id) is similar in syntax to an angle-addr
 #   construct without the internal CFWS.
-#  
+#
 #  message-id      =       "Message-ID:" msg-id CRLF
-#  
+#
 #  in-reply-to     =       "In-Reply-To:" 1*msg-id CRLF
-#  
+#
 #  references      =       "References:" 1*msg-id CRLF
-#  
+#
 #  msg-id          =       [CFWS] "<" id-left "@" id-right ">" [CFWS]
-#  
+#
 #  id-left         =       dot-atom-text / no-fold-quote / obs-id-left
-#  
+#
 #  id-right        =       dot-atom-text / no-fold-literal / obs-id-right
-#  
+#
 #  no-fold-quote   =       DQUOTE *(qtext / quoted-pair) DQUOTE
-#  
+#
 #  no-fold-literal =       "[" *(dtext / quoted-pair) "]"
-#  
+#
 #    The "Message-ID:" field provides a unique message identifier that
 #    refers to a particular version of a particular message.  The
 #    uniqueness of the message identifier is guaranteed by the host that
@@ -38,7 +38,7 @@ require 'spec_helper'
 #    identifier pertains to exactly one instantiation of a particular
 #    message; subsequent revisions to the message each receive new message
 #    identifiers.
-#     
+#
 #    Note: There are many instances when messages are "changed", but those
 #    changes do not constitute a new instantiation of that message, and
 #    therefore the message would not get a new message identifier.  For
@@ -75,7 +75,7 @@ RSpec.describe Mail::MessageIdField do
     end
 
   end
-  
+
   describe "ensuring only one message ID" do
 
     it "should not accept a string with multiple message IDs but only return the first" do
@@ -111,7 +111,7 @@ RSpec.describe Mail::MessageIdField do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
       expect(m.decoded).to eq "<1234@test.lindsaar.net>"
     end
-    
+
     it "should respond to :responsible_for?" do
       m = Mail::MessageIdField.new('<1234@test.lindsaar.net>')
       expect(m).to respond_to(:responsible_for?)
@@ -123,7 +123,7 @@ RSpec.describe Mail::MessageIdField do
       m = Mail::MessageIdField.new
       expect(Mail::Utilities.blank?(m.message_id)).not_to be_truthy
     end
-    
+
     it "should generate a random message ID" do
       m = Mail::MessageIdField.new
       1.upto(100) do
@@ -131,7 +131,7 @@ RSpec.describe Mail::MessageIdField do
       end
     end
   end
-  
+
   describe "weird message IDs" do
     it "should be able to parse <000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com>" do
       m = Mail::MessageIdField.new('<000701c874a6$3df7eaf0$b9e7c0d0$@geille@fiscon.com>')
@@ -162,7 +162,7 @@ RSpec.describe Mail::MessageIdField do
       m = Mail::MessageIdField.new( '<000301caf03a$77d922ae$82dba8c0@.pool.ukrtel.net>')
       expect(m.message_id).to eq '000301caf03a$77d922ae$82dba8c0@.pool.ukrtel.net'
     end
-  
+
     it 'should be able to parse <"urn:correios:msg:2011071303483114f523ef89e040878bca2e451a999448"@1310528911569.rte-svc-na-5006.iad5.amazon.com>' do
       m = Mail::MessageIdField.new( '<"urn:correios:msg:2011071303483114f523ef89e040878bca2e451a999448"@1310528911569.rte-svc-na-5006.iad5.amazon.com>' )
       expect(m.message_id).to eq '"urn:correios:msg:2011071303483114f523ef89e040878bca2e451a999448"@1310528911569.rte-svc-na-5006.iad5.amazon.com'

--- a/spec/mail/fields/mime_version_field_spec.rb
+++ b/spec/mail/fields/mime_version_field_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 RSpec.describe Mail::MimeVersionField do
   # MIME-Version Header Field
-  # 
+  #
   # Since RFC 822 was published in 1982, there has really been only one
   # format standard for Internet messages, and there has been little
   # perceived need to declare the format standard in use.  This document
@@ -12,41 +12,41 @@ RSpec.describe Mail::MimeVersionField do
   # be compatible with RFC 822, there are still circumstances in which it
   # might be desirable for a mail-processing agent to know whether a
   # message was composed with the new standard in mind.
-  # 
+  #
   # Therefore, this document defines a new header field, "MIME-Version",
   # which is to be used to declare the version of the Internet message
   # body format standard in use.
-  # 
+  #
   # Messages composed in aMimeVersionordance with this document MUST include such
   # a header field, with the following verbatim text:
-  # 
+  #
   #   MIME-Version: 1.0
-  # 
+  #
   # The presence of this header field is an assertion that the message
   # has been composed in compliance with this document.
-  # 
+  #
   # Since it is possible that a future document might extend the message
   # format standard again, a formal BNF is given for the content of the
   # MIME-Version field:
-  # 
+  #
   #   version := "MIME-Version" ":" 1*DIGIT "." 1*DIGIT
-  # 
+  #
   # Thus, future format specifiers, which might replace or extend "1.0",
   # are constrained to be two integer fields, separated by a period.  If
   # a message is received with a MIME-version value other than "1.0", it
   # cannot be assumed to conform with this document.
-  # 
+  #
   # Note that the MIME-Version header field is required at the top level
   # of a message.  It is not required for each body part of a multipart
   # entity.  It is required for the embedded headers of a body of type
   # "message/rfc822" or "message/partial" if and only if the embedded
   # message is itself claimed to be MIME-conformant.
-  # 
+  #
   # It is not possible to fully specify how a mail reader that conforms
   # with MIME as defined in this document should treat a message that
   # might arrive in the future with some value of MIME-Version other than
   # "1.0".
-  # 
+  #
   # It is also worth noting that version control for specific media types
   # is not aMimeVersionomplished using the MIME-Version mechanism.  In particular,
   # some formats (such as application/postscript) have version numbering
@@ -54,26 +54,26 @@ RSpec.describe Mail::MimeVersionField do
   # conventions exist, MIME does nothing to supersede them.  Where no
   # such conventions exist, a MIME media type might use a "version"
   # parameter in the content-type field if necessary.
-  # 
+  #
   # NOTE TO IMPLEMENTORS:  When checking MIME-Version values any RFC 822
   # comment strings that are present must be ignored.  In particular, the
   # following four MIME-Version fields are equivalent:
-  # 
+  #
   #   MIME-Version: 1.0
-  # 
+  #
   #   MIME-Version: 1.0 (produced by MetaSend Vx.x)
-  # 
+  #
   #   MIME-Version: (produced by MetaSend Vx.x) 1.0
-  # 
+  #
   #   MIME-Version: 1.(produced by MetaSend Vx.x)0
-  # 
+  #
   # In the absence of a MIME-Version field, a receiving mail user agent
   # (whether conforming to MIME requirements or not) may optionally
   # choose to interpret the body of the message aMimeVersionording to local
   # conventions.  Many such conventions are currently in use and it
   # should be noted that in practice non-MIME messages can contain just
   # about anything.
-  # 
+  #
   # It is impossible to be certain that a non-MIME mail message is
   # actually plain text in the US-ASCII character set since it might well
   # be a message that, using some set of nonstandard local conventions
@@ -110,7 +110,7 @@ RSpec.describe Mail::MimeVersionField do
       t = Mail::MimeVersionField.new('1.0')
       expect(t.version).to eq '1.0'
     end
-    
+
     it "should handle comments before the major version" do
       t = Mail::MimeVersionField.new('(This is a comment) 1.0')
       expect(t.version).to eq '1.0'
@@ -140,12 +140,12 @@ RSpec.describe Mail::MimeVersionField do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
       expect(t.version).to eq '1.0'
     end
-    
+
     it "should accept nil as a value" do
       t = Mail::MimeVersionField.new(nil)
       expect(t.version).not_to be_nil
     end
-    
+
     it "should provide an encoded value" do
       t = Mail::MimeVersionField.new('1.0 (This is a comment)')
       expect(t.encoded).to eq "MIME-Version: 1.0\r\n"

--- a/spec/mail/fields/references_field_spec.rb
+++ b/spec/mail/fields/references_field_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
-# 
+#
 #    The "References:" field will contain the contents of the parent's
 #    "References:" field (if any) followed by the contents of the parent's
 #    "Message-ID:" field (if any).  If the parent message does not contain

--- a/spec/mail/fields/reply_to_field_spec.rb
+++ b/spec/mail/fields/reply_to_field_spec.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
-# 
+#
 # reply-to        =       "Reply-To:" address-list CRLF
-# 
+#
 
 RSpec.describe Mail::ReplyToField do
   
@@ -39,18 +39,18 @@ RSpec.describe Mail::ReplyToField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::ReplyToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return the encoded line" do
       t = Mail::ReplyToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq "Reply-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/resent_bcc_field_spec.rb
+++ b/spec/mail/fields/resent_bcc_field_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
-# 
+#
 # resent-bcc      =       "Resent-Bcc:" (address-list / [CFWS]) CRLF
 
 RSpec.describe Mail::ResentBccField do
@@ -38,18 +38,18 @@ RSpec.describe Mail::ResentBccField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::ResentBccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return the encoded line" do
       t = Mail::ResentBccField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq "Resent-Bcc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/resent_cc_field_spec.rb
+++ b/spec/mail/fields/resent_cc_field_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
-# 
+#
 # resent-cc       =       "Resent-Cc:" address-list CRLF
 
 RSpec.describe Mail::ResentCcField do
@@ -38,18 +38,18 @@ RSpec.describe Mail::ResentCcField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::ResentCcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return the encoded line" do
       t = Mail::ResentCcField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq "Resent-Cc: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/resent_date_field_spec.rb
+++ b/spec/mail/fields/resent_date_field_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mail::ResentDateField do
   it "should initialize" do
     expect { Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT") }.not_to raise_error
   end
-  
+
   it "should be able to tell the time" do
     expect(Mail::ResentDateField.new("12 Aug 2009 00:00:02 GMT").date_time.class).to eq DateTime
   end
@@ -17,7 +17,7 @@ RSpec.describe Mail::ResentDateField do
     expect(t.value).to eq 'Wed, 12 Aug 2009 00:00:02 +0000'
     expect(t.date_time).to eq ::DateTime.parse('12 Aug 2009 00:00:02 GMT')
   end
-  
+
   it "should give today's date if no date is specified" do
     now = DateTime.now
     expect(DateTime).to receive(:now).at_least(:once).and_return(now)

--- a/spec/mail/fields/resent_from_field_spec.rb
+++ b/spec/mail/fields/resent_from_field_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
-# 
+#
 # resent-from     =       "Resent-From:" mailbox-list CRLF
 
 RSpec.describe Mail::ResentFromField do
@@ -38,18 +38,18 @@ RSpec.describe Mail::ResentFromField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::ResentFromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return the encoded line" do
       t = Mail::ResentFromField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq "Resent-From: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/resent_to_field_spec.rb
+++ b/spec/mail/fields/resent_to_field_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
-# 
+#
 # resent-to       =       "Resent-To:" address-list CRLF
 
 RSpec.describe Mail::ResentToField do
@@ -38,18 +38,18 @@ RSpec.describe Mail::ResentToField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::ResentToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return the encoded line" do
       t = Mail::ResentToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq "Resent-To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/return_path_field_spec.rb
+++ b/spec/mail/fields/return_path_field_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mail::ReturnPathField do
     rp = Mail::ReturnPathField.new('mikel@test.lindsaar.net')
     expect(rp.address).to eq 'mikel@test.lindsaar.net'
   end
-  
+
   it "should encode the addr_spec in <>" do
     rp = Mail::ReturnPathField.new('mikel@test.lindsaar.net')
     expect(rp.encoded).to eq "Return-Path: <mikel@test.lindsaar.net>\r\n"
@@ -16,43 +16,43 @@ RSpec.describe Mail::ReturnPathField do
     rp = Mail::ReturnPathField.new('<>')
     expect(rp.encoded).to eq "Return-Path: <>\r\n"
   end
-  
+
   it "should set the return path" do
     mail = Mail.new do
       to "to@someemail.com"
       from "from@someemail.com"
       subject "Can't set the return-path"
-      return_path "bounce@someemail.com" 
+      return_path "bounce@someemail.com"
       message_id "<1234@someemail.com>"
       body "body"
     end
     expect(mail.return_path).to eq "bounce@someemail.com"
   end
-  
+
   it "should set the return path" do
     mail = Mail.new do
       to "to@someemail.com"
       from "from@someemail.com"
       subject "Can't set the return-path"
-      return_path "bounce@someemail.com" 
+      return_path "bounce@someemail.com"
       message_id "<1234@someemail.com>"
       body "body"
     end
     encoded_mail = Mail.new(mail.encoded)
     expect(encoded_mail.return_path).to eq "bounce@someemail.com"
   end
-  
+
   it "should wrap the return path addr_spec in <>" do
     mail = Mail.new do
       to "to@someemail.com"
       from "from@someemail.com"
       subject "Can't set the return-path"
-      return_path "bounce@someemail.com" 
+      return_path "bounce@someemail.com"
       message_id "<1234@someemail.com>"
       body "body"
     end
     expect(mail.encoded).to match(/<bounce@someemail\.com>/)
   end
-  
-  
+
+
 end

--- a/spec/mail/fields/structured_field_spec.rb
+++ b/spec/mail/fields/structured_field_spec.rb
@@ -5,27 +5,27 @@ require 'spec_helper'
 RSpec.describe Mail::StructuredField do
 
   describe "initialization" do
-    
+
     it "should be instantiated" do
       expect {Mail::StructuredField.new("From", "bob@me.com")}.not_to raise_error
     end
-    
+
   end
 
   describe "manipulation" do
-    
+
     before(:each) do
       @field = Mail::StructuredField.new("From", "bob@me.com")
     end
-    
+
     it "should allow us to set a text value at initialization" do
       expect{Mail::StructuredField.new("From", "bob@me.com")}.not_to raise_error
     end
-    
+
     it "should provide access to the text of the field once set" do
       expect(@field.value).to eq "bob@me.com"
     end
-    
+
     it "should provide a means to change the value" do
       @field.value = "bob@you.com"
       expect(@field.value).to eq "bob@you.com"
@@ -33,29 +33,29 @@ RSpec.describe Mail::StructuredField do
   end
 
   describe "displaying encoded field and decoded value" do
-    
+
     before(:each) do
       @field = Mail::FromField.new("bob@me.com")
     end
-    
+
     it "should provide a to_s function that returns the decoded string" do
       expect(@field.to_s).to eq "bob@me.com"
     end
-    
+
     it "should return '' on to_s if there is no value" do
       @field.value = nil
       expect(@field.encoded).to eq ''
     end
-    
+
     it "should give an encoded value ready to insert into an email" do
       expect(@field.encoded).to eq "From: bob@me.com\r\n"
     end
-    
+
     it "should return an empty string on encoded if it has no value" do
       @field.value = nil
       expect(@field.encoded).to eq ''
     end
-    
+
     it "should return the field name and value in proper format when called to_s" do
       expect(@field.encoded).to eq "From: bob@me.com\r\n"
     end

--- a/spec/mail/fields/to_field_spec.rb
+++ b/spec/mail/fields/to_field_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mail::ToField do
   # 
   #    The "To:" field contains the address(es) of the primary recipient(s)
   #    of the message.
-  
+
   describe "initialization" do
 
     it "should initialize" do
@@ -39,37 +39,37 @@ RSpec.describe Mail::ToField do
       expect(t.addresses[1]).to eq 'mikel@me.com'
       expect(t.addresses[2]).to eq 'bob@you.com'
     end
-    
+
     it "should return the formatted line on to_s" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.value).to eq 'sam@me.com, my_group: mikel@me.com, bob@you.com;'
     end
-    
+
     it "should return the encoded line" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.encoded).to eq "To: sam@me.com, \r\n\smy_group: mikel@me.com, \r\n\sbob@you.com;\r\n"
     end
-    
+
     it "should return the decoded line" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.decoded).to eq "sam@me.com, my_group: mikel@me.com, bob@you.com;"
     end
-    
+
     it "should get multiple address out from a group list" do
       t = Mail::ToField.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       expect(t.addresses).to eq ["sam@me.com", "mikel@me.com", "bob@you.com"]
     end
-    
+
     it "should handle commas in the address" do
       t = Mail::ToField.new('"Long, stupid email address" <mikel@test.lindsaar.net>')
       expect(t.addresses).to eq ["mikel@test.lindsaar.net"]
     end
-    
+
     it "should handle commas in the address for multiple fields" do
       t = Mail::ToField.new('"Long, stupid email address" <mikel@test.lindsaar.net>, "Another, really, really, long, stupid email address" <bob@test.lindsaar.net>')
       expect(t.addresses).to eq ["mikel@test.lindsaar.net", "bob@test.lindsaar.net"]
     end
-    
+
   end
 
 
@@ -105,11 +105,11 @@ RSpec.describe Mail::ToField do
       expect(t.encoded).to eq "To: =?UTF-8?B?8J+YjQ==?=@me.eu\r\n"
     end
   end
-  
+
   it "should not crash if it can't understand a name" do
     t = Mail.new('To: <"Undisclosed-Recipient:"@msr19.hinet.net;>')
     expect { t.encoded }.not_to raise_error
     expect(t.encoded).to match(/To\:\s<"Undisclosed\-Recipient\:"@msr19\.hinet\.net;>\r\n/)
   end
-  
+
 end

--- a/spec/mail/mail_spec.rb
+++ b/spec/mail/mail_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8 
+# encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
 
@@ -7,11 +7,11 @@ RSpec.describe "mail" do
   it "should be able to be instantiated" do
     expect { Mail }.not_to raise_error
   end
-  
+
   it "should be able to make a new email" do
     expect(Mail.new.class).to eq Mail::Message
   end
-  
+
   it "should accept headers and body" do
     # Full tests in Message Spec
     message = Mail.new do

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -1443,7 +1443,7 @@ RSpec.describe Mail::Message do
           part.body          = 'a' * 999
         end
         mail.encoded
-        
+
         expect(mail.parts.count).to eq(1)
         expect(mail.parts.last.content_transfer_encoding).to match(/7bit|8bit|binary/)
       end
@@ -1471,19 +1471,19 @@ RSpec.describe Mail::Message do
             end
           end
         end
-        
+
         it "should not add an empty charset header" do
           @mail.charset = nil
-          
+
           expect(@mail.multipart?).to eq true
           expect(@mail.parts.count).to eq 2
           expect(@mail.encoded.scan(/charset=UTF-8/).count).to eq 2
         end
-        
+
         it "should remove the charset header" do
           @mail.charset = 'iso-8859-1'
           @mail.charset = nil
-          
+
           expect(@mail.encoded.scan(/charset=UTF-8/).count).to eq 2
           expect(@mail.encoded.scan(/charset=iso-8859-1/).count).to eq 0
         end

--- a/spec/mail/multipart_report_spec.rb
+++ b/spec/mail/multipart_report_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "multipart/report emails" do
     mail = read_fixture('emails', 'multipart_report_emails', 'report_422.eml')
     expect(mail).to be_multipart_report
   end
-  
+
   describe "delivery-status reports" do
-    
+
     it "should know if it is a deliver-status report" do
       mail = read_fixture('emails', 'multipart_report_emails', 'report_422.eml')
       expect(mail).to be_delivery_status_report
@@ -20,7 +20,7 @@ RSpec.describe "multipart/report emails" do
       mail = read_fixture('emails', 'multipart_report_emails', 'report_422.eml')
       expect(mail.delivery_status_part).not_to be_nil
     end
-    
+
     it "should handle a report that has a human readable message/delivery-status" do
       mail = read_fixture('emails', 'multipart_report_emails', 'multipart_report_multiple_status.eml')
       expect(mail).to be_bounced
@@ -54,70 +54,70 @@ RSpec.describe "multipart/report emails" do
     end
 
     describe "temporary failure" do
-      
+
       before(:each) do
         @mail = read_fixture('emails', 'multipart_report_emails', 'report_422.eml')
       end
-      
+
       it "should be bounced" do
         expect(@mail).not_to be_bounced
       end
-      
+
       it "should say action 'delayed'" do
         expect(@mail.action).to eq 'delayed'
       end
-      
+
       it "should give a final recipient" do
         expect(@mail.final_recipient).to eq 'RFC822; fraser@oooooooo.com.au'
       end
-      
+
       it "should give an error code" do
         expect(@mail.error_status).to eq '4.2.2'
       end
-      
+
       it "should give a diagostic code" do
         expect(@mail.diagnostic_code).to eq 'SMTP; 452 4.2.2 <fraser@oooooooo.com.au>... Mailbox full'
       end
-      
+
       it "should give a remote-mta" do
         expect(@mail.remote_mta).to eq 'DNS; mail.oooooooo.com.au'
       end
-      
+
       it "should be retryable" do
         expect(@mail).to be_retryable
       end
     end
 
     describe "permanent failure" do
-      
+
       before(:each) do
         @mail = read_fixture('emails', 'multipart_report_emails', 'report_530.eml')
       end
-      
+
       it "should be bounced" do
         expect(@mail).to be_bounced
       end
-      
+
       it "should say action 'failed'" do
         expect(@mail.action).to eq 'failed'
       end
-      
+
       it "should give a final recipient" do
         expect(@mail.final_recipient).to eq 'RFC822; edwin@zzzzzzz.com'
       end
-      
+
       it "should give an error code" do
         expect(@mail.error_status).to eq '5.3.0'
       end
-      
+
       it "should give a diagostic code" do
         expect(@mail.diagnostic_code).to eq 'SMTP; 553 5.3.0 <edwin@zzzzzzz.com>... Unknown E-Mail Address'
       end
-      
+
       it "should give a remote-mta" do
         expect(@mail.remote_mta).to eq 'DNS; mail.zzzzzz.com'
       end
-      
+
       it "should be retryable" do
         expect(@mail).not_to be_retryable
       end

--- a/spec/mail/network/retriever_methods/test_retriever_spec.rb
+++ b/spec/mail/network/retriever_methods/test_retriever_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Test Retriever" do
   end
 
   describe "all" do
-    
+
     before do
       @emails = populate(15)
     end
@@ -30,7 +30,7 @@ RSpec.describe "Test Retriever" do
     end
 
   end
-  
+
   describe "find" do
 
     before do


### PR DESCRIPTION
Original PR message from https://github.com/mikel/mail/pull/1441

While reviewing the code to ensure an interoperability issue, I dove into the source. I found my answer (mail does the right thing, by not caring about TLS itself, but delegating this to configuration and OpenSSL) and I also found a lot of trailing whitespace.

Since I dislike that I let rubocop auto-correct that for me and commited the results.

I intentionally did not push a new dependency on you. That would be a hugely different PR and discussion.

This, however, should be easy to merge and help future PRs to stick to the CONTRIBUTING guidelines.