### PR TITLE
Enable UTF8=ACCEPT if the server supports ENABLE (and UTF=ACCEPT).

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -179,6 +179,8 @@ module Mail
           imap.authenticate(settings[:authentication], settings[:user_name], settings[:password])
         end
 
+        imap.enable :utf8 if imap.capable?("ENABLE")
+
         yield imap
       ensure
         if defined?(imap) && imap && !imap.disconnected?

--- a/spec/mail/network/retriever_methods/imap_spec.rb
+++ b/spec/mail/network/retriever_methods/imap_spec.rb
@@ -318,5 +318,18 @@ RSpec.describe "IMAP Retriever" do
     end
   end
 
+
+  describe "UTF8=ACCEPT support" do
+    before(:each) do
+      @imap = MockIMAP.new
+      allow(MockIMAP).to receive(:new).and_return(@imap)
+      allow(@imap).to receive(:capable?).with("ENABLE").and_return(true)
+    end
+    it "should enable UTF8=ACCEPT" do
+      expect(@imap).to receive(:enable).with(:utf8)
+      messages = Mail.find
+    end
+  end
+
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -319,6 +319,10 @@ class MockIMAP
     @@marked_for_deletion = []
   end
 
+  def capable?(name)
+    false
+  end
+
   def self.mailbox; @@mailbox end    # test only
   def self.readonly?; @@readonly end # test only
 


### PR DESCRIPTION
This is written so that net-imap has the option of enabling IMAP4REV2 instead, if the IMAP server has that. (IMAP4Rev2 includes the same syntax and functionality.)

With this PR, mikel-mail is able to read a message with UTF8 addresses from a compliant IMAP server, generate a reply and send it. Both net-imap and net-smtp contain the necessary code. At one line of code, this is the smallest such PR I've ever made ;)

(You may wonder about the call to .capable?. It's enough, see RFF5161 page 2. ENABLE is written to allow clients to send a fixed string; the server ignores what it can't enable.)