### PR TITLE
Remove unusued `testEof` variables

### DIFF
--- a/lib/mail/parsers/address_lists_parser.rb
+++ b/lib/mail/parsers/address_lists_parser.rb
@@ -31983,7 +31983,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -33226,10 +33225,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 2461

--- a/lib/mail/parsers/content_disposition_parser.rb
+++ b/lib/mail/parsers/content_disposition_parser.rb
@@ -582,7 +582,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -885,10 +884,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 40

--- a/lib/mail/parsers/content_location_parser.rb
+++ b/lib/mail/parsers/content_location_parser.rb
@@ -603,7 +603,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -806,10 +805,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 32

--- a/lib/mail/parsers/content_transfer_encoding_parser.rb
+++ b/lib/mail/parsers/content_transfer_encoding_parser.rb
@@ -354,7 +354,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -506,10 +505,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 21

--- a/lib/mail/parsers/content_type_parser.rb
+++ b/lib/mail/parsers/content_type_parser.rb
@@ -708,7 +708,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -1032,10 +1031,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 47

--- a/lib/mail/parsers/envelope_from_parser.rb
+++ b/lib/mail/parsers/envelope_from_parser.rb
@@ -3237,7 +3237,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -3659,10 +3658,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 257

--- a/lib/mail/parsers/message_ids_parser.rb
+++ b/lib/mail/parsers/message_ids_parser.rb
@@ -4844,7 +4844,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -5145,10 +5144,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 318

--- a/lib/mail/parsers/mime_version_parser.rb
+++ b/lib/mail/parsers/mime_version_parser.rb
@@ -318,7 +318,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -497,10 +496,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 23

--- a/lib/mail/parsers/phrase_lists_parser.rb
+++ b/lib/mail/parsers/phrase_lists_parser.rb
@@ -698,7 +698,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -868,10 +867,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 42

--- a/lib/mail/parsers/received_parser.rb
+++ b/lib/mail/parsers/received_parser.rb
@@ -7510,7 +7510,6 @@ begin
         end
 
         begin
-          testEof = false
           _slen, _trans, _keys, _inds, _acts, _nacts = nil
           _goto_level = 0
           _resume = 10
@@ -8766,10 +8765,6 @@ begin
               break
             end
           end
-        end
-
-        if false
-          testEof
         end
 
         if p != eof || cs < 648


### PR DESCRIPTION
There's a bunch of weird `testEof` variable declarations with the same pattern:

```ruby
testEof = false

...

if false
  testEof
end
```

these are leading to runtime warnings, so I guess we can simply remove them.