### PR TITLE
Fix JRuby builds / minimum ruby version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ruby:
     name: ${{ matrix.ruby }} (timeout ${{ matrix.timeout }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
@@ -18,22 +18,31 @@ jobs:
        include:
          - ruby: 3.1
            timeout: 5
+           os: ubuntu-latest
          - ruby: 3.2
            timeout: 5
+           os: ubuntu-latest
          - ruby: 3.3
            timeout: 5
+           os: ubuntu-latest
          - ruby: ruby
            timeout: 5
+           os: ubuntu-latest
          - ruby: head
            timeout: 5
+           os: ubuntu-latest
          - ruby: truffleruby
            timeout: 50
+           os: ubuntu-latest
          - ruby: truffleruby-head
            timeout: 50
+           os: ubuntu-latest
          - ruby: jruby
            timeout: 5
+           os: ubuntu-22.04
          - ruby: jruby-head
            timeout: 5
+           os: ubuntu-22.04
     steps:
     - name: Installing libyaml-dev
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,15 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         - ruby: 2.5
-           timeout: 5
-         - ruby: 2.6
-           timeout: 5
-         - ruby: 2.7
-           timeout: 5
-         - ruby: '3.0'
-           timeout: 5
          - ruby: 3.1
            timeout: 5
          - ruby: 3.2
            timeout: 5
          - ruby: 3.3
+           timeout: 5
+         - ruby: ruby
+           timeout: 5
+         - ruby: head
            timeout: 5
          - ruby: truffleruby
            timeout: 50
@@ -37,12 +33,6 @@ jobs:
          - ruby: jruby
            timeout: 5
          - ruby: jruby-head
-           timeout: 5
-         - ruby: jruby-9.4
-           timeout: 5
-         - ruby: jruby-9.3
-           timeout: 5
-         - ruby: jruby-9.2
            timeout: 5
     steps:
     - name: Installing libyaml-dev

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 if ENV['MBCHARS'] # see spec/environment.rb
-  if RUBY_VERSION < '2.7.0'
-    gem 'activesupport', '< 6'
-  else
-    gem 'activesupport', :git => 'https://github.com/rails/rails', :branch => 'main'
-  end
+  gem 'activesupport', :git => 'https://github.com/rails/rails', :branch => 'main'
 end
 
 gem 'jruby-openssl', :platforms => :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gem 'jruby-openssl', :platforms => :jruby
 gem 'mini_mime'
 
 gem 'byebug', :platforms => :mri
+
+gem "benchmark"

--- a/README.md
+++ b/README.md
@@ -49,19 +49,9 @@ our documentation, add new features—up to you! Thank you for pitching in.
 
 Mail is tested against:
 
-* Ruby: 2.5
-* Ruby: 2.6
-* Ruby: 2.7
-* Ruby: 3.0
-* Ruby: 3.1
-* Ruby: 3.2
-* JRuby: 9.2
-* JRuby: 9.3
-* JRuby: 9.4
-* JRuby: stable
-* JRuby: head
-* Truffleruby: stable
-* Truffleruby: head
+* Ruby: 3.1, 3.2, 3.3, stable, head
+* JRuby: stable, head
+* Truffleruby: stable, head
 
 As new versions of Ruby are released, Mail will be compatible with support for the "preview" and all "normal maintenance", "security maintenance" and the two most recent "end of life" versions listed at the [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/) page.  Pull requests to assist in adding support for new preview releases are more than welcome.
 

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[ README.md ]
   s.rdoc_options << '--exclude' << 'lib/mail/values/unicode_tables.dat'
 
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 3.1"
 
   s.add_dependency('logger')
   s.add_dependency('mini_mime', '>= 0.1.1')


### PR DESCRIPTION
Recent JRuby builds were failing with errors "Error: Unavailable version 9.2.21.0 for jruby on ubuntu-24.04".

This PR ensures JRuby uses ubuntu-22.04.

It also prunes builds for CRuby 2.5 and 2.6.