### PR TITLE
Standardise on WARNING: prefix

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -420,7 +420,7 @@ module Mail
       end
       transcode_to_scrubbed_utf8(str)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError, Encoding::InvalidByteSequenceError
-      warn "Encoding conversion failed #{$!}"
+      warn "WARNING: Encoding conversion failed #{$!}"
       str.dup.force_encoding(Encoding::UTF_8)
     end
 
@@ -444,7 +444,7 @@ module Mail
       end
       transcode_to_scrubbed_utf8(str)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
-      warn "Encoding conversion failed #{$!}"
+      warn "WARNING: Encoding conversion failed #{$!}"
       str.dup.force_encoding(Encoding::UTF_8)
     end
 
@@ -453,7 +453,7 @@ module Mail
       str = charset_encoder.encode(str, encoding) if encoding
       transcode_to_scrubbed_utf8(str)
     rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
-      warn "Encoding conversion failed #{$!}"
+      warn "WARNING: Encoding conversion failed #{$!}"
       str.dup.force_encoding(Encoding::UTF_8)
     end
 


### PR DESCRIPTION
Most if not all the other warn() calls prefix the text with WARNING: This makes it more obvious what is happening

[skip ci] -- will mostly fail at present due to #1522