### PR TITLE
Add test for multiple files with identical filenames

### DIFF
--- a/spec/mail/attachments_list_spec.rb
+++ b/spec/mail/attachments_list_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe "Attachments" do
       expect(Mail::Utilities.blank?(@mail.attachments)).not_to eq true
       expect(Mail::Encodings.decode_encode(@mail.attachments[0].filename, :decode)).to eq 'てすと.txt'
     end
+
+    it "should accept multiple files with the same filename" do
+      @mail.attachments['test.png'] = @test_png
+      @mail.attachments['test.png'] = @test_png
+      expect(@mail.attachments.count).to eq 2
+      expect(Mail::Encodings.decode_encode(@mail.attachments[0].filename, :decode)).to eq 'test.png'
+      expect(Mail::Encodings.decode_encode(@mail.attachments[1].filename, :decode)).to eq 'test.png'
+    end
   end
 
   describe "from a supplied Hash" do


### PR DESCRIPTION
Currently the AttachmentList's `[]=` method can be called multiple times with the same filename, and a new part will be added to the email for each of the files without overwriting previous files with the same name.

I've assumed that this is intended behaviour (since it's valid for an email to have multiple attachments with the same filename, or even have the same file attached multiple times). 

This PR adds a fairly basic test to make that assumption explicit.