### PR TITLE
Fix TruffleRuby head on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
            timeout: 5
          - ruby: 3.4
            timeout: 5
+         - ruby: 4.0
+           timeout: 5
          - ruby: truffleruby
            timeout: 50
          - ruby: truffleruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,6 @@ gem 'jruby-openssl', :platforms => :jruby
 gem 'mini_mime'
 
 gem 'byebug', :platforms => :mri
+
+# rbs (rdoc's dependency) fails to build on JRuby
+gem 'rdoc', :platforms => :mri

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '> 0.8.7')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-benchmark')
-  s.add_development_dependency('rdoc')
   s.add_development_dependency('rufo')
 
   s.files = Dir.glob(%w[ README.md MIT-LICENSE lib/**/* ])

--- a/mail.gemspec
+++ b/mail.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('net-imap')
   s.add_dependency('net-pop')
 
+  s.add_development_dependency('benchmark')
   s.add_development_dependency('bundler', '>= 1.0.3')
   s.add_development_dependency('rake', '> 0.8.7')
   s.add_development_dependency('rspec', '~> 3.0')


### PR DESCRIPTION
Changes:
- added Ruby 4.0 on CI
- fixed CI on Ruby 4.0 and TruffleRuby head
- fixed CI on JRuby (except JRuby 9.2)

cc @eregon 

### Notes

Example of failure on Ruby 4.0:

```
bundle exec rake spec
/home/runner/work/mail/mail/rakelib/corpus.rake:1: warning: benchmark used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add benchmark to your Gemfile or gemspec to fix this error.
rake aborted!
LoadError: cannot load such file -- benchmark (LoadError)
/home/runner/work/mail/mail/rakelib/corpus.rake:1:in '<top (required)>'
```
https://github.com/andrykonchin/mail/actions/runs/29605756245/job/87968456667

Example of failure on JRuby:

```
Installing rbs 4.0.3 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/home/runner/work/mail/mail/vendor/bundle/jruby/4.0.0/gems/rbs-4.0.3/ext/rbs_extension
/home/runner/.rubies/jruby-head/bin/jruby extconf.rb
checking for whether -std=gnu99 is accepted as CFLAGS... *** extconf.rb failed
***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```
https://github.com/andrykonchin/mail/actions/runs/29606157288/job/87969771741