### PR TITLE
Emit CRLF line endings for 8bit non-ascii text bodies

### DIFF
--- a/lib/mail/encodings/8bit.rb
+++ b/lib/mail/encodings/8bit.rb
@@ -9,6 +9,13 @@ module Mail
       PRIORITY = 4
       Encodings.register(NAME, self)
 
+      # 8bit, like 7bit, is a textual transfer encoding and must use CRLF line
+      # endings on the wire per RFC 5322 2.3. Binary data keeps the identity
+      # encoding inherited from Binary.
+      def self.encode(str)
+        ::Mail::Utilities.binary_unsafe_to_crlf str
+      end
+
       # Per RFC 2821 4.5.3.1, SMTP lines may not be longer than 1000 octets including the <CRLF>.
       def self.compatible_input?(str)
         !str.lines.find { |line| line.bytesize > 998 }

--- a/spec/mail/body_spec.rb
+++ b/spec/mail/body_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe Mail::Body do
       expect(body.encoded).to eq "This has \r\n various \r\n new \r\n lines"
     end
 
+    it "should use crlf line endings for 8bit non-ascii bodies" do
+      body = Mail::Body.new("Caf\xC3\xA9\nSecond line\n".dup.force_encoding('UTF-8'))
+      body.encoding = '8bit'
+      expect(body.encoded).to eq "Caf\xC3\xA9\r\nSecond line\r\n".dup.force_encoding('UTF-8')
+    end
+
   end
 
   describe "decoding" do


### PR DESCRIPTION
Since 2.9.0, `Body#initialize` no longer normalizes its raw source to CRLF (this was removed in #1511 so LF-only multipart bodies parse correctly). For non-ascii text parts the selected transfer encoding falls back to 8bit, whose `encode` is the identity inherited from `Binary`, so the body is emitted with whatever line endings the caller passed in (typically bare LF from templates). ASCII bodies are unaffected because `SevenBit.encode` still calls `to_crlf`, which is why this is easy to miss.

8bit is a textual transfer encoding like 7bit, so this gives `EightBit` its own `encode` that normalizes to CRLF, matching `SevenBit`. Binary attachments use the `binary` encoding and keep the identity behavior, so they stay byte-exact. Fixes #1662.
