### PR TITLE
Address `warning: URI::RFC3986_PARSER` warnings

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -165,7 +165,11 @@ module Mail
     end
 
     def uri_parser
-      @uri_parser ||= URI.const_defined?(:DEFAULT_PARSER) ? URI::DEFAULT_PARSER : URI
+      @uri_parser ||= if URI.const_defined?(:DEFAULT_PARSER)
+                        defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::DEFAULT_PARSER
+                      else
+                        URI
+                      end
     end
 
     # Matches two objects with their to_s values case insensitively
@@ -464,7 +468,7 @@ module Mail
     end
 
     def Utilities.uri_parser
-      URI::DEFAULT_PARSER
+      defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::DEFAULT_PARSER
     end
 
     # Pick a Ruby encoding corresponding to the message charset. Most


### PR DESCRIPTION
This commit addresses the following warnings against Ruby 3.4.0.preview 2 below.

- Ruby version tested
```
$ ruby -v
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +PRISM [x86_64-linux]
```

- Warnings without this commit
```ruby
/path/to/mail/lib/mail/spec/mail/attachments_list_spec.rb:179: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.
/path/to/mail/lib/mail/spec/mail/utilities_spec.rb:386: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.
/path/to/mail/lib/mail/spec/mail/utilities_spec.rb:390: warning: URI::RFC3986_PARSER.unescape is obsoleted. Use URI::RFC2396_PARSER.unescape explicitly.
/path/to/mail/lib/mail/utilities.rb:160: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.
/path/to/mail/lib/mail/utilities.rb:164: warning: URI::RFC3986_PARSER.unescape is obsoleted. Use URI::RFC2396_PARSER.unescape explicitly.
/path/to/mail/lib/mail/utilities.rb:452: warning: URI::RFC3986_PARSER.unescape is obsoleted. Use URI::RFC2396_PARSER.unescape explicitly.
/path/to/mail/lib/mail/utilities.rb:463: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.
```

Ruby 3.4 changes URI::DEFAULT_PARSER to URI::RFC3986_Parser and deprecates some methods. URI::RFC3986_PARSER.make_regexp and URI::RFC3986_PARSER.make_regexp are used in the mail gem.

This commit uses URI::RFC2396_PARSER only if it is available for these versions:

- uri v0.12.2 for Ruby 3.2/3.1
- uri v0.13.1 for Ruby 3.3
- Ruby 3.4.0dev

Refer to https://bugs.ruby-lang.org/issues/19266