### PR TITLE
Add logger as a dependency for Ruby 3.4 warnings

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.5"
 
+  s.add_dependency('logger')
   s.add_dependency('mini_mime', '>= 0.1.1')
   s.add_dependency('net-smtp')
   s.add_dependency('net-imap')


### PR DESCRIPTION
This commit addreses the following warning that logger will be part of default gem.

```ruby
$ ruby -v
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +PRISM [x86_64-linux]
$ bundle exec rspec -w
Running Specs under Ruby Version 3.4.0
Running Specs for Mail Version 2.9.0.edge
logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
... snip ...
```

Refer to
https://bugs.ruby-lang.org/issues/20309
https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c