### PR TITLE
Sendmail: allow for some string :arguments

### DIFF
--- a/spec/mail/network/delivery_methods/sendmail_spec.rb
+++ b/spec/mail/network/delivery_methods/sendmail_spec.rb
@@ -169,4 +169,17 @@ describe Mail::Sendmail do
       mail.deliver!
     end.to raise_error('SMTP To address may not be blank: []')
   end
+
+  it 'allows for legacy callers with :arguments strings containing default flags -i and/or -t' do
+    Mail.defaults do
+      delivery_method :sendmail, :arguments => '-i -t'
+    end
+
+    expect(mail.delivery_method).to receive(:popen).
+      with(%w[ /usr/sbin/sendmail -i -t
+        -f roger@test.lindsaar.net
+        -- marcel@test.lindsaar.net bob@test.lindsaar.net ])
+
+    mail.deliver!
+  end
 end


### PR DESCRIPTION
This PR is a bandaid for callers that initialize Mail::Sendmail with an `arguments` string (https://github.com/mikel/mail/issues/1538).

Rails applications configured to use sendmail and using the default `arguments` from ActionMailer (versions < 7.1), will with mail 2.8.0 experience an ArgumentError. This PR prevents this and shows a deprecation warning:
```
# config in config/environments/$RAILS_ENV.rb
config.action_mailer.delivery_method = :sendmail

# console
Loading development environment (Rails 7.0.4)
irb(main):001:0> UserMailer.welcome_email.deliver_now
DEPRECATION WARNING: Mail::Sendmail :arguments should be an Array of string args, not a string. (called from initialize at /Users/gert/src/mail/lib/mail/network/delivery_methods/sendmail.rb:55)
  Rendering layout layouts/mailer.text.erb
  Rendering user_mailer/welcome_email.text.erb within layouts/mailer
  Rendered user_mailer/welcome_email.text.erb within layouts/mailer (Duration: 0.6ms | Allocations: 280)
  Rendered layout layouts/mailer.text.erb (Duration: 1.1ms | Allocations: 517)
UserMailer#welcome_email: processed outbound mail in 12.8ms
```

A kernel warning is issued when AS is not available - the warning is the same (but without the filename and hopefully descriptive enough).

Callers that have flags other than `-t` and `-i`, will nonetheless experience the ArgumentError (we can't just split the arguments string). But as these applications have explicitly defined these arguments, it should be less cryptic where the errors originate from.