### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
            timeout: 5
          - ruby: 3.2
            timeout: 5
+         - ruby: 3.3
+           timeout: 5
          - ruby: truffleruby
            timeout: 50
          - ruby: truffleruby-head


### PR DESCRIPTION
This PR backports https://github.com/mikel/mail/pull/1595 to the 2-8-stable-branch.