### PR TITLE
Stop using insecure deprecated Net::IMAP.new args

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -167,9 +167,13 @@ module Mail
           raise ArgumentError, ":enable_starttls and :enable_ssl are mutually exclusive. Set :enable_ssl if you're on an IMAPS connection. Set :enable_starttls if you're on an IMAP connection and using STARTTLS for secure TLS upgrade."
         end
 
-        imap = Net::IMAP.new(settings[:address], settings[:port], settings[:enable_ssl], nil, false)
+        ssl      = settings[:enable_ssl]
+        starttls = settings[:enable_starttls]
+        ssl      &&= Hash.try_convert(ssl)      || {}
+        starttls &&= Hash.try_convert(starttls) || {}
 
-        imap.starttls if settings[:enable_starttls]
+        imap = Net::IMAP.new(settings[:address], port: settings[:port], ssl: ssl)
+        imap.starttls(starttls) if starttls
 
         if settings[:authentication].nil?
           imap.login(settings[:user_name], settings[:password])


### PR DESCRIPTION
This fixes the insecure `verify = false` argument that was previously unconfigurable.  Now _any_ SSLContext params can be set on the IMAP connection.

The original parameters have been undocumented since ~2007, will print deprecation warnings in the next release and will be removed in a year.

Fixes #1586.