### PR TITLE
Fix all 'assigned but unused variable' warnings

### DIFF
--- a/lib/mail/parsers/address_lists_parser.rb
+++ b/lib/mail/parsers/address_lists_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -32011,10 +32010,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/address_lists_parser.rb
+++ b/lib/mail/parsers/address_lists_parser.rb
@@ -33228,6 +33228,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 2461
           raise Mail::Field::IncompleteParseError.new(Mail::AddressList, data, p)
         end

--- a/lib/mail/parsers/address_lists_parser.rl
+++ b/lib/mail/parsers/address_lists_parser.rl
@@ -165,6 +165,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::AddressList, data, p)
       end

--- a/lib/mail/parsers/content_disposition_parser.rb
+++ b/lib/mail/parsers/content_disposition_parser.rb
@@ -887,6 +887,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 40
           raise Mail::Field::IncompleteParseError.new(Mail::ContentDispositionElement, data, p)
         end

--- a/lib/mail/parsers/content_disposition_parser.rb
+++ b/lib/mail/parsers/content_disposition_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -610,10 +609,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]
@@ -654,7 +653,7 @@ begin
                     # Use quoted string value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_disposition.parameters << {param_attr => value}
+                    content_disposition.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -712,7 +711,7 @@ begin
                     # Use quoted string value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_disposition.parameters << {param_attr => value}
+                    content_disposition.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -742,7 +741,7 @@ begin
                     # Use quoted string value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_disposition.parameters << {param_attr => value}
+                    content_disposition.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -799,7 +798,7 @@ begin
                     # Use quoted string value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_disposition.parameters << {param_attr => value}
+                    content_disposition.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -823,7 +822,7 @@ begin
                     # Use quoted string value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_disposition.parameters << {param_attr => value}
+                    content_disposition.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -857,7 +856,7 @@ begin
                     # Use quoted string value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_disposition.parameters << {param_attr => value}
+                    content_disposition.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -875,7 +874,7 @@ begin
                     # Use quoted string value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_disposition.parameters << {param_attr => value}
+                    content_disposition.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end

--- a/lib/mail/parsers/content_disposition_parser.rl
+++ b/lib/mail/parsers/content_disposition_parser.rl
@@ -75,6 +75,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::ContentDispositionElement, data, p)
       end

--- a/lib/mail/parsers/content_location_parser.rb
+++ b/lib/mail/parsers/content_location_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -631,10 +630,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/content_location_parser.rb
+++ b/lib/mail/parsers/content_location_parser.rb
@@ -588,7 +588,7 @@ begin
         return content_location if Mail::Utilities.blank?(data)
 
         # Parser state
-        disp_type_s = param_attr_s = param_attr = qstr_s = qstr = param_val_s = nil
+        qstr_s = qstr = param_val_s = nil
 
         # 5.1 Variables Used by Ragel
         p = 0
@@ -806,6 +806,10 @@ begin
               break
             end
           end
+        end
+
+        if false
+          testEof
         end
 
         if p != eof || cs < 32

--- a/lib/mail/parsers/content_location_parser.rl
+++ b/lib/mail/parsers/content_location_parser.rl
@@ -54,7 +54,7 @@ module Mail::Parsers
       return content_location if Mail::Utilities.blank?(data)
 
       # Parser state
-      disp_type_s = param_attr_s = param_attr = qstr_s = qstr = param_val_s = nil
+      qstr_s = qstr = param_val_s = nil
 
       # 5.1 Variables Used by Ragel
       p = 0
@@ -63,6 +63,10 @@ module Mail::Parsers
 
       %%write init;
       %%write exec;
+
+      if false
+        testEof
+      end
 
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::ContentLocationElement, data, p)

--- a/lib/mail/parsers/content_transfer_encoding_parser.rb
+++ b/lib/mail/parsers/content_transfer_encoding_parser.rb
@@ -508,6 +508,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 21
           raise Mail::Field::IncompleteParseError.new(Mail::ContentTransferEncodingElement, data, p)
         end

--- a/lib/mail/parsers/content_transfer_encoding_parser.rb
+++ b/lib/mail/parsers/content_transfer_encoding_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -382,10 +381,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/content_transfer_encoding_parser.rl
+++ b/lib/mail/parsers/content_transfer_encoding_parser.rl
@@ -57,6 +57,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::ContentTransferEncodingElement, data, p)
       end

--- a/lib/mail/parsers/content_type_parser.rb
+++ b/lib/mail/parsers/content_type_parser.rb
@@ -1034,6 +1034,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 47
           raise Mail::Field::IncompleteParseError.new(Mail::ContentTypeElement, data, p)
         end

--- a/lib/mail/parsers/content_type_parser.rb
+++ b/lib/mail/parsers/content_type_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -736,10 +735,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]
@@ -788,7 +787,7 @@ begin
                     # Use quoted s value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_type.parameters << {param_attr => value}
+                    content_type.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -859,7 +858,7 @@ begin
                     # Use quoted s value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_type.parameters << {param_attr => value}
+                    content_type.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -889,7 +888,7 @@ begin
                     # Use quoted s value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_type.parameters << {param_attr => value}
+                    content_type.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -946,7 +945,7 @@ begin
                     # Use quoted s value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_type.parameters << {param_attr => value}
+                    content_type.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -970,7 +969,7 @@ begin
                     # Use quoted s value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_type.parameters << {param_attr => value}
+                    content_type.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -1004,7 +1003,7 @@ begin
                     # Use quoted s value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_type.parameters << {param_attr => value}
+                    content_type.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end
@@ -1022,7 +1021,7 @@ begin
                     # Use quoted s value if one exists, otherwise use parameter value
                     value = qstr || chars(data, param_val_s, p - 1)
 
