### PR TITLE
Capture delivery_method.delivery! response as Mail#response

### DIFF
--- a/lib/mail/message.rb
+++ b/lib/mail/message.rb
@@ -228,6 +228,7 @@ module Mail
     # This setting is ignored by mail (though still available as a flag) if you
     # define a delivery_handler
     attr_accessor :raise_delivery_errors
+    attr_reader :response
 
     def self.default_charset; @@default_charset; end
     def self.default_charset=(charset); @@default_charset = charset; end
@@ -2145,7 +2146,7 @@ module Mail
     def do_delivery
       begin
         if perform_deliveries
-          delivery_method.deliver!(self)
+          @response = delivery_method.deliver!(self)
         end
       rescue => e # Net::SMTP errors or sendmail pipe errors
         raise e if raise_delivery_errors

--- a/spec/mail/network_spec.rb
+++ b/spec/mail/network_spec.rb
@@ -281,6 +281,20 @@ RSpec.describe "Mail" do
         @message.perform_deliveries = false
         expect { @message.deliver }.not_to change(Mail::TestMailer.deliveries, :size)
       end
+
+      it "should capture the delivery response when perform_deliveries is true" do
+        delivery_agent = MyDeliveryMethod.new
+        allow(@message).to receive(:delivery_method).and_return(delivery_agent)
+        allow(delivery_agent).to receive(:deliver!).and_return("smtp_response")
+        @message.deliver
+        expect(@message.response).to eq("smtp_response")
+      end
+
+      it "should not capture a delivery response when perform_deliveries is false" do
+        @message.perform_deliveries = false
+        @message.deliver
+        expect(@message.response).to be_nil
+      end
     end
 
     describe "observers" do


### PR DESCRIPTION
This captures the delivery response to an instance variable so it can be access later, for example if using AWS SES and needing the SES created message_id (https://engineering.monstar-lab.com/en/post/2022/10/05/Handling-bounced-emails-by-SES-with-Rails/).

