### PR TITLE
Rubygems release on tag push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [ master ]
+    tags: [v*]
   pull_request:
     branches: [ master ]
 
@@ -78,3 +79,18 @@ jobs:
       run: |
         cd rails/actionmailer
         bundle exec rake
+  release:
+    needs: [ruby, actionmailer]
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, 'refs/tags/v') }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3
+          bundler-cache: true
+          cache-version: 4
+      - uses: cadwallion/publish-rubygems-action@master
+        env:
+          RELEASE_COMMAND: rake release
+          RUBYGEMS_API_KEY: ${{ secrets.rubygems_api_key }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,8 @@ Syntax:
 * Follow the conventions you see used in the source already.
 
 And in case we didn't emphasize it enough: we love specs!
+
+
+## Releases
+
+Releases are performed automatically by a Github Action which executes whenever a version tag (eg `v2.8.1`) is pushed.


### PR DESCRIPTION
It is known that there is a defect in the release process when triggered in a certain context, evident from https://github.com/mikel/mail/issues/1489. This results in a large degree of frustration, as well as the inability of anyone other than the individual who triggered the release to debug the source of the problem.

Here we automate the release process as a Github Action which is triggered by a push of a tag which begins with `v`, such as `v2.8.1`. In order for this to work correctly, it is necessary to set the secret `rubygems_api_key` on the Github repo, which is something only @mikel can do, but once he does that a release can be cut by anyone with the ability to push tags to this repo, and the release process is executed in a clean context like that in which tests are run, making it available to debugging efforts by the broader community.