-                    content_type.parameters << {param_attr => value}
+                    content_type.parameters << { param_attr => value }
                     param_attr = nil
                     qstr = nil
                   end

--- a/lib/mail/parsers/content_type_parser.rl
+++ b/lib/mail/parsers/content_type_parser.rl
@@ -76,6 +76,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::ContentTypeElement, data, p)
       end

--- a/lib/mail/parsers/date_time_parser.rb
+++ b/lib/mail/parsers/date_time_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -715,10 +714,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/date_time_parser.rb
+++ b/lib/mail/parsers/date_time_parser.rb
@@ -877,6 +877,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 103
           raise Mail::Field::IncompleteParseError.new(Mail::DateTimeElement, data, p)
         end

--- a/lib/mail/parsers/date_time_parser.rl
+++ b/lib/mail/parsers/date_time_parser.rl
@@ -55,6 +55,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::DateTimeElement, data, p)
       end

--- a/lib/mail/parsers/envelope_from_parser.rb
+++ b/lib/mail/parsers/envelope_from_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -3265,10 +3264,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/envelope_from_parser.rb
+++ b/lib/mail/parsers/envelope_from_parser.rb
@@ -3661,6 +3661,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 257
           raise Mail::Field::IncompleteParseError.new(Mail::EnvelopeFromElement, data, p)
         end

--- a/lib/mail/parsers/envelope_from_parser.rl
+++ b/lib/mail/parsers/envelope_from_parser.rl
@@ -75,6 +75,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::EnvelopeFromElement, data, p)
       end

--- a/lib/mail/parsers/message_ids_parser.rb
+++ b/lib/mail/parsers/message_ids_parser.rb
@@ -5147,6 +5147,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 318
           raise Mail::Field::IncompleteParseError.new(Mail::MessageIdsElement, data, p)
         end

--- a/lib/mail/parsers/message_ids_parser.rb
+++ b/lib/mail/parsers/message_ids_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -4872,10 +4871,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/message_ids_parser.rl
+++ b/lib/mail/parsers/message_ids_parser.rl
@@ -79,6 +79,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::MessageIdsElement, data, p)
       end

--- a/lib/mail/parsers/mime_version_parser.rb
+++ b/lib/mail/parsers/mime_version_parser.rb
@@ -499,6 +499,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 23
           raise Mail::Field::IncompleteParseError.new(Mail::MimeVersionElement, data, p)
         end

--- a/lib/mail/parsers/mime_version_parser.rb
+++ b/lib/mail/parsers/mime_version_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -346,10 +345,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/mime_version_parser.rl
+++ b/lib/mail/parsers/mime_version_parser.rl
@@ -54,6 +54,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::MimeVersionElement, data, p)
       end

--- a/lib/mail/parsers/phrase_lists_parser.rb
+++ b/lib/mail/parsers/phrase_lists_parser.rb
@@ -870,6 +870,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 42
           raise Mail::Field::IncompleteParseError.new(Mail::PhraseList, data, p)
         end

--- a/lib/mail/parsers/phrase_lists_parser.rb
+++ b/lib/mail/parsers/phrase_lists_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -726,10 +725,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/phrase_lists_parser.rl
+++ b/lib/mail/parsers/phrase_lists_parser.rl
@@ -76,6 +76,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::PhraseList, data, p)
       end

--- a/lib/mail/parsers/received_parser.rb
+++ b/lib/mail/parsers/received_parser.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require "mail/utilities"
 require "mail/parser_tools"
@@ -7538,10 +7537,10 @@ begin
               _trans = if (_slen > 0 &&
                            _trans_keys[_keys] <= _wide &&
                            _wide <= _trans_keys[_keys + 1])
-                         _indicies[_inds + _wide - _trans_keys[_keys]]
-                       else
-                         _indicies[_inds + _slen]
-                       end
+                  _indicies[_inds + _wide - _trans_keys[_keys]]
+                else
+                  _indicies[_inds + _slen]
+                end
               cs = _trans_targs[_trans]
               if _trans_actions[_trans] != 0
                 case _trans_actions[_trans]

--- a/lib/mail/parsers/received_parser.rb
+++ b/lib/mail/parsers/received_parser.rb
@@ -8768,6 +8768,10 @@ begin
           end
         end
 
+        if false
+          testEof
+        end
+
         if p != eof || cs < 648
           raise Mail::Field::IncompleteParseError.new(Mail::ReceivedElement, data, p)
         end

--- a/lib/mail/parsers/received_parser.rl
+++ b/lib/mail/parsers/received_parser.rl
@@ -77,6 +77,10 @@ module Mail::Parsers
       %%write init;
       %%write exec;
 
+      if false
+        testEof
+      end
+
       if p != eof || cs < %%{ write first_final; }%%
         raise Mail::Field::IncompleteParseError.new(Mail::ReceivedElement, data, p)
       end

--- a/spec/mail/network/delivery_methods/smtp_connection_spec.rb
+++ b/spec/mail/network/delivery_methods/smtp_connection_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe "SMTP Delivery Method" do
   end
 
   it "should not dot-stuff unterminated last line with no leading dot" do
-    body = "this is a test\n.\nonly a test"
-
     Mail.deliver do
       from 'from@example.com'
       to 'to@example.com'


### PR DESCRIPTION
- The variables in content_location_parser appear to have been copied from content_disposition_parser but are unused
- Ragel seems to always generate a useless testEof variable. The `if false` trick is also used in https://github.com/whitequark/parser/commit/21581a2 to suppress the warning. As mentioned in the parser commit, `if false` will not actually generate instructions and so it has no runtime cost.

The first commit is simply running `rake ragel` again to regenerate the parsers

Fixes #1400 (I've added @GQuirino as a Co-Author)