### PR TITLE
Add benchmark as a development dependency

### DIFF
--- a/mail.gemspec
+++ b/mail.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec-benchmark')
   s.add_development_dependency('rdoc')
   s.add_development_dependency('rufo')
+  s.add_development_dependency('benchmark')
 
   s.files = Dir.glob(%w[ README.md MIT-LICENSE lib/**/* ])
 end


### PR DESCRIPTION
Suppress a warning when running rake job.
```
❯ ruby -v
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin24]
❯ RUBYOPT=W:deprecated bundle exec rake
/Users/ydah/mail/rakelib/corpus.rake:1: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
```