### PR TITLE
fix undefined method `disable_starttls_auto'

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,6 +1,7 @@
 == Version 2.8.1 (unreleased)
 
 Bug Fixes:
+* Regression: accept enable_starttls_auto: false @ahorek
 
 == Version 2.8.0 (3-Dec-2022)
 

--- a/lib/mail/network/delivery_methods/smtp.rb
+++ b/lib/mail/network/delivery_methods/smtp.rb
@@ -135,7 +135,7 @@ module Mail
             when true
               smtp.enable_starttls_auto(ssl_context)
             when false
-              smtp.disable_starttls_auto
+              smtp.disable_starttls
             else
               raise ArgumentError, "Unrecognized :enable_starttls_auto value #{settings[:enable_starttls_auto].inspect}; expected true, false, or nil"
             end

--- a/spec/mail/network/delivery_methods/smtp_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_spec.rb
@@ -237,6 +237,48 @@ describe "SMTP Delivery Method" do
 
       expect(MockSMTP.starttls).to eq false
     end
+
+    it 'should allow forcing STARTTLS auto' do
+      message = Mail.new do
+        from 'mikel@test.lindsaar.net'
+        to 'ada@test.lindsaar.net'
+        subject 'Re: No way!'
+        body 'Yeah sure'
+        delivery_method :smtp, { :address         => "localhost",
+                                 :port            => 25,
+                                 :domain          => 'localhost.localdomain',
+                                 :user_name       => nil,
+                                 :password        => nil,
+                                 :authentication  => nil,
+                                 :enable_starttls_auto => true  }
+
+      end
+
+      message.deliver!
+
+      expect(MockSMTP.starttls).to eq :auto
+    end
+
+    it 'should allow disabling automatic STARTTLS auto' do
+      message = Mail.new do
+        from 'mikel@test.lindsaar.net'
+        to 'ada@test.lindsaar.net'
+        subject 'Re: No way!'
+        body 'Yeah sure'
+        delivery_method :smtp, { :address         => "localhost",
+                                 :port            => 25,
+                                 :domain          => 'localhost.localdomain',
+                                 :user_name       => nil,
+                                 :password        => nil,
+                                 :authentication  => nil,
+                                 :enable_starttls_auto => false }
+
+      end
+
+      message.deliver!
+
+      expect(MockSMTP.starttls).to eq false
+    end
   end
 
   describe "SMTP Envelope" do


### PR DESCRIPTION
this PR fixes a failure if you pass a setting enable_starttls_auto: false as suggested by https://github.com/mikel/mail/pull/1515#issuecomment-1344455737
