### PR TITLE
Make activesupport gem optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
-if RUBY_VERSION < '2.7.0'
-  gem 'activesupport', '< 6'
-else
-  gem 'activesupport', :git => 'https://github.com/rails/rails', :branch => 'main'
+if ENV['MBCHARS'] # see spec/environment.rb
+  if RUBY_VERSION < '2.7.0'
+    gem 'activesupport', '< 6'
+  else
+    gem 'activesupport', :git => 'https://github.com/rails/rails', :branch => 'main'
+  end
 end
 
 gem 'jruby-openssl', :platforms => :jruby


### PR DESCRIPTION
It's a nuisance to have to download rails from Github if it is not needed.