### PR TITLE
Improve decoding of Q- and B-encoded strings

### DIFF
--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -416,16 +416,28 @@ module Mail
     end
 
     def Utilities.b_value_decode(str)
-      match = str.match(/\=\?(.+)?\?[Bb]\?(.*)\?\=/m)
-      if match
-        charset = match[1]
-        str = Utilities.decode_base64(match[2])
-        str = charset_encoder.encode(str, charset)
+      # match = str.match(/\=\?(.+)?\?[Bb]\?(.*)\?\=/m)
+      # match = str.match(/=\?([^?]+)\?[Bb]\?([^?]+)\?=/m)
+      # if match
+      #   charset = match[1]
+      #   str = Utilities.decode_base64(match[2])
+      #   str = charset_encoder.encode(str, charset)
+      # end
+
+      b_decoded = str.gsub(/=\?([^?]+)\?[Bb]\?([^?]*)\?=/m) do |match|
+        charset = $1
+
+        string = Utilities.decode_base64($2)
+
+        begin
+          charset_encoder.encode(string, charset)
+        rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError, Encoding::InvalidByteSequenceError
+          warn "WARNING: Encoding conversion failed #{$!}"
+          string.dup.force_encoding(Encoding::UTF_8)
+        end
       end
-      transcode_to_scrubbed_utf8(str)
-    rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError, Encoding::InvalidByteSequenceError
-      warn "WARNING: Encoding conversion failed #{$!}"
-      str.dup.force_encoding(Encoding::UTF_8)
+
+      transcode_to_scrubbed_utf8(b_decoded)
     end
 
     def Utilities.q_value_encode(str, encoding = nil)
@@ -434,22 +446,28 @@ module Mail
     end
 
     def Utilities.q_value_decode(str)
-      match = str.match(/\=\?(.+)?\?[Qq]\?(.*)\?\=/m)
-      if match
-        charset = match[1]
-        string = match[2].gsub(/_/, '=20')
-        # Remove trailing = if it exists in a Q encoding
-        string = string.sub(/\=$/, '')
-        str = Encodings::QuotedPrintable.decode(string)
-        str = charset_encoder.encode(str, charset)
+      q_decoded = str.gsub(/=\?([^?]+)\?[Qq]\?((?:[^?]|\?(?!\=))*)\?=/m) do |_match|
+        charset = $1
+        string  = $2
+          .gsub(/_/, '=20')
+          .sub(/\=$/, '') # Remove trailing = if it exists in a Q encoding
+
+        unquoted_printable = Encodings::QuotedPrintable.decode(string)
+        decoded = begin
+                    charset_encoder.encode(unquoted_printable, charset)
+                  rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
+                    warn "WARNING: Encoding conversion failed #{$!}"
+                    unquoted_printable.dup.force_encoding(Encoding::UTF_8)
+                  end
+
         # We assume that binary strings hold utf-8 directly to work around
         # jruby/jruby#829 which subtly changes String#encode semantics.
-        str.force_encoding(Encoding::UTF_8) if str.encoding == Encoding::ASCII_8BIT
+        decoded.force_encoding(Encoding::UTF_8) if decoded.encoding == Encoding::ASCII_8BIT
+
+        decoded
       end
-      transcode_to_scrubbed_utf8(str)
-    rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
-      warn "WARNING: Encoding conversion failed #{$!}"
-      str.dup.force_encoding(Encoding::UTF_8)
+
+      transcode_to_scrubbed_utf8(q_decoded)
     end
 
     def Utilities.param_decode(str, encoding)

--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -416,14 +416,6 @@ module Mail
     end
 
     def Utilities.b_value_decode(str)
-      # match = str.match(/\=\?(.+)?\?[Bb]\?(.*)\?\=/m)
-      # match = str.match(/=\?([^?]+)\?[Bb]\?([^?]+)\?=/m)
-      # if match
-      #   charset = match[1]
-      #   str = Utilities.decode_base64(match[2])
-      #   str = charset_encoder.encode(str, charset)
-      # end
-
       b_decoded = str.gsub(/=\?([^?]+)\?[Bb]\?([^?]*)\?=/m) do |match|
         charset = $1
 

--- a/spec/mail/elements/address_list_spec.rb
+++ b/spec/mail/elements/address_list_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe Mail::AddressList do
       expect(list.addresses.length).to eq 2
     end
 
-
     it "should create an address instance for each address returned" do
       list = Mail::AddressList.new('sam@me.com, my_group: mikel@me.com, bob@you.com;')
       list.addresses.each do |address|
@@ -119,6 +118,11 @@ RSpec.describe Mail::AddressList do
       expect(list.group_names).to eq ["my_group"]
     end
 
