### PR TITLE
Install libyaml-dev for Psych

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,6 @@ jobs:
          - ruby: jruby
            timeout: 5
     steps:
-    - name: Installing libyaml-dev
-      run: |
-        sudo apt-get update
-        sudo apt-get install libyaml-dev
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         rubygems: 3.3.12
         bundler-cache: true
+        cache-version: 2
     - name: Run tests
       run: bundle exec rake spec
       continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}
@@ -47,6 +48,7 @@ jobs:
       with:
         ruby-version: 3
         bundler-cache: true
+        cache-version: 2
     - name: Setup mail with ActionMailer edge
       run: |
         git clone --depth=1 https://github.com/rails/rails.git -b main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         rubygems: 3.3.12
         bundler-cache: true
-        cache-version: ${{ matrix.ruby }}
+        cache-version: 3
     - name: Run tests
       run: bundle exec rake spec
       continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,10 @@ jobs:
          - ruby: jruby
            timeout: 5
     steps:
+    - name: Installing libyaml-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libyaml-dev
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         rubygems: 3.3.12
         bundler-cache: true
+        cache-version: ${{ matrix.ruby }}
     - name: Run tests
       run: bundle exec rake spec
       continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         rubygems: 3.3.12
         bundler-cache: true
-        cache-version: 3
+        cache-version: 4
     - name: Run tests
       run: bundle exec rake spec
       continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}
@@ -56,6 +56,7 @@ jobs:
       with:
         ruby-version: 3
         bundler-cache: true
+        cache-version: 4
     - name: Setup mail with ActionMailer edge
       run: |
         git clone --depth=1 https://github.com/rails/rails.git -b main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,25 +30,33 @@ jobs:
          - ruby: jruby
            timeout: 5
     steps:
+    - name: Installing libyaml-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libyaml-dev
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         rubygems: 3.3.12
         bundler-cache: true
-        cache-version: 2
+        cache-version: 1
     - name: Run tests
       run: bundle exec rake spec
       continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}
   actionmailer:
     runs-on: ubuntu-latest
     steps:
+    - name: Installing libyaml-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libyaml-dev
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3
         bundler-cache: true
-        cache-version: 2
+        cache-version: 1
     - name: Setup mail with ActionMailer edge
       run: |
         git clone --depth=1 https://github.com/rails/rails.git -b main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         rubygems: 3.3.12
         bundler-cache: true
-        cache-version: ${{ matrix.ruby }}
     - name: Run tests
       run: bundle exec rake spec
       continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}
@@ -54,7 +53,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3
         bundler-cache: true
     - name: Setup mail with ActionMailer edge
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         rubygems: 3.3.12
         bundler-cache: true
-        cache-version: 1
+        cache-version: ${{ matrix.ruby }}
     - name: Run tests
       run: bundle exec rake spec
       continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}
@@ -54,9 +54,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3
+        ruby-version: 3.1
         bundler-cache: true
-        cache-version: 1
     - name: Setup mail with ActionMailer edge
       run: |
         git clone --depth=1 https://github.com/rails/rails.git -b main


### PR DESCRIPTION
Psych 5 was released a few days ago. Apparently this requires libyaml-dev on the server. Psych is required by RDoc.

An issue with Jruby in Psych 5.0.0 (https://github.com/ruby/psych/issues/598) was causing test failures, but that has been fixed in 5.0.1.