### PR TITLE
Add metadata to gemspec

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -29,4 +29,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rufo')
 
   s.files = Dir.glob(%w[ README.md MIT-LICENSE lib/**/* ])
+
+  s.metadata["bug_tracker_uri"] = "#{s.homepage}/issues"
+  s.metadata["changelog_uri"] = "#{s.homepage}/releases"
+  s.metadata["documentation_uri"] = "https://rubydoc.info/gems/#{s.name}/#{s.version}"
+  s.metadata["homepage_uri"] = s.homepage
+  s.metadata["source_code_uri"] = "#{s.homepage}/src/tag/v#{s.version}"
 end


### PR DESCRIPTION
Configures links that will appear on this gem's page on RubyGems.org when new versions of the gem are released. See the [specification reference](https://guides.rubygems.org/specification-reference/#metadata) for more.

If nothing else, I'd like to see the addition of `changelog_uri` merged as its presence is quite helpful when working through gem updates and navigating via RubyGems.org.

Note that the duplicative `homepage_uri` accounts for [this issue](https://github.com/rubygems/rubygems.org/issues/4924).

Thanks for considering this change!