### PR TITLE
Fix typo in Mail::DateField documentation

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -24,6 +24,7 @@ Bug Fixes:
 
 * Regression: Preserve message-level charset when adding parts (related to Rails ActionMailer) @shields
 * Regression: Adding a part should not reset the mail's charset to nil @railsbob
+* Typo: Fix typo in Mail::DateField documentation
 
 Performance:
 

--- a/lib/mail/fields/date_field.rb
+++ b/lib/mail/fields/date_field.rb
@@ -11,7 +11,7 @@ module Mail
   # has a DateField as its field type.  This includes all Mail::CommonAddress
   # module instance methods.
   #
-  # There must be excatly one Date field in an RFC2822 email.
+  # There must be exactly one Date field in an RFC2822 email.
   #
   # == Examples:
   #


### PR DESCRIPTION
I found a tiny typo whilst reading the docs.