### PR TITLE
Revert PR #1495 because it is a dupe of #1470

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -2073,11 +2073,7 @@ module Mail
 
     def add_boundary
       unless body.boundary && boundary
-        unless header['content-type']
-          _charset = charset
-          header['content-type'] = 'multipart/mixed'
-          header['content-type'].parameters[:charset] = _charset
-        end
+        header['content-type'] = 'multipart/mixed' unless header['content-type']
         header['content-type'].parameters[:boundary] = ContentTypeField.generate_boundary
         body.boundary = boundary
       end


### PR DESCRIPTION
Partial revert of PR #1495 ("Preserve message-level charset when adding parts") because it was fixed by PR #1470 ("Adding a part should not reset the mail's charset to nil") merged around the same time. The fix in #1470 is more elegant.

The specs added in #1495 verify that it works with the #1470 fix.
