### PR TITLE
2.8.0.1.rc1 to fix non-world-readable file permissions

### DIFF
--- a/lib/mail/version.rb
+++ b/lib/mail/version.rb
@@ -5,7 +5,7 @@ module Mail
     MAJOR = 2
     MINOR = 8
     PATCH = 0
-    BUILD = "1.rc1"
+    BUILD = 1
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
 

--- a/lib/mail/version.rb
+++ b/lib/mail/version.rb
@@ -5,7 +5,7 @@ module Mail
     MAJOR = 2
     MINOR = 8
     PATCH = 0
-    BUILD = nil
+    BUILD = "1.rc1"
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
 


### PR DESCRIPTION
Re-release 2.8.0 as 2.8.0.1 with world-readable file perms.

Fixes #1489. References #1541.