### PR TITLE
Add Ruby 3.4 to CI matrix in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
            timeout: 5
          - ruby: 3.3
            timeout: 5
+         - ruby: 3.4
+           timeout: 5
          - ruby: truffleruby
            timeout: 50
          - ruby: truffleruby-head


### PR DESCRIPTION
Just add ruby  3.4 in CI matrix.