+    it 'should handle wrongly Q encoded email addresses' do
+      q_encoded = '"John Doe" <=?UTF-8?Q?spoof?Q?agent?=@example.com>'
+      list = Mail::AddressList.new(q_encoded)
+      expect(list.addresses.first.address).to eq 'spoof?Q?agent@example.com'
+    end
   end
 
 end

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -532,4 +532,56 @@ RSpec.describe "Utilities Module" do
       expect(decoded).to eq "a"
     end
   end
+
+  describe '.q_value_decode' do
+    it 'handles Q-encoded strings' do
+      decoded = Mail::Utilities.q_value_decode("=?UTF-8?Q?This_is_=E3=81=82_string?=")
+
+      expect(decoded).to eq "This is あ string"
+    end
+
+    it 'handles Q-encoded strings with multiple encoded words' do
+      decoded = Mail::Utilities.q_value_decode("=?UTF-8?Q?This_is_=E3=81=82_string?= unencoded =?UTF-8?Q?part?=")
+
+      expect(decoded).to eq "This is あ string unencoded part"
+    end
+
+    it 'handles Q-encoded strings with complex format' do
+      decoded = Mail::Utilities.q_value_decode('From: "Vardenis Pavardenis" =?utf-8?Q?agent?=@example.com')
+
+      expect(decoded).to eq('From: "Vardenis Pavardenis" agent@example.com')
+    end
+
+    it 'tries to decode the string even when format is incorrect' do
+      decoded = Mail::Utilities.q_value_decode('=?utf-8?Q?agent?Q?spoof=40example.org?=@example.com')
+
+      expect(decoded).to eq('agent?Q?spoof@example.org@example.com')
+    end
+  end
+
+  describe '.b_value_decode' do
+    it 'handles B-encoded strings' do
+      decoded = Mail::Utilities.b_value_decode("=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n=?=")
+
+      expect(decoded).to eq "This is あ string"
+    end
+
+    it 'handles B-encoded strings with multiple encoded words' do
+      decoded = Mail::Utilities.b_value_decode("=?UTF-8?B?VGhpcyBpcyDjgYIgc3RyaW5n=?= unencoded =?UTF-8?B?cGFydA==?=")
+
+      expect(decoded).to eq "This is あ string unencoded part"
+    end
+
+    it 'handles B-encoded strings with complex format' do
+      decoded = Mail::Utilities.b_value_decode('From: "Vardenis Pavardenis" =?utf-8?B?YWdlbnQ=?=@example.com')
+
+      expect(decoded).to eq('From: "Vardenis Pavardenis" agent@example.com')
+    end
+
+    it 'tries to decode the string even when format is incorrect' do
+      decoded = Mail::Utilities.q_value_decode('=?utf-8?B?YWdlbnQ=?B?c3Bvb2ZAZXhhbXBsZS5vcmc=?=@example.com')
+
+      expect(decoded).to eq('=?utf-8?B?YWdlbnQ=?B?c3Bvb2ZAZXhhbXBsZS5vcmc=?=@example.com')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Improves decoding of RFC 2047 Q- and B-encoded words in `Mail::Utilities.q_value_decode` and `Mail::Utilities.b_value_decode`.

Previously both methods used a single `String#match`, so only the **first** encoded-word in a string was decoded and any surrounding or subsequent text/encoded-words were effectively dropped. A broad, greedy charset pattern (`.+`) also allowed malformed encoded-words to swallow more of the string than intended, which could be abused to spoof email addresses.

## Changes

- **`b_value_decode`** — switch to `String#gsub` so every `=?charset?B?...?=` word in the string is decoded in place, preserving text between words. Tighten the charset capture to `[^?]+` so it stops at the first `?`. Encoding-conversion failures are now rescued **per encoded-word** (falling back to UTF-8) instead of aborting the whole decode.
- **`q_value_decode`** — same `gsub`-based, per-word approach. The payload pattern `(?:[^?]|\?(?!\=))*` permits a literal `?` inside the encoded text unless it is the `?=` terminator, so malformed/ambiguous words decode predictably rather than truncating the string.

## Why

- Correctly handles strings containing **multiple** encoded-words mixed with plain text.
- Isolates encoding failures to the offending word.
- Prevents malformed encoded-words from being used to spoof addresses (see the added `AddressList` spec).

## Tests

- `spec/mail/utilities_spec.rb` — new `.q_value_decode` / `.b_value_decode` examples covering single words, multiple words, complex `From:` formats, and malformed input.
- `spec/mail/elements/address_list_spec.rb` — spec for a wrongly Q-encoded address.
